### PR TITLE
Add missing tag and fix typo

### DIFF
--- a/Sources/HTMLKit/Localize.swift
+++ b/Sources/HTMLKit/Localize.swift
@@ -60,7 +60,7 @@ extension Localized where B == NoData {
     }
 }
 
-public struct EnviromentModifier: HTML {
+public struct EnvironmentModifier: HTML {
 
     let view: HTML
     let locale: HTML
@@ -82,11 +82,11 @@ public struct EnviromentModifier: HTML {
 }
 
 extension HTML {
-    public func enviroment(locale: String) -> EnviromentModifier {
-        return EnviromentModifier(view: self, locale: locale)
+    public func environment(locale: String) -> EnvironmentModifier {
+        return EnvironmentModifier(view: self, locale: locale)
     }
 
-    public func enviroment(locale: TemplateValue<String>) -> EnviromentModifier {
-        return EnviromentModifier(view: self, locale: locale)
+    public func environment(locale: TemplateValue<String>) -> EnvironmentModifier {
+        return EnvironmentModifier(view: self, locale: locale)
     }
 }

--- a/Sources/HTMLKit/View Builders/TemplateBuilder.swift
+++ b/Sources/HTMLKit/View Builders/TemplateBuilder.swift
@@ -2071,3 +2071,22 @@ public struct Viewport: HTMLComponent {
         Meta().name(.viewport).content("width=\(mode.width), initial-scale=\(internalScale)")
     }
 }
+
+/// The <main> tag defines the dominant content of a document.
+public struct Main: ContentNode {
+
+    public var name: String { "main" }
+
+    public var attributes: [HTMLAttribute] = []
+
+    public var content: HTML
+
+    public init(@HTMLBuilder builder: () -> HTML) {
+        content = builder()
+    }
+
+    public init(attributes: [HTMLAttribute] = [], content: HTML = "") {
+        self.content = content
+        self.attributes = attributes
+    }
+}

--- a/Tests/HTMLKitTests/HTMLTestDocuments.swift
+++ b/Tests/HTMLKitTests/HTMLTestDocuments.swift
@@ -740,7 +740,7 @@ struct LocalizedView: HTMLTemplate {
             P("unread.messages", with: ["numberTest": 2])
             P("unread.messages", with: context)
         }
-        .enviroment(locale: context.locale)
+        .environment(locale: context.locale)
     }
 }
 
@@ -859,7 +859,7 @@ struct LocalizedDateView: HTMLTemplate {
                 context.date.formatted(string: "MM/dd/yyyy")
             }
         }
-        .enviroment(locale: context.locale)
+        .environment(locale: context.locale)
     }
 }
 


### PR DESCRIPTION
The Main tag seems to miss. Since it is still an official html 5 tag, I added it to the TemplateBuilder.

There was I misspelling in the Localize file, wich came to my attention. 