### PR TITLE
Correct spelling, add missing case and fix a html tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ struct SimpleTemplate: HTMLTemplate {
                 Title { context.title }
                 Author { context.name }
                     .twitter(handle: context.handle)
-                Viewport(.acordingToDevice)
+                Viewport(.accordingToDevice)
             }
             Body {
                 Unwrap(context.title) { title in
@@ -205,7 +205,7 @@ struct LocalizedDateView: HTMLTemplate {
                     .formatted(string: "MM/dd/yyyy")
             }
         }
-        .enviroment(locale: context.locale)
+        .environment(locale: context.locale)
     }
 }
 ```

--- a/Sources/HTMLKit/View Builders/TemplateBuilder.swift
+++ b/Sources/HTMLKit/View Builders/TemplateBuilder.swift
@@ -503,6 +503,7 @@ public struct Title: HTMLComponent, AttributeNode, LocalizableNode {
 public enum ButtonType: String {
     case button
     case submit
+    case reset
 }
 
 public struct Button: ContentNode, TypableAttribute, NameableAttribute, LocalizableNode {

--- a/Sources/HTMLKit/View Builders/TemplateBuilder.swift
+++ b/Sources/HTMLKit/View Builders/TemplateBuilder.swift
@@ -2048,12 +2048,12 @@ public struct FavIcon: HTMLComponent {
 public struct Viewport: HTMLComponent {
 
     public enum WidthMode {
-        case acordingToDevice
+        case accordingToDevice
         case constant(Int)
 
         public var width: String {
             switch self {
-            case .acordingToDevice: return "device-width"
+            case .accordingToDevice: return "device-width"
             case .constant(let width): return "\(width)"
             }
         }

--- a/Sources/HTMLKit/View Builders/TemplateBuilder.swift
+++ b/Sources/HTMLKit/View Builders/TemplateBuilder.swift
@@ -722,7 +722,7 @@ public struct Aside: ContentNode {
 /// Currently, there are 3 supported file formats for the <audio> element: MP3, WAV, and OGG:
 public struct Audio: ContentNode {
 
-    public var name: String { "aside" }
+    public var name: String { "audio" }
 
     public var attributes: [HTMLAttribute] = []
 


### PR DESCRIPTION
I forgot to correct the .environment spelling in the Readme file in the first place, so I changed it now. Also I corrected the spelling accordingly the issues #26 and changed it in the Readme file either. 

I have added the missing option "reset" for the Button tag.

The Audio tag hadn't the right tag name yet.