### PR TITLE
Rework the modifier

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
           inputs: "Sources"
           output: "dcov.json"
       - name: Check Documentation Percent
-        run: sudo bash Scripts/DocCoverage/check-percentage.sh dcov.json 15
+        run: sudo bash Scripts/DocCoverage/check-percentage.sh dcov.json 13
         
   xenial:
     needs: check-doc-coverage

--- a/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
@@ -574,6 +574,11 @@ public protocol ContentAttribute: AnyAttribute {
     ///
     ///
     func content(_ value: String) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func content(_ value: TemplateValue<String>) -> Self
 }
 
 extension ContentAttribute {
@@ -1414,6 +1419,11 @@ public protocol ReferenceAttribute: AnyAttribute {
     ///
     ///
     func reference(_ value: String) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func reference(_ value: TemplateValue<String>) -> Self
 }
 
 extension ReferenceAttribute {
@@ -1494,6 +1504,11 @@ public protocol IdentifierAttribute: AnyAttribute {
     ///
     ///
     func id(_ value: String) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func id(_ value: TemplateValue<String>) -> Self
 }
 
 extension IdentifierAttribute {
@@ -1814,7 +1829,7 @@ public protocol ItemTypeAttribute: AnyAttribute {
     /// The func adds
     ///
     ///
-    func id(_ value: String) -> Self
+    func itemType(_ value: String) -> Self
 }
 
 extension ItemTypeAttribute {
@@ -2411,10 +2426,17 @@ extension MutedAttribute where Self: EmptyNode {
 ///
 public protocol NameAttribute: AnyAttribute {
 
+    associatedtype NameValue
+    
     /// The func adds
     ///
     ///
-    func name(_ type: NameType) -> Self
+    func name(_ value: NameValue) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func name(_ value: TemplateValue<NameValue>) -> Self
 }
 
 extension NameAttribute {
@@ -2735,6 +2757,11 @@ public protocol PlaceholderAttribute: AnyAttribute {
     ///
     ///
     func placeholder(_ value: String) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func placeholder(_ value: TemplateValue<String>) -> Self
 }
 
 extension PlaceholderAttribute {
@@ -3808,10 +3835,12 @@ extension TranslateAttribute where Self: EmptyNode {
 ///
 public protocol TypeAttribute: AnyAttribute {
 
+    associatedtype TypeValue
+    
     /// The func adds
     ///
     ///
-    func type(_ value: String) -> Self
+    func type(_ value: TypeValue) -> Self
 }
 
 extension TypeAttribute {
@@ -3852,6 +3881,11 @@ public protocol ValueAttribute: AnyAttribute {
     ///
     ///
     func value(_ value: String) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func value(_ value: TemplateValue<String>) -> Self
 }
 
 extension ValueAttribute {

--- a/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
@@ -1,12 +1,28 @@
+/// # Description:
+/// The file contains the basic attribute handlers.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
+/// # Description:
+/// The alias combines the global attributes.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#global-attributes
 ///
 public typealias GlobalAttributes = AccessKeyAttribute & AutocapitalizeAttribute & AutofocusAttribute & ClassAttribute & EditAttribute & DirectionAttribute & DragAttribute & EnterKeyHintAttribute & HiddenAttribute & InputModeAttribute & IsAttribute & ItemIdAttribute & ItemPropertyAttribute & ItemReferenceAttribute & ItemScopeAttribute & ItemTypeAttribute & IdentifierAttribute & LanguageAttribute & NonceAttribute & RoleAttribute & SpellCheckAttribute & StyleAttribute & TabulatorAttribute & TitleAttribute & TranslateAttribute
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the accesskey handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-accesskey-attribute
 ///
 public protocol AccessKeyAttribute: AnyAttribute {
     
@@ -45,8 +61,11 @@ extension AccessKeyAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the accept handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-accept
 ///
 public protocol AcceptAttribute: AnyAttribute {
     
@@ -85,8 +104,11 @@ extension AcceptAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the action handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-alt
 ///
 public protocol ActionAttribute: AnyAttribute {
     
@@ -125,8 +147,11 @@ extension ActionAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the alternate handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-alt
 ///
 public protocol AlternateAttribute: AnyAttribute {
     
@@ -165,8 +190,11 @@ extension AlternateAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the asynchronously handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-autocapitalize
 ///
 public protocol AsynchronouslyAttribute: AnyAttribute {
     
@@ -205,8 +233,11 @@ extension AsynchronouslyAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the autocapitalize handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-autocapitalize
 ///
 public protocol AutocapitalizeAttribute: AnyAttribute {
     
@@ -245,8 +276,11 @@ extension AutocapitalizeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the autocomplete handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fe-autocomplete
 ///
 public protocol AutocompleteAttribute: AnyAttribute {
     
@@ -285,8 +319,11 @@ extension AutocompleteAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the autofocus handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fe-autofocus
 ///
 public protocol AutofocusAttribute: AnyAttribute {
     
@@ -325,8 +362,11 @@ extension AutofocusAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the autoplay handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-checked
 ///
 public protocol AutoplayAttribute: AnyAttribute {
     
@@ -365,8 +405,11 @@ extension AutoplayAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the checked handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-checked
 ///
 public protocol CheckedAttribute: AnyAttribute {
     
@@ -405,8 +448,11 @@ extension CheckedAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the cite handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tdth-colspan
 ///
 public protocol CiteAttribute: AnyAttribute {
     
@@ -445,8 +491,11 @@ extension CiteAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol provides
+/// # Description:
+/// The protocol provides the element with the class handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tdth-colspan
 ///
 public protocol ClassAttribute: AnyAttribute{
     
@@ -485,8 +534,11 @@ extension ClassAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the columns handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tdth-colspan
 ///
 public protocol ColumnsAttribute: AnyAttribute {
     
@@ -525,8 +577,11 @@ extension ColumnsAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the columnspan handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tdth-colspan
 ///
 public protocol ColumnSpanAttribute: AnyAttribute {
     
@@ -565,8 +620,11 @@ extension ColumnSpanAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the content handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-contenteditable
 ///
 public protocol ContentAttribute: AnyAttribute {
     
@@ -610,8 +668,11 @@ extension ContentAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the iseditable handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-contenteditable
 ///
 public protocol EditAttribute: AnyAttribute {
     
@@ -650,8 +711,11 @@ extension EditAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the controls handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-accesskey-attribute
 ///
 public protocol ControlsAttribute: AnyAttribute {
     
@@ -690,8 +754,11 @@ extension ControlsAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the coordinates handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-accesskey-attribute
 ///
 public protocol CoordinatesAttribute: AnyAttribute {
     
@@ -730,8 +797,11 @@ extension CoordinatesAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the date handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-accesskey-attribute
 ///
 public protocol DataAttribute: AnyAttribute{
     
@@ -770,8 +840,11 @@ extension DataAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the datetime handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-accesskey-attribute
 ///
 public protocol DateTimeAttribute: AnyAttribute {
     
@@ -810,8 +883,11 @@ extension DateTimeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the default handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-track-default
 ///
 public protocol DefaultAttribute: AnyAttribute {
     
@@ -850,12 +926,15 @@ extension DefaultAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the defer handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-script-defer
 ///
 public protocol DeferAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler defers the script execution.
     ///
     ///
     func `defer`() -> Self
@@ -890,12 +969,15 @@ extension DeferAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the direction handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-dir
 ///
 public protocol DirectionAttribute: AnyAttribute {
 
-    /// The func adds
+    /// The handler specifies the element's text directionality.
     ///
     ///
     func direction(_ type: Direction) -> Self
@@ -930,12 +1012,15 @@ extension DirectionAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the disabled handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fe-disabled
 ///
 public protocol DisabledAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler disables the element.
     ///
     ///
     func disabled() -> Self
@@ -970,12 +1055,15 @@ extension DisabledAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the download handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-hyperlink-download
 ///
 public protocol DownloadAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler indicates that the link is used for downloading a source.
     ///
     ///
     func download() -> Self
@@ -1010,12 +1098,15 @@ extension DownloadAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the isdraggable handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-draggable
 ///
 public protocol DragAttribute: AnyAttribute {
  
-    /// The func adds
+    /// The handler sets if the element is draggable.
     ///
     ///
     func isDraggable(_ condition: Bool) -> Self
@@ -1050,12 +1141,15 @@ extension DragAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the encoding handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fs-enctype
 ///
 public protocol EncodingAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler specifies encoding type to use for form submission.
     ///
     ///
     func encoding(_ type: Encoding) -> Self
@@ -1090,12 +1184,15 @@ extension EncodingAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol provides
+/// # Description:
+/// The protocol provides the element with the enterkeyhint handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-enterkeyhint
 ///
 public protocol EnterKeyHintAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler specifies what action label to present for the enter key on virtual keyboards.
     ///
     ///
     func enterKeyHint(_ type: Hint) -> Self
@@ -1130,12 +1227,15 @@ extension EnterKeyHintAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the for handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-label-for
 ///
 public protocol ForAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler specifies the form control with wich the caption is be associated.
     ///
     ///
     func `for`(_ value: String) -> Self
@@ -1170,8 +1270,11 @@ extension ForAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the form handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fae-form
 ///
 public protocol FormAttribute: AnyAttribute {
     
@@ -1210,12 +1313,15 @@ extension FormAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the formaction handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fs-formaction
 ///
 public protocol FormActionAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler sets the url to use for form submission.
     ///
     ///
     func formAction(_ value: String) -> Self
@@ -1250,12 +1356,15 @@ extension FormActionAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the headers handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tdth-headers
 ///
 public protocol HeaderAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler specifiies the header cells for the element.
     ///
     ///
     func headers(_ value: String) -> Self
@@ -1290,12 +1399,15 @@ extension HeaderAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the height handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-dim-height
 ///
 public protocol HeightAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler sets the height of the element.
     ///
     ///
     func height(_ size: Int) -> Self
@@ -1330,8 +1442,11 @@ extension HeightAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with hidden handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-hidden)
 ///
 public protocol HiddenAttribute: AnyAttribute {
  
@@ -1370,12 +1485,15 @@ extension HiddenAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with high handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-meter-high)
 ///
 public protocol HighAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler sets the range of the value.
     ///
     ///
     func high(_ size: Int) -> Self
@@ -1410,17 +1528,20 @@ extension HighAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with reference handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-hyperlink-href)
 ///
 public protocol ReferenceAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler gives the adress of the link.
     ///
     ///
     func reference(_ value: String) -> Self
     
-    /// The func adds
+    /// The handler gives the adress of the link.
     ///
     ///
     func reference(_ value: TemplateValue<String>) -> Self
@@ -1455,12 +1576,15 @@ extension ReferenceAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the language reference handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-hyperlink-hreflang
 ///
 public protocol ReferenceLanguageAttribute: AnyAttribute {
     
-    /// The func adds
+    /// The handler gives the language of the linked resource.
     ///
     ///
     func referenceLanguage(_ type: Language) -> Self
@@ -1495,17 +1619,20 @@ extension ReferenceLanguageAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the id handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-id-attribute
 ///
 public protocol IdentifierAttribute: AnyAttribute {
  
-    /// The func adds
+    /// The handler specifies its element's unique identifier.
     ///
     ///
     func id(_ value: String) -> Self
     
-    /// The func adds
+    /// The handler specifies its element's unique identifier.
     ///
     ///
     func id(_ value: TemplateValue<String>) -> Self
@@ -1540,8 +1667,11 @@ extension IdentifierAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the ismap handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-img-ismap
 ///
 public protocol IsMapAttribute: AnyAttribute {
  
@@ -1580,8 +1710,11 @@ extension IsMapAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the inputmode handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-inputmode
 ///
 public protocol InputModeAttribute: AnyAttribute {
  
@@ -1620,8 +1753,11 @@ extension InputModeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the inputmode handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-is
 ///
 public protocol IsAttribute: AnyAttribute {
  
@@ -1660,9 +1796,11 @@ extension IsAttribute where Self: EmptyNode {
     }
 }
 
-
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the itemid handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-itemid
 ///
 public protocol ItemIdAttribute: AnyAttribute {
  
@@ -1701,8 +1839,11 @@ extension ItemIdAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the itemproperty handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#names:-the-itemprop-attribute
 ///
 public protocol ItemPropertyAttribute: AnyAttribute {
  
@@ -1741,8 +1882,11 @@ extension ItemPropertyAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the itemreference handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-itemref
 ///
 public protocol ItemReferenceAttribute: AnyAttribute {
  
@@ -1781,8 +1925,11 @@ extension ItemReferenceAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the itemscope handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-itemscope
 ///
 public protocol ItemScopeAttribute: AnyAttribute {
  
@@ -1821,8 +1968,11 @@ extension ItemScopeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the itemtype handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-itemtype
 ///
 public protocol ItemTypeAttribute: AnyAttribute {
  
@@ -1861,8 +2011,11 @@ extension ItemTypeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the kind handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-track-kind
 ///
 public protocol KindAttribute: AnyAttribute {
     
@@ -1901,8 +2054,11 @@ extension KindAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the label handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-track-label
 ///
 public protocol LabelAttribute: AnyAttribute {
     
@@ -1941,8 +2097,11 @@ extension LabelAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the language handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-lang
 ///
 public protocol LanguageAttribute: AnyAttribute {
     
@@ -1981,8 +2140,11 @@ extension LanguageAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the list handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-list
 ///
 public protocol ListAttribute: AnyAttribute {
     
@@ -2021,8 +2183,11 @@ extension ListAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the loop handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-media-loop
 ///
 public protocol LoopAttribute: AnyAttribute {
     
@@ -2061,8 +2226,11 @@ extension LoopAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the low handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-meter-low
 ///
 public protocol LowAttribute: AnyAttribute {
     
@@ -2101,8 +2269,12 @@ extension LowAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the maximumvalue handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-max
+/// https://html.spec.whatwg.org/#attr-meter-max
 ///
 public protocol MaximumValueAttribute: AnyAttribute {
     
@@ -2141,8 +2313,11 @@ extension MaximumValueAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the maximumlength handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-maxlength
 ///
 public protocol MaximumLengthAttribute: AnyAttribute {
     
@@ -2181,8 +2356,11 @@ extension MaximumLengthAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the media handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-link-media
 ///
 public protocol MediaAttribute: AnyAttribute {
     
@@ -2221,8 +2399,11 @@ extension MediaAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the method handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fs-method
 ///
 public protocol MethodAttribute: AnyAttribute {
     
@@ -2261,8 +2442,11 @@ extension MethodAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the minimumvalue handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-min
 ///
 public protocol MinimumValueAttribute: AnyAttribute {
     
@@ -2301,8 +2485,11 @@ extension MinimumValueAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the minimumlength handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-minlength
 ///
 public protocol MinimumLengthAttribute: AnyAttribute {
     
@@ -2341,8 +2528,11 @@ extension MinimumLengthAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the multiple handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-multiple
 ///
 public protocol MultipleAttribute: AnyAttribute {
     
@@ -2381,8 +2571,11 @@ extension MultipleAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the muted handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-media-muted
 ///
 public protocol MutedAttribute: AnyAttribute {
     
@@ -2421,8 +2614,11 @@ extension MutedAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the name handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-form-name
 ///
 public protocol NameAttribute: AnyAttribute {
 
@@ -2468,8 +2664,11 @@ extension NameAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the nonce handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-nonce
 ///
 public protocol NonceAttribute: AnyAttribute {
     
@@ -2508,8 +2707,11 @@ extension NonceAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the novalidate handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-fs-novalidate
 ///
 public protocol NoValidateAttribute: AnyAttribute {
 
@@ -2548,8 +2750,11 @@ extension NoValidateAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the open handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-details-open
 ///
 public protocol OpenAttribute: AnyAttribute {
     
@@ -2588,8 +2793,11 @@ extension OpenAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the optimum handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-meter-optimum
 ///
 public protocol OptimumAttribute: AnyAttribute {
     
@@ -2628,8 +2836,11 @@ extension OptimumAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the pattern handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-pattern
 ///
 public protocol PatternAttribute: AnyAttribute {
     
@@ -2668,8 +2879,11 @@ extension PatternAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the part handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-pattern
 ///
 public protocol PartAttribute: AnyAttribute {
     
@@ -2708,8 +2922,11 @@ extension PartAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ping handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-pattern
 ///
 public protocol PingAttribute: AnyAttribute {
     
@@ -2748,8 +2965,11 @@ extension PingAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the placeholder handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-placeholder
 ///
 public protocol PlaceholderAttribute: AnyAttribute {
     
@@ -2793,8 +3013,11 @@ extension PlaceholderAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the poster handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-video-poster
 ///
 public protocol PosterAttribute: AnyAttribute {
     
@@ -2833,8 +3056,11 @@ extension PosterAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the preload handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-media-preload
 ///
 public protocol PreloadAttribute: AnyAttribute {
     
@@ -2873,8 +3099,11 @@ extension PreloadAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the readonly handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-readonly-attribute
 ///
 public protocol ReadyOnlyAttribute: AnyAttribute {
     
@@ -2913,8 +3142,11 @@ extension ReadyOnlyAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the referrerpolicy handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-hyperlink-referrerpolicy
 ///
 public protocol ReferrerPolicyAttribute: AnyAttribute {
     
@@ -2953,8 +3185,11 @@ extension ReferrerPolicyAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the relationship handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-link-rel
 ///
 public protocol RelationshipAttribute: AnyAttribute {
     
@@ -2993,8 +3228,11 @@ extension RelationshipAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the required handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-required
 ///
 public protocol RequiredAttribute: AnyAttribute {
     
@@ -3033,8 +3271,11 @@ extension RequiredAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the reversed handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ReversedAttribute: AnyAttribute {
     
@@ -3073,8 +3314,11 @@ extension ReversedAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the role handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol RoleAttribute: AnyAttribute {
     
@@ -3113,11 +3357,17 @@ extension RoleAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the rows handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol RowsAttribute: AnyAttribute {
     
+    /// The func adss
+    ///
+    ///
     func rows(_ size: Int) -> Self
 }
 
@@ -3150,8 +3400,11 @@ extension RowsAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the rowspan handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tdth-rowspan
 ///
 public protocol RowSpanAttribute: AnyAttribute {
     
@@ -3190,8 +3443,11 @@ extension RowSpanAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the sandbox handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-iframe-sandbox
 ///
 public protocol SandboxAttribute: AnyAttribute {
     
@@ -3230,8 +3486,11 @@ extension SandboxAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the scope handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-th-scope
 ///
 public protocol ScopeAttribute: AnyAttribute {
     
@@ -3270,8 +3529,11 @@ extension ScopeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the shape handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-area-shape
 ///
 public protocol ShapeAttribute: AnyAttribute {
     
@@ -3310,8 +3572,11 @@ extension ShapeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the size handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-size-attribute
 ///
 public protocol SizeAttribute: AnyAttribute {
     
@@ -3350,8 +3615,11 @@ extension SizeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the sizes handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SizesAttribute: AnyAttribute {
     
@@ -3390,8 +3658,11 @@ extension SizesAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the slot handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-slot
 ///
 public protocol SlotAttribute: AnyAttribute {
     
@@ -3430,8 +3701,12 @@ extension SlotAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the span handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-colgroup-span
+/// https://html.spec.whatwg.org/#attr-col-span
 ///
 public protocol SpanAttribute: AnyAttribute {
     
@@ -3470,8 +3745,11 @@ extension SpanAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the hasspellcheck handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-spellcheck
 ///
 public protocol SpellCheckAttribute: AnyAttribute {
  
@@ -3510,8 +3788,11 @@ extension SpellCheckAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the source handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-src
 ///
 public protocol SourceAttribute: AnyAttribute {
     
@@ -3550,8 +3831,11 @@ extension SourceAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the start handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-start
 ///
 public protocol StartAttribute: AnyAttribute {
     
@@ -3590,8 +3874,11 @@ extension StartAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the step handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-step-attribute
 ///
 public protocol StepAttribute: AnyAttribute {
     
@@ -3630,8 +3917,11 @@ extension StepAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the style handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-style
 ///
 public protocol StyleAttribute: AnyAttribute {
     
@@ -3670,8 +3960,11 @@ extension StyleAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the tabindex handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-tabindex
 ///
 public protocol TabulatorAttribute: AnyAttribute {
  
@@ -3710,8 +4003,11 @@ extension TabulatorAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the target handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-base-target
 ///
 public protocol TargetAttribute: AnyAttribute {
     
@@ -3750,8 +4046,11 @@ extension TargetAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the title handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-title
 ///
 public protocol TitleAttribute: AnyAttribute {
  
@@ -3790,8 +4089,11 @@ extension TitleAttribute where Self: EmptyNode {
     }
 }
 
-/// The protcol privides
+/// # Description:
+/// The protocol provides the element with the translate handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-translate
 ///
 public protocol TranslateAttribute: AnyAttribute {
  
@@ -3830,8 +4132,11 @@ extension TranslateAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the type handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-link-type
 ///
 public protocol TypeAttribute: AnyAttribute {
 
@@ -3872,8 +4177,11 @@ extension TypeAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the value handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-input-value
 ///
 public protocol ValueAttribute: AnyAttribute {
     
@@ -3917,8 +4225,11 @@ extension ValueAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the width handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-dim-width
 ///
 public protocol WidthAttribute: AnyAttribute {
     
@@ -3957,8 +4268,11 @@ extension WidthAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the wrap handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-textarea-wrap
 ///
 public protocol WrapAttribute: AnyAttribute {
     
@@ -3997,8 +4311,11 @@ extension WrapAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the property handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PropertyAttribute: AnyAttribute {
     

--- a/Sources/HTMLKit/External/Attributes/EventAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/EventAttributes.swift
@@ -1,12 +1,28 @@
+/// # Description:
+/// The file contains the event attribute handlers.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
+/// # Description:
+/// The alias combines the global attributes.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public typealias GlobalEventAttributes = ContextMenuEventAttribute & WheelEventAttribute & DragEventAttribute & DragEndEventAttribute & DragEnterEventAttribute & DragLeaveEventAttribute & DragOverEventAttribute & DragStartEventAttribute & DropEventAttribute
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onafterprint handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol AfterPrintEventAttribute: AnyAttribute {
     
@@ -45,8 +61,11 @@ extension AfterPrintEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onbeforeprint handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol BeforePrintEventAttribute: AnyAttribute {
     
@@ -85,8 +104,11 @@ extension BeforePrintEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onbeforeunload handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol BeforeUnloadEventAttribute: AnyAttribute {
     
@@ -125,8 +147,11 @@ extension BeforeUnloadEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onerror handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ErrorEventAttribute: AnyAttribute {
     
@@ -165,8 +190,11 @@ extension ErrorEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onhashchange handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol HashChangeEventAttribute: AnyAttribute {
     
@@ -205,8 +233,11 @@ extension HashChangeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onload handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol LoadEventAttribute: AnyAttribute {
     
@@ -245,8 +276,11 @@ extension LoadEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onmessage handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol MessageEventAttribute: AnyAttribute {
     
@@ -285,8 +319,11 @@ extension MessageEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onoffline handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol OfflineEventAttribute: AnyAttribute {
     
@@ -325,8 +362,11 @@ extension OfflineEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ononline handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol OnlineEventAttribute: AnyAttribute {
     
@@ -365,8 +405,11 @@ extension OnlineEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onpagehide handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PageHideEventAttribute: AnyAttribute {
     
@@ -405,8 +448,11 @@ extension PageHideEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onpageshow handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PageShowEventAttribute: AnyAttribute {
     
@@ -445,8 +491,11 @@ extension PageShowEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onpopstate handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PopstateEventAttribute: AnyAttribute {
     
@@ -485,8 +534,11 @@ extension PopstateEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onresize handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ResizeEventAttribute: AnyAttribute {
     
@@ -525,8 +577,11 @@ extension ResizeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onstorage handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol StorageEventAttribute: AnyAttribute {
     
@@ -565,8 +620,11 @@ extension StorageEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onunload handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol UnloadEventAttribute: AnyAttribute {
     
@@ -605,8 +663,11 @@ extension UnloadEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onblur handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol BlurEventAttribute: AnyAttribute {
     
@@ -645,8 +706,11 @@ extension BlurEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onchange handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ChangeEventAttribute: AnyAttribute {
     
@@ -685,8 +749,11 @@ extension ChangeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oncontextmenu handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ContextMenuEventAttribute: AnyAttribute {
     
@@ -725,8 +792,11 @@ extension ContextMenuEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onfocus handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol FocusEventAttribute: AnyAttribute {
     
@@ -765,8 +835,11 @@ extension FocusEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oninput handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol InputEventAttribute: AnyAttribute {
     
@@ -805,8 +878,11 @@ extension InputEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oninvalid handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol InvalidEventAttribute: AnyAttribute {
     
@@ -845,8 +921,11 @@ extension InvalidEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onreset handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ResetEventAttribute: AnyAttribute {
     
@@ -885,8 +964,11 @@ extension ResetEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onsearch handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SearchEventAttribute: AnyAttribute {
     
@@ -925,8 +1007,11 @@ extension SearchEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onselect handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SelectEventAttribute: AnyAttribute {
     
@@ -965,8 +1050,11 @@ extension SelectEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onsubmit handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SubmitEventAttribute: AnyAttribute {
     
@@ -1005,8 +1093,11 @@ extension SubmitEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onkeydown handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol KeyDownEventAttribute: AnyAttribute {
     
@@ -1045,8 +1136,11 @@ extension KeyDownEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onkeypress handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol KeyPressEventAttribute: AnyAttribute {
     
@@ -1085,8 +1179,11 @@ extension KeyPressEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onkeyup handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol KeyUpEventAttribute: AnyAttribute {
     
@@ -1125,8 +1222,11 @@ extension KeyUpEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onclick handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ClickEventAttribute: AnyAttribute {
     
@@ -1165,8 +1265,11 @@ extension ClickEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondbclick handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DoubleClickEventAttribute: AnyAttribute {
     
@@ -1205,8 +1308,11 @@ extension DoubleClickEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onmousedown handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol MouseDownEventAttribute: AnyAttribute {
     
@@ -1245,8 +1351,11 @@ extension MouseDownEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onmousemove handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol MouseMoveEventAttribute: AnyAttribute {
     
@@ -1285,8 +1394,11 @@ extension MouseMoveEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onmouseout handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol MouseOutEventAttribute: AnyAttribute {
     
@@ -1325,8 +1437,11 @@ extension MouseOutEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onmouseover handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol MouseOverEventAttribute: AnyAttribute {
     
@@ -1365,8 +1480,11 @@ extension MouseOverEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onmouseup handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol MouseUpEventAttribute: AnyAttribute {
     
@@ -1405,8 +1523,11 @@ extension MouseUpEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onwheel handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol WheelEventAttribute: AnyAttribute {
     
@@ -1445,8 +1566,11 @@ extension WheelEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondrag handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DragEventAttribute: AnyAttribute {
     
@@ -1485,8 +1609,11 @@ extension DragEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondragenter handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DragEnterEventAttribute: AnyAttribute {
     
@@ -1525,8 +1652,11 @@ extension DragEnterEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondragend handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DragEndEventAttribute: AnyAttribute {
     
@@ -1565,8 +1695,11 @@ extension DragEndEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondragleave handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DragLeaveEventAttribute: AnyAttribute {
     
@@ -1605,8 +1738,11 @@ extension DragLeaveEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondragover handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DragOverEventAttribute: AnyAttribute {
     
@@ -1645,8 +1781,11 @@ extension DragOverEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondragstart handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DragStartEventAttribute: AnyAttribute {
     
@@ -1685,8 +1824,11 @@ extension DragStartEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondrop handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DropEventAttribute: AnyAttribute {
     
@@ -1725,8 +1867,11 @@ extension DropEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onscroll handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ScrollEventAttribute: AnyAttribute {
     
@@ -1765,8 +1910,11 @@ extension ScrollEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oncopy handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol CopyEventAttribute: AnyAttribute {
     
@@ -1805,8 +1953,11 @@ extension CopyEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oncut handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol CutEventAttribute: AnyAttribute {
     
@@ -1845,8 +1996,11 @@ extension CutEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onpaste handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PasteEventAttribute: AnyAttribute {
     
@@ -1885,8 +2039,11 @@ extension PasteEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onabort handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol AbortEventAttribute: AnyAttribute {
     
@@ -1925,8 +2082,11 @@ extension AbortEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oncanplay handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol CanPlayEventAttribute: AnyAttribute {
     
@@ -1965,8 +2125,11 @@ extension CanPlayEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oncanplaythrough handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol CanPlayThroughEventAttribute: AnyAttribute {
     
@@ -2005,8 +2168,11 @@ extension CanPlayThroughEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the oncuechange handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol CueChangeEventAttribute: AnyAttribute {
     
@@ -2045,8 +2211,11 @@ extension CueChangeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ondurationchange handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol DurationChangeEventAttribute: AnyAttribute {
     
@@ -2085,8 +2254,11 @@ extension DurationChangeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onemptied handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol EmptiedEventAttribute: AnyAttribute {
     
@@ -2125,8 +2297,11 @@ extension EmptiedEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onended handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol EndedEventAttribute: AnyAttribute {
     
@@ -2165,8 +2340,11 @@ extension EndedEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onloadeddata handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol LoadedDataEventAttribute: AnyAttribute {
     
@@ -2205,8 +2383,11 @@ extension LoadedDataEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onloadedmetadata handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol LoadedMetaDataEventAttribute: AnyAttribute {
     
@@ -2245,8 +2426,11 @@ extension LoadedMetaDataEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onloadstart handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol LoadStartEventAttribute: AnyAttribute {
     
@@ -2285,8 +2469,11 @@ extension LoadStartEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onpause handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PauseEventAttribute: AnyAttribute {
     
@@ -2325,8 +2512,11 @@ extension PauseEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onplay handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PlayEventAttribute: AnyAttribute {
     
@@ -2365,8 +2555,11 @@ extension PlayEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onplaying handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol PlayingEventAttribute: AnyAttribute {
     
@@ -2405,8 +2598,11 @@ extension PlayingEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onprogress handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ProgressEventAttribute: AnyAttribute {
     
@@ -2445,8 +2641,11 @@ extension ProgressEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onratechange handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol RateChangeEventAttribute: AnyAttribute {
     
@@ -2485,8 +2684,11 @@ extension RateChangeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onseeked handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SeekedEventAttribute: AnyAttribute {
     
@@ -2525,8 +2727,11 @@ extension SeekedEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onseeking handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SeekingEventAttribute: AnyAttribute {
     
@@ -2565,8 +2770,11 @@ extension SeekingEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onstalled handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol StalledEventAttribute: AnyAttribute {
     
@@ -2605,8 +2813,11 @@ extension StalledEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onsuspend handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol SuspendEventAttribute: AnyAttribute {
     
@@ -2645,8 +2856,11 @@ extension SuspendEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ontimeupdate handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol TimeUpdateEventAttribute: AnyAttribute {
     
@@ -2685,8 +2899,11 @@ extension TimeUpdateEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onvolumechange handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol VolumeChangeEventAttribute: AnyAttribute {
     
@@ -2725,8 +2942,11 @@ extension VolumeChangeEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the onwaiting handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol WaitingEventAttribute: AnyAttribute {
     
@@ -2765,8 +2985,11 @@ extension WaitingEventAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides
+/// # Description:
+/// The protocol provides the element with the ontoggle handler.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#attr-ol-reversed
 ///
 public protocol ToggleEventAttribute: AnyAttribute {
     

--- a/Sources/HTMLKit/External/Components.swift
+++ b/Sources/HTMLKit/External/Components.swift
@@ -1,7 +1,17 @@
-// MARK: components
-
-/// The component ist for
+/// # Description:
+/// The file contains the view components.
 ///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
+/// The component returns a meta element with twitter and opengraph.
+///
+/// # References:
 ///
 public struct MetaTitle: Component {
     
@@ -34,8 +44,10 @@ public struct MetaTitle: Component {
     }
 }
 
-/// The component ist for
+/// # Description:
+/// The component returns a meta element with twitter and opengraph.
 ///
+/// # References:
 ///
 public struct MetaDescription: Component {
 
@@ -68,8 +80,10 @@ public struct MetaDescription: Component {
     }
 }
 
-/// The component ist for
+/// # Description:
+/// The component returns a link element.
 ///
+/// # References:
 ///
 public struct Favicon: Component {
 
@@ -86,8 +100,10 @@ public struct Favicon: Component {
     }
 }
 
-/// The component ist for
+/// # Description:
+/// The component returns a link element.
 ///
+/// # References:
 ///
 public struct Stylesheet: Component {
     
@@ -105,8 +121,10 @@ public struct Stylesheet: Component {
     }
 }
 
-/// The component ist for
+/// # Description:
+/// The component returns a meta element.
 ///
+/// # References:
 ///
 public struct Viewport: Component {
 
@@ -137,8 +155,10 @@ public struct Viewport: Component {
     }
 }
 
-/// The component ist for
+/// # Description:
+/// The component returns a meta element.
 ///
+/// # References:
 ///
 public struct Author: Component {
 

--- a/Sources/HTMLKit/External/Components.swift
+++ b/Sources/HTMLKit/External/Components.swift
@@ -24,7 +24,7 @@ public struct MetaTitle: Component {
         IF(useOpenGraph) {
             Meta()
                 .property(.title)
-                .content(self.title.rawValue)
+                .content(self.title)
         }
         IF(useTwitter) {
             Meta()
@@ -48,11 +48,11 @@ public struct MetaDescription: Component {
     public var body: AnyContent {
         Meta()
             .name(.description)
-            .content(self.description.rawValue)
+            .content(self.description)
         IF(useOpenGraph) {
             Meta()
                 .property(.description)
-                .content(self.description.rawValue)
+                .content(self.description)
         }
         IF(useTwitter) {
             Meta()
@@ -100,8 +100,8 @@ public struct Stylesheet: Component {
     public var body: AnyContent {
         Link()
             .relationship(.stylesheet)
-            .reference(self.url.rawValue)
-            .type("text/css")
+            .reference(self.url)
+            .type(.css)
     }
 }
 
@@ -149,11 +149,11 @@ public struct Author: Component {
     public var body: AnyContent {
         Meta()
             .name(.author)
-            .content(self.author.rawValue)
+            .content(self.author)
         Unwrap(handle) { handle in
             Meta()
                 .name(.init(rawValue: "twitter:creator")!)
-                .content(handle.rawValue)
+                .content(handle)
         }
     }
     

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -128,6 +128,10 @@ extension Html: GlobalAttributes {
     public func itemScope(_ value: String) -> Html {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Html {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Html {
         return mutate(id: value)

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -176,3 +176,15 @@ extension Html: AnyContent {
         try self.build(with: manager)
     }
 }
+
+extension Html: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -132,6 +132,10 @@ extension Html: GlobalAttributes {
     public func id(_ value: String) -> Html {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Html {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Html {
         return mutate(lang: type.rawValue)

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -1,7 +1,20 @@
+/// # Description:
+/// The file contains the basics elements. These elements should be used at first.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#comments
 ///
 public struct Comment: CommentNode {
     
@@ -23,8 +36,11 @@ extension Comment: AnyContent {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the the document.
 ///
+/// # References:
+/// https://dom.spec.whatwg.org/#document-element
 ///
 public struct Document: DocumentNode, BasicElement {
     
@@ -46,8 +62,11 @@ extension Document: AnyContent {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the document's root element.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-html-element
 ///
 public struct Html: ContentNode, BasicElement {
 

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -1,187 +1,201 @@
+/// # Description:
+/// The file contains the body elements. The html element Body only allows these elements
+/// to be its descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Navigation.
 ///
 public typealias Nav = Navigation
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Heading1.
 ///
 public typealias H1 = Heading1
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Heading2.
 ///
 public typealias H2 = Heading2
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Heading3.
 ///
 public typealias H3 = Heading3
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Heading4.
 ///
 public typealias H4 = Heading4
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Heading5.
 ///
 public typealias H5 = Heading5
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Heading6.
 ///
 public typealias H6 = Heading6
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to HeadingGroup.
 ///
 public typealias Hgroup = HeadingGroup
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Paragraph.
 ///
 public typealias P = Paragraph
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to HorizontalRule.
 ///
 public typealias Hr = HorizontalRule
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to PreformattedText.
 ///
 public typealias Pre = PreformattedText
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to OrderedList.
 ///
 public typealias Ol = OrderedList
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to UnorderedList.
 ///
 public typealias Ul = UnorderedList
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to DescriptionList.
 ///
 public typealias Dl = DescriptionList
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Division.
 ///
 public typealias Div = Division
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Anchor.
 ///
 public typealias A = Anchor
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Emphasize.
 ///
 public typealias Em = Emphasize
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to StrikeThrough.
 ///
 public typealias S = StrikeThrough
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to ShortQuote.
 ///
 public typealias Q = ShortQuote
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Definition.
 ///
 public typealias Dfn = Definition
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Abbreviation.
 ///
 public typealias Abbr = Abbreviation
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Variable.
 ///
 public typealias V = Variable
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to SampleOutput.
 ///
 public typealias Samp = SampleOutput
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to KeyboardInput.
 ///
 public typealias Kbd = KeyboardInput
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Subscript.
 ///
 public typealias Sub = Subscript
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Superscript.
 ///
 public typealias Sup = Superscript
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Italic.
 ///
 public typealias I = Italic
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Bold.
 ///
 public typealias B = Bold
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Underline.
 ///
 public typealias U = Underline
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to LineBreak.
 ///
 public typealias Br = LineBreak
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to WordBreak.
 ///
 public typealias Wbr = WordBreak
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to InsertedText.
 ///
 public typealias Ins = InsertedText
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to DeletedText.
 ///
 public typealias Del = DeletedText
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Image.
 ///
 public typealias Img = Image
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to InlineFrame.
 ///
 public typealias Iframe = InlineFrame
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Parameter.
 ///
 public typealias Param = Parameter
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-link-element
 ///
 public struct Link: EmptyNode, BodyElement {
 
@@ -366,8 +380,11 @@ extension Link: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a self-contained content.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-article-element
 ///
 public struct Article: ContentNode, BodyElement {
 
@@ -517,8 +534,11 @@ extension Article: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a generic section of the document.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-section-element
 ///
 public struct Section: ContentNode, BodyElement {
 
@@ -668,8 +688,11 @@ extension Section: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a section of a page that links to other pages or parts within the page.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-nav-element)
 ///
 public struct Navigation: ContentNode, BodyElement {
 
@@ -819,8 +842,11 @@ extension Navigation: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element defines some content aside from the content it is placed in.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-aside-element
 ///
 public struct Aside: ContentNode, BodyElement {
 
@@ -970,8 +996,11 @@ extension Aside: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a heading.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
 public struct Heading1: ContentNode, BodyElement {
 
@@ -1132,8 +1161,11 @@ extension Heading1: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a heading.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
 public struct Heading2: ContentNode, BodyElement {
 
@@ -1294,8 +1326,11 @@ extension Heading2: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a heading.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
 public struct Heading3: ContentNode, BodyElement {
 
@@ -1456,8 +1491,11 @@ extension Heading3: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a heading.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
 public struct Heading4: ContentNode, BodyElement {
 
@@ -1618,8 +1656,11 @@ extension Heading4: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a heading.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
 public struct Heading5: ContentNode, BodyElement {
 
@@ -1780,8 +1821,11 @@ extension Heading5: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a heading.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
 public struct Heading6: ContentNode, BodyElement {
 
@@ -1942,8 +1986,11 @@ extension Heading6: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is used to group a set of heading elements.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-hgroup-element
 ///
 public struct HeadingGroup: ContentNode, BodyElement {
 
@@ -2093,8 +2140,11 @@ extension HeadingGroup: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a header.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-header-element
 ///
 public struct Header: ContentNode, BodyElement {
 
@@ -2244,8 +2294,11 @@ extension Header: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a footer.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-footer-element
 ///
 public struct Footer: ContentNode, BodyElement {
 
@@ -2395,8 +2448,11 @@ extension Footer: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the contact information.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-address-element
 ///
 public struct Address: ContentNode, BodyElement {
 
@@ -2546,8 +2602,11 @@ extension Address: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is used to define a paragraph.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-p-element
 ///
 public struct Paragraph: ContentNode, BodyElement {
 
@@ -2708,8 +2767,11 @@ extension Paragraph: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is used for horizontal rules that act as dividers between sections.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-hr-element
 ///
 public struct HorizontalRule: EmptyNode, BodyElement {
 
@@ -2854,8 +2916,11 @@ extension HorizontalRule: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a block of preformatted text.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-pre-element
 ///
 public struct PreformattedText: ContentNode, BodyElement {
 
@@ -3005,8 +3070,11 @@ extension PreformattedText: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a section that is quoted from another source.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-blockquote-element
 ///
 public struct Blockquote: ContentNode, BodyElement {
 
@@ -3171,8 +3239,11 @@ extension Blockquote: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a list of items, where the items have been intentionally ordered.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-ol-element
 ///
 public struct OrderedList: ContentNode, BodyElement {
 
@@ -3334,8 +3405,11 @@ extension OrderedList: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a list of items, where the order of the items is not important.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-ul-element
 ///
 public struct UnorderedList: ContentNode, BodyElement {
 
@@ -3485,8 +3559,11 @@ extension UnorderedList: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element defines a list of terms and corresponding definitions.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-dl-element
 ///
 public struct DescriptionList: ContentNode, BodyElement {
 
@@ -3636,8 +3713,11 @@ extension DescriptionList: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element can thus be used to annotate illustrations, diagrams, photos, code listings.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-figure-element
 ///
 public struct Figure: ContentNode, BodyElement {
 
@@ -3787,8 +3867,11 @@ extension Figure: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-a-element
 ///
 public struct Anchor: ContentNode, BodyElement {
 
@@ -3989,8 +4072,11 @@ extension Anchor: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element provides typographic emphasis.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-em-element
 ///
 public struct Emphasize: ContentNode, BodyElement {
 
@@ -4140,8 +4226,11 @@ extension Emphasize: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element provides strong typographic emphasis.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-strong-element
 ///
 public struct Strong: ContentNode, BodyElement {
 
@@ -4291,8 +4380,11 @@ extension Strong: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents side comments such as small print.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-small-element
 ///
 public struct Small: ContentNode, BodyElement {
 
@@ -4453,8 +4545,11 @@ extension Small: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents contents that are no longer accurate or no longer relevant.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-s-element
 ///
 public struct StrikeThrough: ContentNode, BodyElement {
 
@@ -4615,8 +4710,11 @@ extension StrikeThrough: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the dominant contents of the document.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-main-element
 ///
 public struct Main: ContentNode, BodyElement {
 
@@ -4766,8 +4864,11 @@ extension Main: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is used to represent different kinds of containers.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-div-element
 ///
 public struct Division: ContentNode, BodyElement {
 
@@ -4917,8 +5018,11 @@ extension Division: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-dfn-element
 ///
 public struct Definition: ContentNode, BodyElement {
 
@@ -5068,8 +5172,11 @@ extension Definition: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element specifies a citation.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-cite-element
 ///
 public struct Cite: ContentNode, BodyElement {
 
@@ -5219,8 +5326,11 @@ extension Cite: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is used for a short quotation.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-q-element
 ///
 public struct ShortQuote: ContentNode, BodyElement {
 
@@ -5374,8 +5484,11 @@ extension ShortQuote: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an abbreviation or acronym.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-abbr-element
 ///
 public struct Abbreviation: ContentNode, BodyElement {
 
@@ -5525,8 +5638,11 @@ extension Abbreviation: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element allows one or more spans of phrasing content to be marked with ruby annotations.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-ruby-element
 ///
 public struct Ruby: ContentNode, BodyElement {
 
@@ -5676,8 +5792,11 @@ extension Ruby: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-data-element
 ///
 public struct Data: ContentNode, BodyElement {
 
@@ -5835,8 +5954,11 @@ extension Data: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents its contents, along with a machine-readable form of those contents in the datetime attribute.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-time-element
 ///
 public struct Time: ContentNode, BodyElement {
 
@@ -5990,8 +6112,11 @@ extension Time: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an example of code.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-code-element
 ///
 public struct Code: ContentNode, BodyElement {
 
@@ -6141,8 +6266,11 @@ extension Code: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element indicates a variable name.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-link-element
 ///
 public struct Variable: ContentNode, BodyElement {
 
@@ -6292,8 +6420,11 @@ extension Variable: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents sample or quoted output from another program or computing system.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-samp-element
 ///
 public struct SampleOutput: ContentNode, BodyElement {
 
@@ -6443,8 +6574,11 @@ extension SampleOutput: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents user input.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-kbd-element
 ///
 public struct KeyboardInput: ContentNode, BodyElement {
 
@@ -6594,8 +6728,11 @@ extension KeyboardInput: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a subscript.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-sub-and-sup-elements
 ///
 public struct Subscript: ContentNode, BodyElement {
 
@@ -6745,8 +6882,11 @@ extension Subscript: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a superscript.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-sub-and-sup-elements
 ///
 public struct Superscript: ContentNode, BodyElement {
 
@@ -6896,8 +7036,11 @@ extension Superscript: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an italic font text.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-i-element
 ///
 public struct Italic: ContentNode, BodyElement {
 
@@ -7058,8 +7201,11 @@ extension Italic: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an bold font text.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-b-element
 ///
 public struct Bold: ContentNode, BodyElement {
 
@@ -7220,8 +7366,11 @@ extension Bold: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element specifies that the enclosed text should be displayed as underlined.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-u-element
 ///
 public struct Underline: ContentNode, BodyElement {
 
@@ -7382,8 +7531,11 @@ extension Underline: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a run of text in the document marked or highlighted for reference purposes.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-mark-element
 ///
 public struct Mark: ContentNode, BodyElement {
 
@@ -7533,8 +7685,11 @@ extension Mark: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a span of text that is to be isolated from its surroundings for the purposes of bidirectional text formatting.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-bdi-element
 ///
 public struct Bdi: ContentNode, BodyElement {
 
@@ -7684,8 +7839,11 @@ extension Bdi: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents explicit text directionality formatting control.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-bdo-element
 ///
 public struct Bdo: EmptyNode, BodyElement {
 
@@ -7830,8 +7988,11 @@ extension Bdo: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element doesn't mean anything on its own.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-span-element
 ///
 public struct Span: ContentNode, BodyElement {
 
@@ -7981,8 +8142,11 @@ extension Span: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a line break.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-br-element
 ///
 public struct LineBreak: EmptyNode, BodyElement {
 
@@ -8127,8 +8291,11 @@ extension LineBreak: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a line break opportunity.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-wbr-element
 ///
 public struct WordBreak: EmptyNode, BodyElement {
 
@@ -8273,8 +8440,11 @@ extension WordBreak: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an addition to the document.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-ins-element
 ///
 public struct InsertedText: ContentNode, BodyElement {
 
@@ -8432,8 +8602,11 @@ extension InsertedText: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a removal from the document.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-del-element
 ///
 public struct DeletedText: ContentNode, BodyElement {
 
@@ -8591,8 +8764,11 @@ extension DeletedText: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is a container which provides multiple sources to its contained image element.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-picture-element
 ///
 public struct Picture: ContentNode, BodyElement {
 
@@ -8742,8 +8918,11 @@ extension Picture: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an image.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-img-element
 ///
 public struct Image: EmptyNode, BodyElement {
 
@@ -8920,8 +9099,11 @@ extension Image: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents its nested browsing context.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-iframe-element
 ///
 public struct InlineFrame: ContentNode, BodyElement {
     
@@ -9095,8 +9277,11 @@ extension InlineFrame: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element provides an integration point for an external application or interactive content.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-embed-element
 ///
 public struct Embed: EmptyNode, BodyElement {
 
@@ -9257,8 +9442,11 @@ extension Embed: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an external resource.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-object-element
 ///
 public struct Object: ContentNode, BodyElement {
     
@@ -9440,8 +9628,11 @@ extension Object: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-video-element
 ///
 public struct Video: ContentNode, BodyElement {
 
@@ -9619,8 +9810,11 @@ extension Video: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-audio-element
 ///
 public struct Audio: ContentNode, BodyElement {
 
@@ -9790,8 +9984,11 @@ extension Audio: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-map-elements
 ///
 public struct Map: ContentNode, BodyElement {
     
@@ -9949,8 +10146,11 @@ extension Map: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-form-element
 ///
 public struct Form: ContentNode, BodyElement {
 
@@ -10140,8 +10340,11 @@ extension Form: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a set of options.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-datalist-element
 ///
 public struct DataList: ContentNode, BodyElement {
 
@@ -10291,8 +10494,11 @@ extension DataList: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the result of a calculation.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-output-element
 ///
 public struct Output: ContentNode, BodyElement {
     
@@ -10458,8 +10664,11 @@ extension Output: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the completion progress of a task.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-progress-element
 ///
 public struct Progress: ContentNode, BodyElement {
 
@@ -10621,8 +10830,11 @@ extension Progress: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a scalar measurement within a known range, or a fractional value.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-meter-element
 ///
 public struct Meter: ContentNode, BodyElement {
 
@@ -10796,8 +11008,11 @@ extension Meter: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a disclosure widget from which the user can obtain additional information or controls.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-details-element
 ///
 public struct Details: ContentNode, BodyElement {
 
@@ -10955,8 +11170,11 @@ extension Details: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element defines a dialog box or window.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-dialog-element
 ///
 public struct Dialog: ContentNode, BodyElement {
 
@@ -11110,8 +11328,11 @@ extension Dialog: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element allows to include dynamic script and data blocks in a document.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-script-element
 ///
 public struct Script: ContentNode, BodyElement {
 
@@ -11285,8 +11506,11 @@ extension Script: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a caption for the rest of the contents of a fieldset.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-template-element
 ///
 public struct NoScript: ContentNode, BodyElement {
 
@@ -11436,8 +11660,11 @@ extension NoScript: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element is used to declare fragments of HTML that can be cloned and inserted in the document by script.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-template-element
 ///
 public struct Template: ContentNode, BodyElement {
 
@@ -11587,8 +11814,11 @@ extension Template: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-canvas-element
 ///
 public struct Canvas: ContentNode, BodyElement {
 
@@ -11746,8 +11976,11 @@ extension Canvas: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-table-element
 ///
 public struct Table: ContentNode, BodyElement {
 

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -4315,57 +4315,13 @@ extension Division: AnyContent {
 
 extension Division: Modifiable {
     
-    public func modify(if condition: Bool, modifyer: (Self) -> Self) -> Self {
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
         
-        let element = modifyer(.init(attributes: [:], content: [""]))
-        
-        guard var attributes = self.attributes else {
-
-            return .init(attributes: element.attributes!, content: self.content)
+        if condition {
+            return modify(element(.init(attributes: [:], content: [""])))
         }
         
-        return .init(attributes: merge(element.attributes!, with: &attributes), content: self.content)
-    }
-    
-    public func modify<Value>(unwrap value: TemplateValue<Value?>, modifyer: (TemplateValue<Value>, Self) -> Self) -> Self {
-        
-        switch value {
-            
-        case .constant(let optional):
-            
-            guard let value = optional else {
-                return self
-            }
-            
-            let element = modifyer(.constant(value), .init(attributes: [:], content: [""]))
-
-            guard var attributes = self.attributes else {
-
-                return .init(attributes: element.attributes!, content: self.content)
-            }
-            
-            return .init(attributes: merge(element.attributes!, with: &attributes), content: self.content)
-            
-        case .dynamic(let context):
-            
-            var element: Self!
-            
-            if context.isMascadingOptional {
-                
-                element = modifyer(.dynamic(context.unsafeCast(to: Value.self)), .init(attributes: [:], content: [""]))
-                
-            } else {
-                
-                element = modifyer(.dynamic(context.unsafelyUnwrapped), .init(attributes: [:], content: [""]))
-            }
-
-            guard var attributes = self.attributes else {
-
-                return .init(attributes: element.attributes!, content: self.content)
-            }
-            
-            return .init(attributes: merge(element.attributes!, with: &attributes), content: self.content)
-        }
+        return self
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -265,6 +265,10 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
     public func itemScope(_ value: String) -> Link {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Link {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Link {
         return mutate(id: value)
@@ -444,6 +448,10 @@ extension Article: GlobalAttributes {
     public func itemScope(_ value: String) -> Article {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Article {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Article {
         return mutate(id: value)
@@ -590,6 +598,10 @@ extension Section: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Section {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Section {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Section {
@@ -738,6 +750,10 @@ extension Navigation: GlobalAttributes {
     public func itemScope(_ value: String) -> Navigation {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Navigation {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Navigation {
         return mutate(id: value)
@@ -885,6 +901,10 @@ extension Aside: GlobalAttributes {
     public func itemScope(_ value: String) -> Aside {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Aside {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Aside {
         return mutate(id: value)
@@ -1031,6 +1051,10 @@ extension Heading1: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Heading1 {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Heading1 {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Heading1 {
@@ -1190,6 +1214,10 @@ extension Heading2: GlobalAttributes {
     public func itemScope(_ value: String) -> Heading2 {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Heading2 {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Heading2 {
         return mutate(id: value)
@@ -1347,6 +1375,10 @@ extension Heading3: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Heading3 {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Heading3 {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Heading3 {
@@ -1506,6 +1538,10 @@ extension Heading4: GlobalAttributes {
     public func itemScope(_ value: String) -> Heading4 {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Heading4 {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Heading4 {
         return mutate(id: value)
@@ -1664,6 +1700,10 @@ extension Heading5: GlobalAttributes {
     public func itemScope(_ value: String) -> Heading5 {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Heading5 {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Heading5 {
         return mutate(id: value)
@@ -1821,6 +1861,10 @@ extension Heading6: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Heading6 {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Heading6 {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Heading6 {
@@ -1981,6 +2025,10 @@ extension HeadingGroup: GlobalAttributes {
         return mutate(itemscope: value)
     }
 
+    public func itemType(_ value: String) -> HeadingGroup {
+        return mutate(itemtype: value)
+    }
+    
     public func id(_ value: String) -> HeadingGroup {
         return mutate(id: value)
     }
@@ -2126,6 +2174,10 @@ extension Header: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Header {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Header {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Header {
@@ -2274,6 +2326,10 @@ extension Footer: GlobalAttributes {
     public func itemScope(_ value: String) -> Footer {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Footer {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Footer {
         return mutate(id: value)
@@ -2421,6 +2477,10 @@ extension Address: GlobalAttributes {
     public func itemScope(_ value: String) -> Address {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Address {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Address {
         return mutate(id: value)
@@ -2567,6 +2627,10 @@ extension Paragraph: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Paragraph {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Paragraph {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Paragraph {
@@ -2721,6 +2785,10 @@ extension HorizontalRule: GlobalAttributes {
     public func itemScope(_ value: String) -> HorizontalRule {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> HorizontalRule {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> HorizontalRule {
         return mutate(id: value)
@@ -2868,6 +2936,10 @@ extension PreformattedText: GlobalAttributes {
     public func itemScope(_ value: String) -> PreformattedText {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> PreformattedText {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> PreformattedText {
         return mutate(id: value)
@@ -3014,6 +3086,10 @@ extension Blockquote: GlobalAttributes, CiteAttribute {
 
     public func itemScope(_ value: String) -> Blockquote {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Blockquote {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Blockquote {
@@ -3177,6 +3253,10 @@ extension OrderedList: GlobalAttributes, ReversedAttribute, StartAttribute, Type
     public func itemScope(_ value: String) -> OrderedList {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> OrderedList {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> OrderedList {
         return mutate(id: value)
@@ -3336,6 +3416,10 @@ extension UnorderedList: GlobalAttributes {
     public func itemScope(_ value: String) -> UnorderedList {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> UnorderedList {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> UnorderedList {
         return mutate(id: value)
@@ -3482,6 +3566,10 @@ extension DescriptionList: GlobalAttributes {
 
     public func itemScope(_ value: String) -> DescriptionList {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> DescriptionList {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> DescriptionList {
@@ -3631,6 +3719,10 @@ extension Figure: GlobalAttributes {
         return mutate(itemscope: value)
     }
 
+    public func itemType(_ value: String) -> Figure {
+        return mutate(itemtype: value)
+    }
+    
     public func id(_ value: String) -> Figure {
         return mutate(id: value)
     }
@@ -3776,6 +3868,10 @@ extension Anchor: GlobalAttributes, DownloadAttribute, ReferenceAttribute, Refer
 
     public func itemScope(_ value: String) -> Anchor {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Anchor {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Anchor {
@@ -3975,6 +4071,10 @@ extension Emphasize: GlobalAttributes {
     public func itemScope(_ value: String) -> Emphasize {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Emphasize {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Emphasize {
         return mutate(id: value)
@@ -4122,6 +4222,10 @@ extension Strong: GlobalAttributes {
     public func itemScope(_ value: String) -> Strong {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Strong {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Strong {
         return mutate(id: value)
@@ -4268,6 +4372,10 @@ extension Small: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Small {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Small {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Small {
@@ -4427,6 +4535,10 @@ extension StrikeThrough: GlobalAttributes {
     public func itemScope(_ value: String) -> StrikeThrough {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> StrikeThrough {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> StrikeThrough {
         return mutate(id: value)
@@ -4585,6 +4697,10 @@ extension Main: GlobalAttributes {
     public func itemScope(_ value: String) -> Main {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Main {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Main {
         return mutate(id: value)
@@ -4731,6 +4847,10 @@ extension Division: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Division {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Division {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Division {
@@ -4879,6 +4999,10 @@ extension Definition: GlobalAttributes {
     public func itemScope(_ value: String) -> Definition {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Definition {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Definition {
         return mutate(id: value)
@@ -5026,6 +5150,10 @@ extension Cite: GlobalAttributes {
     public func itemScope(_ value: String) -> Cite {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Cite {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Cite {
         return mutate(id: value)
@@ -5172,6 +5300,10 @@ extension ShortQuote: GlobalAttributes, CiteAttribute {
 
     public func itemScope(_ value: String) -> ShortQuote {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> ShortQuote {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> ShortQuote {
@@ -5324,6 +5456,10 @@ extension Abbreviation: GlobalAttributes {
     public func itemScope(_ value: String) -> Abbreviation {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Abbreviation {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Abbreviation {
         return mutate(id: value)
@@ -5471,6 +5607,10 @@ extension Ruby: GlobalAttributes {
     public func itemScope(_ value: String) -> Ruby {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Ruby {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Ruby {
         return mutate(id: value)
@@ -5617,6 +5757,10 @@ extension Data: GlobalAttributes, ValueAttribute {
 
     public func itemScope(_ value: String) -> Data {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Data {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Data {
@@ -5773,6 +5917,10 @@ extension Time: GlobalAttributes, DateTimeAttribute {
     public func itemScope(_ value: String) -> Time {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Time {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Time {
         return mutate(id: value)
@@ -5924,6 +6072,10 @@ extension Code: GlobalAttributes {
     public func itemScope(_ value: String) -> Code {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Code {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Code {
         return mutate(id: value)
@@ -6070,6 +6222,10 @@ extension Variable: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Variable {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Variable {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Variable {
@@ -6218,6 +6374,10 @@ extension SampleOutput: GlobalAttributes {
     public func itemScope(_ value: String) -> SampleOutput {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> SampleOutput {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> SampleOutput {
         return mutate(id: value)
@@ -6364,6 +6524,10 @@ extension KeyboardInput: GlobalAttributes {
 
     public func itemScope(_ value: String) -> KeyboardInput {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> KeyboardInput {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> KeyboardInput {
@@ -6512,6 +6676,10 @@ extension Subscript: GlobalAttributes {
     public func itemScope(_ value: String) -> Subscript {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Subscript {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Subscript {
         return mutate(id: value)
@@ -6659,6 +6827,10 @@ extension Superscript: GlobalAttributes {
     public func itemScope(_ value: String) -> Superscript {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Superscript {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Superscript {
         return mutate(id: value)
@@ -6805,6 +6977,10 @@ extension Italic: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Italic {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Italic {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Italic {
@@ -6964,6 +7140,10 @@ extension Bold: GlobalAttributes {
     public func itemScope(_ value: String) -> Bold {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Bold {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Bold {
         return mutate(id: value)
@@ -7121,6 +7301,10 @@ extension Underline: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Underline {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Underline {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Underline {
@@ -7280,6 +7464,10 @@ extension Mark: GlobalAttributes {
     public func itemScope(_ value: String) -> Mark {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Mark {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Mark {
         return mutate(id: value)
@@ -7427,6 +7615,10 @@ extension Bdi: GlobalAttributes {
     public func itemScope(_ value: String) -> Bdi {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Bdi {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Bdi {
         return mutate(id: value)
@@ -7568,6 +7760,10 @@ extension Bdo: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Bdo {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Bdo {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Bdo {
@@ -7716,6 +7912,10 @@ extension Span: GlobalAttributes {
     public func itemScope(_ value: String) -> Span {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Span {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Span {
         return mutate(id: value)
@@ -7858,6 +8058,10 @@ extension LineBreak: GlobalAttributes {
     public func itemScope(_ value: String) -> LineBreak {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> LineBreak {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> LineBreak {
         return mutate(id: value)
@@ -7999,6 +8203,10 @@ extension WordBreak: GlobalAttributes {
 
     public func itemScope(_ value: String) -> WordBreak {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> WordBreak {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> WordBreak {
@@ -8146,6 +8354,10 @@ extension InsertedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
 
     public func itemScope(_ value: String) -> InsertedText {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> InsertedText {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> InsertedText {
@@ -8302,6 +8514,10 @@ extension DeletedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
     public func itemScope(_ value: String) -> DeletedText {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> DeletedText {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> DeletedText {
         return mutate(id: value)
@@ -8457,6 +8673,10 @@ extension Picture: GlobalAttributes {
     public func itemScope(_ value: String) -> Picture {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Picture {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Picture {
         return mutate(id: value)
@@ -8606,6 +8826,10 @@ extension Image: GlobalAttributes, AlternateAttribute, SourceAttribute, SizesAtt
 
     public func itemScope(_ value: String) -> Image {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Image {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Image {
@@ -8778,6 +9002,10 @@ extension InlineFrame: GlobalAttributes, SourceAttribute, NameAttribute, WidthAt
     public func itemScope(_ value: String) -> InlineFrame {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> InlineFrame {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> InlineFrame {
         return mutate(id: value)
@@ -8943,6 +9171,10 @@ extension Embed: GlobalAttributes, SourceAttribute, TypeAttribute, WidthAttribut
 
     public func itemScope(_ value: String) -> Embed {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Embed {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Embed {
@@ -9110,6 +9342,10 @@ extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute,
 
     public func itemScope(_ value: String) -> Object {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Object {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Object {
@@ -9286,6 +9522,10 @@ extension Video: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
     public func itemScope(_ value: String) -> Video {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Video {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Video {
         return mutate(id: value)
@@ -9461,6 +9701,10 @@ extension Audio: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
     public func itemScope(_ value: String) -> Audio {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Audio {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Audio {
         return mutate(id: value)
@@ -9628,6 +9872,10 @@ extension Map: GlobalAttributes, NameAttribute {
     public func itemScope(_ value: String) -> Map {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Map {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Map {
         return mutate(id: value)
@@ -9790,6 +10038,10 @@ extension Form: GlobalAttributes, ActionAttribute, AutocompleteAttribute, Encodi
 
     public func itemScope(_ value: String) -> Form {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Form {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Form {
@@ -9970,6 +10222,10 @@ extension DataList: GlobalAttributes {
     public func itemScope(_ value: String) -> DataList {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> DataList {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> DataList {
         return mutate(id: value)
@@ -10116,6 +10372,10 @@ extension Output: GlobalAttributes, ForAttribute, FormAttribute, NameAttribute {
 
     public func itemScope(_ value: String) -> Output {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Output {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Output {
@@ -10280,6 +10540,10 @@ extension Progress: GlobalAttributes, ValueAttribute, MaximumValueAttribute {
     public func itemScope(_ value: String) -> Progress {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Progress {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Progress {
         return mutate(id: value)
@@ -10438,6 +10702,10 @@ extension Meter: GlobalAttributes, ValueAttribute, MinimumValueAttribute, Maximu
 
     public func itemScope(_ value: String) -> Meter {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Meter {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Meter {
@@ -10614,6 +10882,10 @@ extension Details: GlobalAttributes, OpenAttribute, ToggleEventAttribute {
     public func itemScope(_ value: String) -> Details {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Details {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Details {
         return mutate(id: value)
@@ -10764,6 +11036,10 @@ extension Dialog: GlobalAttributes, OpenAttribute {
 
     public func itemScope(_ value: String) -> Dialog {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Dialog {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Dialog {
@@ -10923,6 +11199,10 @@ extension Script: GlobalAttributes, AsynchronouslyAttribute, ReferrerPolicyAttri
 
     public func itemScope(_ value: String) -> Script {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Script {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Script {
@@ -11087,6 +11367,10 @@ extension NoScript: GlobalAttributes {
     public func itemScope(_ value: String) -> NoScript {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> NoScript {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> NoScript {
         return mutate(id: value)
@@ -11234,6 +11518,10 @@ extension Template: GlobalAttributes {
     public func itemScope(_ value: String) -> Template {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Template {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Template {
         return mutate(id: value)
@@ -11380,6 +11668,10 @@ extension Canvas: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func itemScope(_ value: String) -> Canvas {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Canvas {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Canvas {
@@ -11535,6 +11827,10 @@ extension Table: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func itemScope(_ value: String) -> Table {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Table {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Table {

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -269,6 +269,10 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
     public func id(_ value: String) -> Link {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Link {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Link {
         return mutate(lang: type.rawValue)
@@ -306,6 +310,10 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
         return mutate(href: value)
     }
     
+    public func reference(_ value: TemplateValue<String>) -> Link {
+        return mutate(href: value.rawValue)
+    }
+    
     public func referenceLanguage(_ type: Language) -> Link {
         return mutate(hreflang: type.rawValue)
     }
@@ -326,8 +334,8 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
         return mutate(sizes: size)
     }
     
-    public func type(_ value: String) -> Link {
-        return mutate(type: value)
+    public func type(_ value: MediaType) -> Link {
+        return mutate(type: value.rawValue)
     }
 }
 
@@ -439,6 +447,10 @@ extension Article: GlobalAttributes {
 
     public func id(_ value: String) -> Article {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Article {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Article {
@@ -583,6 +595,10 @@ extension Section: GlobalAttributes {
     public func id(_ value: String) -> Section {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Section {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Section {
         return mutate(lang: type.rawValue)
@@ -725,6 +741,10 @@ extension Navigation: GlobalAttributes {
 
     public func id(_ value: String) -> Navigation {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Navigation {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Navigation {
@@ -869,6 +889,10 @@ extension Aside: GlobalAttributes {
     public func id(_ value: String) -> Aside {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Aside {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Aside {
         return mutate(lang: type.rawValue)
@@ -1011,6 +1035,10 @@ extension Heading1: GlobalAttributes {
 
     public func id(_ value: String) -> Heading1 {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Heading1 {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Heading1 {
@@ -1167,6 +1195,10 @@ extension Heading2: GlobalAttributes {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Heading2 {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Heading2 {
         return mutate(lang: type.rawValue)
     }
@@ -1321,6 +1353,10 @@ extension Heading3: GlobalAttributes {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Heading3 {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Heading3 {
         return mutate(lang: type.rawValue)
     }
@@ -1473,6 +1509,10 @@ extension Heading4: GlobalAttributes {
 
     public func id(_ value: String) -> Heading4 {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Heading4 {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Heading4 {
@@ -1628,6 +1668,10 @@ extension Heading5: GlobalAttributes {
     public func id(_ value: String) -> Heading5 {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Heading5 {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Heading5 {
         return mutate(lang: type.rawValue)
@@ -1781,6 +1825,10 @@ extension Heading6: GlobalAttributes {
 
     public func id(_ value: String) -> Heading6 {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Heading6 {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Heading6 {
@@ -1936,6 +1984,10 @@ extension HeadingGroup: GlobalAttributes {
     public func id(_ value: String) -> HeadingGroup {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> HeadingGroup {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> HeadingGroup {
         return mutate(lang: type.rawValue)
@@ -2079,6 +2131,10 @@ extension Header: GlobalAttributes {
     public func id(_ value: String) -> Header {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Header {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Header {
         return mutate(lang: type.rawValue)
@@ -2221,6 +2277,10 @@ extension Footer: GlobalAttributes {
 
     public func id(_ value: String) -> Footer {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Footer {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Footer {
@@ -2366,6 +2426,10 @@ extension Address: GlobalAttributes {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Address {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Address {
         return mutate(lang: type.rawValue)
     }
@@ -2507,6 +2571,10 @@ extension Paragraph: GlobalAttributes {
 
     public func id(_ value: String) -> Paragraph {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Paragraph {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Paragraph {
@@ -2657,6 +2725,10 @@ extension HorizontalRule: GlobalAttributes {
     public func id(_ value: String) -> HorizontalRule {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> HorizontalRule {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> HorizontalRule {
         return mutate(lang: type.rawValue)
@@ -2801,6 +2873,10 @@ extension PreformattedText: GlobalAttributes {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> PreformattedText {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> PreformattedText {
         return mutate(lang: type.rawValue)
     }
@@ -2942,6 +3018,10 @@ extension Blockquote: GlobalAttributes, CiteAttribute {
 
     public func id(_ value: String) -> Blockquote {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Blockquote {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Blockquote {
@@ -3101,6 +3181,10 @@ extension OrderedList: GlobalAttributes, ReversedAttribute, StartAttribute, Type
     public func id(_ value: String) -> OrderedList {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> OrderedList {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> OrderedList {
         return mutate(lang: type.rawValue)
@@ -3256,6 +3340,10 @@ extension UnorderedList: GlobalAttributes {
     public func id(_ value: String) -> UnorderedList {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> UnorderedList {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> UnorderedList {
         return mutate(lang: type.rawValue)
@@ -3398,6 +3486,10 @@ extension DescriptionList: GlobalAttributes {
 
     public func id(_ value: String) -> DescriptionList {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> DescriptionList {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> DescriptionList {
@@ -3542,6 +3634,10 @@ extension Figure: GlobalAttributes {
     public func id(_ value: String) -> Figure {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Figure {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Figure {
         return mutate(lang: type.rawValue)
@@ -3685,6 +3781,10 @@ extension Anchor: GlobalAttributes, DownloadAttribute, ReferenceAttribute, Refer
     public func id(_ value: String) -> Anchor {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Anchor {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Anchor {
         return mutate(lang: type.rawValue)
@@ -3724,6 +3824,10 @@ extension Anchor: GlobalAttributes, DownloadAttribute, ReferenceAttribute, Refer
     
     public func reference(_ value: String) -> Anchor {
         return mutate(href: value)
+    }
+    
+    public func reference(_ value: TemplateValue<String>) -> Anchor {
+        return mutate(href: value.rawValue)
     }
     
     public func referenceLanguage(_ type: Language) -> Anchor {
@@ -3875,6 +3979,10 @@ extension Emphasize: GlobalAttributes {
     public func id(_ value: String) -> Emphasize {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Emphasize {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Emphasize {
         return mutate(lang: type.rawValue)
@@ -4019,6 +4127,10 @@ extension Strong: GlobalAttributes {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Strong {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Strong {
         return mutate(lang: type.rawValue)
     }
@@ -4160,6 +4272,10 @@ extension Small: GlobalAttributes {
 
     public func id(_ value: String) -> Small {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Small {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Small {
@@ -4315,6 +4431,10 @@ extension StrikeThrough: GlobalAttributes {
     public func id(_ value: String) -> StrikeThrough {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> StrikeThrough {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> StrikeThrough {
         return mutate(lang: type.rawValue)
@@ -4469,6 +4589,10 @@ extension Main: GlobalAttributes {
     public func id(_ value: String) -> Main {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Main {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Main {
         return mutate(lang: type.rawValue)
@@ -4611,6 +4735,10 @@ extension Division: GlobalAttributes {
 
     public func id(_ value: String) -> Division {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Division {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Division {
@@ -4755,6 +4883,10 @@ extension Definition: GlobalAttributes {
     public func id(_ value: String) -> Definition {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Definition {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Definition {
         return mutate(lang: type.rawValue)
@@ -4897,6 +5029,10 @@ extension Cite: GlobalAttributes {
 
     public func id(_ value: String) -> Cite {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Cite {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Cite {
@@ -5042,6 +5178,10 @@ extension ShortQuote: GlobalAttributes, CiteAttribute {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> ShortQuote {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> ShortQuote {
         return mutate(lang: type.rawValue)
     }
@@ -5188,6 +5328,10 @@ extension Abbreviation: GlobalAttributes {
     public func id(_ value: String) -> Abbreviation {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Abbreviation {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Abbreviation {
         return mutate(lang: type.rawValue)
@@ -5330,6 +5474,10 @@ extension Ruby: GlobalAttributes {
 
     public func id(_ value: String) -> Ruby {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Ruby {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Ruby {
@@ -5474,6 +5622,10 @@ extension Data: GlobalAttributes, ValueAttribute {
     public func id(_ value: String) -> Data {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Data {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Data {
         return mutate(lang: type.rawValue)
@@ -5509,6 +5661,10 @@ extension Data: GlobalAttributes, ValueAttribute {
     
     public func value(_ value: String) -> Data {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Data {
+        return mutate(value: value.rawValue)
     }
 }
 
@@ -5620,6 +5776,10 @@ extension Time: GlobalAttributes, DateTimeAttribute {
 
     public func id(_ value: String) -> Time {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Time {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Time {
@@ -5769,6 +5929,10 @@ extension Code: GlobalAttributes {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Code {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Code {
         return mutate(lang: type.rawValue)
     }
@@ -5910,6 +6074,10 @@ extension Variable: GlobalAttributes {
 
     public func id(_ value: String) -> Variable {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Variable {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Variable {
@@ -6054,6 +6222,10 @@ extension SampleOutput: GlobalAttributes {
     public func id(_ value: String) -> SampleOutput {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> SampleOutput {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> SampleOutput {
         return mutate(lang: type.rawValue)
@@ -6196,6 +6368,10 @@ extension KeyboardInput: GlobalAttributes {
 
     public func id(_ value: String) -> KeyboardInput {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> KeyboardInput {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> KeyboardInput {
@@ -6340,6 +6516,10 @@ extension Subscript: GlobalAttributes {
     public func id(_ value: String) -> Subscript {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Subscript {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Subscript {
         return mutate(lang: type.rawValue)
@@ -6483,6 +6663,10 @@ extension Superscript: GlobalAttributes {
     public func id(_ value: String) -> Superscript {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Superscript {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Superscript {
         return mutate(lang: type.rawValue)
@@ -6625,6 +6809,10 @@ extension Italic: GlobalAttributes {
 
     public func id(_ value: String) -> Italic {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Italic {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Italic {
@@ -6780,6 +6968,10 @@ extension Bold: GlobalAttributes {
     public func id(_ value: String) -> Bold {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Bold {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Bold {
         return mutate(lang: type.rawValue)
@@ -6933,6 +7125,10 @@ extension Underline: GlobalAttributes {
 
     public func id(_ value: String) -> Underline {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Underline {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Underline {
@@ -7088,6 +7284,10 @@ extension Mark: GlobalAttributes {
     public func id(_ value: String) -> Mark {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Mark {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Mark {
         return mutate(lang: type.rawValue)
@@ -7231,6 +7431,10 @@ extension Bdi: GlobalAttributes {
     public func id(_ value: String) -> Bdi {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Bdi {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Bdi {
         return mutate(lang: type.rawValue)
@@ -7368,6 +7572,10 @@ extension Bdo: GlobalAttributes {
 
     public func id(_ value: String) -> Bdo {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Bdo {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Bdo {
@@ -7512,6 +7720,10 @@ extension Span: GlobalAttributes {
     public func id(_ value: String) -> Span {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Span {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Span {
         return mutate(lang: type.rawValue)
@@ -7650,6 +7862,10 @@ extension LineBreak: GlobalAttributes {
     public func id(_ value: String) -> LineBreak {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> LineBreak {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> LineBreak {
         return mutate(lang: type.rawValue)
@@ -7787,6 +8003,10 @@ extension WordBreak: GlobalAttributes {
 
     public func id(_ value: String) -> WordBreak {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> WordBreak {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> WordBreak {
@@ -7930,6 +8150,10 @@ extension InsertedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
 
     public func id(_ value: String) -> InsertedText {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> InsertedText {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> InsertedText {
@@ -8082,6 +8306,10 @@ extension DeletedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
     public func id(_ value: String) -> DeletedText {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> DeletedText {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> DeletedText {
         return mutate(lang: type.rawValue)
@@ -8233,6 +8461,10 @@ extension Picture: GlobalAttributes {
     public func id(_ value: String) -> Picture {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Picture {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Picture {
         return mutate(lang: type.rawValue)
@@ -8378,6 +8610,10 @@ extension Image: GlobalAttributes, AlternateAttribute, SourceAttribute, SizesAtt
 
     public func id(_ value: String) -> Image {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Image {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Image {
@@ -8546,6 +8782,10 @@ extension InlineFrame: GlobalAttributes, SourceAttribute, NameAttribute, WidthAt
     public func id(_ value: String) -> InlineFrame {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> InlineFrame {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> InlineFrame {
         return mutate(lang: type.rawValue)
@@ -8583,8 +8823,12 @@ extension InlineFrame: GlobalAttributes, SourceAttribute, NameAttribute, WidthAt
         return mutate(source: value)
     }
     
-    public func name(_ type: NameType) -> InlineFrame {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> InlineFrame {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> InlineFrame {
+        return mutate(name: value.rawValue)
     }
     
     public func width(_ size: Int) -> InlineFrame {
@@ -8704,6 +8948,10 @@ extension Embed: GlobalAttributes, SourceAttribute, TypeAttribute, WidthAttribut
     public func id(_ value: String) -> Embed {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Embed {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Embed {
         return mutate(lang: type.rawValue)
@@ -8741,8 +8989,8 @@ extension Embed: GlobalAttributes, SourceAttribute, TypeAttribute, WidthAttribut
         return mutate(source: value)
     }
     
-    public func type(_ value: String) -> Embed {
-        return mutate(type: value)
+    public func type(_ value: MediaType) -> Embed {
+        return mutate(type: value.rawValue)
     }
     
     public func width(_ size: Int) -> Embed {
@@ -8799,7 +9047,7 @@ public struct Object: ContentNode, BodyElement {
 }
 
 extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute, FormAttribute, WidthAttribute, HeightAttribute, ErrorEventAttribute {
-    
+
     public func onError(_ value: String) -> Object {
         return mutate(onerror: value)
     }
@@ -8867,6 +9115,10 @@ extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute,
     public func id(_ value: String) -> Object {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Object {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Object {
         return mutate(lang: type.rawValue)
@@ -8904,12 +9156,16 @@ extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute,
         return mutate(data: value)
     }
     
-    public func type(_ value: String) -> Object {
-        return mutate(type: value)
+    public func type(_ value: MediaType) -> Object {
+        return mutate(type: value.rawValue)
     }
     
-    public func name(_ type: NameType) -> Object {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Object {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Object {
+        return mutate(name: value.rawValue)
     }
     
     public func form(_ value: String) -> Object {
@@ -9033,6 +9289,10 @@ extension Video: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
 
     public func id(_ value: String) -> Video {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Video {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Video {
@@ -9205,6 +9465,10 @@ extension Audio: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
     public func id(_ value: String) -> Audio {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Audio {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Audio {
         return mutate(lang: type.rawValue)
@@ -9368,6 +9632,10 @@ extension Map: GlobalAttributes, NameAttribute {
     public func id(_ value: String) -> Map {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Map {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Map {
         return mutate(lang: type.rawValue)
@@ -9401,8 +9669,12 @@ extension Map: GlobalAttributes, NameAttribute {
         return mutate(translate: value)
     }
 
-    public func name(_ type: NameType) -> Map {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Map {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Map {
+        return mutate(name: value.rawValue)
     }
 }
 
@@ -9523,6 +9795,10 @@ extension Form: GlobalAttributes, ActionAttribute, AutocompleteAttribute, Encodi
     public func id(_ value: String) -> Form {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Form {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Form {
         return mutate(lang: type.rawValue)
@@ -9572,8 +9848,12 @@ extension Form: GlobalAttributes, ActionAttribute, AutocompleteAttribute, Encodi
         return mutate(method: type.rawValue)
     }
     
-    public func name(_ type: NameType) -> Form {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Form {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Form {
+        return mutate(name: value.rawValue)
     }
     
     public func target(_ type: Target) -> Form {
@@ -9693,6 +9973,10 @@ extension DataList: GlobalAttributes {
 
     public func id(_ value: String) -> DataList {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> DataList {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> DataList {
@@ -9837,6 +10121,10 @@ extension Output: GlobalAttributes, ForAttribute, FormAttribute, NameAttribute {
     public func id(_ value: String) -> Output {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Output {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Output {
         return mutate(lang: type.rawValue)
@@ -9878,8 +10166,12 @@ extension Output: GlobalAttributes, ForAttribute, FormAttribute, NameAttribute {
         return mutate(form: value)
     }
     
-    public func name(_ type: NameType) -> Output {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Output {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Output {
+        return mutate(name: value.rawValue)
     }
 }
 
@@ -9992,6 +10284,10 @@ extension Progress: GlobalAttributes, ValueAttribute, MaximumValueAttribute {
     public func id(_ value: String) -> Progress {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Progress {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Progress {
         return mutate(lang: type.rawValue)
@@ -10031,6 +10327,10 @@ extension Progress: GlobalAttributes, ValueAttribute, MaximumValueAttribute {
 
     public func value(_ value: String) -> Progress {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Progress {
+        return mutate(value: value.rawValue)
     }
 }
 
@@ -10143,6 +10443,10 @@ extension Meter: GlobalAttributes, ValueAttribute, MinimumValueAttribute, Maximu
     public func id(_ value: String) -> Meter {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Meter {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Meter {
         return mutate(lang: type.rawValue)
@@ -10194,6 +10498,10 @@ extension Meter: GlobalAttributes, ValueAttribute, MinimumValueAttribute, Maximu
     
     public func value(_ value: String) -> Meter {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Meter {
+        return mutate(value: value.rawValue)
     }
 }
 
@@ -10309,6 +10617,10 @@ extension Details: GlobalAttributes, OpenAttribute, ToggleEventAttribute {
 
     public func id(_ value: String) -> Details {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Details {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Details {
@@ -10456,6 +10768,10 @@ extension Dialog: GlobalAttributes, OpenAttribute {
 
     public func id(_ value: String) -> Dialog {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Dialog {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Dialog {
@@ -10612,6 +10928,10 @@ extension Script: GlobalAttributes, AsynchronouslyAttribute, ReferrerPolicyAttri
     public func id(_ value: String) -> Script {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Script {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Script {
         return mutate(lang: type.rawValue)
@@ -10657,8 +10977,8 @@ extension Script: GlobalAttributes, AsynchronouslyAttribute, ReferrerPolicyAttri
         return mutate(source: value)
     }
     
-    public func type(_ value: String) -> Script {
-        return mutate(type: value)
+    public func type(_ value: MediaType) -> Script {
+        return mutate(type: value.rawValue)
     }
 }
 
@@ -10770,6 +11090,10 @@ extension NoScript: GlobalAttributes {
 
     public func id(_ value: String) -> NoScript {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> NoScript {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> NoScript {
@@ -10918,6 +11242,10 @@ extension Template: GlobalAttributes {
     public func language(_ type: Language) -> Template {
         return mutate(lang: type.rawValue)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Template {
+        return mutate(id: value.rawValue)
+    }
 
     public func nonce(_ value: String) -> Template {
         return mutate(nonce: value)
@@ -11056,6 +11384,10 @@ extension Canvas: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func id(_ value: String) -> Canvas {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Canvas {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Canvas {
@@ -11207,6 +11539,10 @@ extension Table: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func id(_ value: String) -> Table {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Table {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Table {

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -342,6 +342,18 @@ extension Link: AnyContent {
     }
 }
 
+extension Link: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -470,6 +482,18 @@ extension Article: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Article: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -604,6 +628,18 @@ extension Section: AnyContent {
     }
 }
 
+extension Section: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -732,6 +768,18 @@ extension Navigation: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Navigation: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -866,6 +914,18 @@ extension Aside: AnyContent {
     }
 }
 
+extension Aside: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -986,6 +1046,17 @@ extension Heading1: GlobalAttributes {
     }
 }
 
+extension Heading1: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Heading1: Localizable {
     
     public init(_ localizedKey: String) {
@@ -997,14 +1068,15 @@ extension Heading1: Localizable {
     }
 }
 
-extension Heading1: AnyContent {
+extension Heading1: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1128,6 +1200,17 @@ extension Heading2: GlobalAttributes {
     }
 }
 
+extension Heading2: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Heading2: Localizable {
     
     public init(_ localizedKey: String) {
@@ -1139,14 +1222,15 @@ extension Heading2: Localizable {
     }
 }
 
-extension Heading2: AnyContent {
+extension Heading2: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1234,8 +1318,7 @@ extension Heading3: GlobalAttributes {
     }
 
     public func id(_ value: String) -> Heading3 {
-        
-return mutate(id: value)
+        return mutate(id: value)
     }
 
     public func language(_ type: Language) -> Heading3 {
@@ -1271,6 +1354,17 @@ return mutate(id: value)
     }
 }
 
+extension Heading3: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Heading3: Localizable {
     
     public init(_ localizedKey: String) {
@@ -1282,14 +1376,15 @@ extension Heading3: Localizable {
     }
 }
 
-extension Heading3: AnyContent {
+extension Heading3: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1413,6 +1508,17 @@ extension Heading4: GlobalAttributes {
     }
 }
 
+extension Heading4: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Heading4: Localizable {
     
     public init(_ localizedKey: String) {
@@ -1424,14 +1530,15 @@ extension Heading4: Localizable {
     }
 }
 
-extension Heading4: AnyContent {
+extension Heading4: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1555,6 +1662,17 @@ extension Heading5: GlobalAttributes {
     }
 }
 
+extension Heading5: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Heading5: Localizable {
     
     public init(_ localizedKey: String) {
@@ -1566,14 +1684,15 @@ extension Heading5: Localizable {
     }
 }
 
-extension Heading5: AnyContent {
+extension Heading5: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1697,6 +1816,17 @@ extension Heading6: GlobalAttributes {
     }
 }
 
+extension Heading6: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Heading6: Localizable {
     
     public init(_ localizedKey: String) {
@@ -1708,14 +1838,15 @@ extension Heading6: Localizable {
     }
 }
 
-extension Heading6: AnyContent {
+extension Heading6: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1850,6 +1981,18 @@ extension HeadingGroup: AnyContent {
     }
 }
 
+extension HeadingGroup: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -1978,6 +2121,18 @@ extension Header: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Header: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -2112,6 +2267,18 @@ extension Footer: AnyContent {
     }
 }
 
+extension Footer: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -2136,13 +2303,11 @@ public struct Address: ContentNode, BodyElement {
 extension Address: GlobalAttributes {
     
     public func accessKey(_ value: String) -> Address {
-        
-return mutate(accesskey: value)
+        return mutate(accesskey: value)
     }
 
     public func autocapitalize(_ type: Capitalization) -> Address {
-        
-return mutate(autocapitalize: type.rawValue)
+        return mutate(autocapitalize: type.rawValue)
     }
 
     public func autofocus() -> Address {
@@ -2242,6 +2407,18 @@ extension Address: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Address: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -2365,6 +2542,17 @@ extension Paragraph: GlobalAttributes {
     }
 }
 
+extension Paragraph: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Paragraph: Localizable {
     
     public init(_ localizedKey: String) {
@@ -2376,14 +2564,15 @@ extension Paragraph: Localizable {
     }
 }
 
-extension Paragraph: AnyContent {
+extension Paragraph: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -2510,6 +2699,18 @@ extension HorizontalRule: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension HorizontalRule: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -2644,6 +2845,18 @@ extension PreformattedText: AnyContent {
     }
 }
 
+extension PreformattedText: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -2768,6 +2981,17 @@ extension Blockquote: GlobalAttributes, CiteAttribute {
     }
 }
 
+extension Blockquote: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Blockquote: Localizable {
     
     public init(_ localizedKey: String) {
@@ -2779,14 +3003,15 @@ extension Blockquote: Localizable {
     }
 }
 
-extension Blockquote: AnyContent {
+extension Blockquote: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -2933,6 +3158,18 @@ extension OrderedList: AnyContent {
     }
 }
 
+extension OrderedList: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -3061,6 +3298,18 @@ extension UnorderedList: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension UnorderedList: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -3195,6 +3444,18 @@ extension DescriptionList: AnyContent {
     }
 }
 
+extension DescriptionList: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -3323,6 +3584,18 @@ extension Figure: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Figure: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -3482,6 +3755,17 @@ extension Anchor: GlobalAttributes, DownloadAttribute, ReferenceAttribute, Refer
     }
 }
 
+extension Anchor: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Anchor: Localizable {
     
     public init(_ localizedKey: String) {
@@ -3493,14 +3777,15 @@ extension Anchor: Localizable {
     }
 }
 
-extension Anchor: AnyContent {
+extension Anchor: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -3528,8 +3813,7 @@ public struct Emphasize: ContentNode, BodyElement {
 extension Emphasize: GlobalAttributes {
     
     public func accessKey(_ value: String) -> Emphasize {
-        
-return mutate(accesskey: value)
+        return mutate(accesskey: value)
     }
 
     public func autocapitalize(_ type: Capitalization) -> Emphasize {
@@ -3633,6 +3917,18 @@ extension Emphasize: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Emphasize: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -3767,6 +4063,18 @@ extension Strong: AnyContent {
     }
 }
 
+extension Strong: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -3887,6 +4195,17 @@ extension Small: GlobalAttributes {
     }
 }
 
+extension Small: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Small: Localizable {
     
     public init(_ localizedKey: String) {
@@ -3898,14 +4217,15 @@ extension Small: Localizable {
     }
 }
 
-extension Small: AnyContent {
+extension Small: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -4029,6 +4349,17 @@ extension StrikeThrough: GlobalAttributes {
     }
 }
 
+extension StrikeThrough: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension StrikeThrough: Localizable {
     
     public init(_ localizedKey: String) {
@@ -4040,14 +4371,15 @@ extension StrikeThrough: Localizable {
     }
 }
 
-extension StrikeThrough: AnyContent {
+extension StrikeThrough: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -4179,6 +4511,18 @@ extension Main: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Main: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -4318,7 +4662,7 @@ extension Division: Modifiable {
     public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
         
         if condition {
-            return modify(element(.init(attributes: [:], content: [""])))
+            return modify(element(self))
         }
         
         return self
@@ -4456,6 +4800,18 @@ extension Definition: AnyContent {
     }
 }
 
+extension Definition: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -4584,6 +4940,18 @@ extension Cite: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Cite: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -4722,6 +5090,18 @@ extension ShortQuote: AnyContent {
     }
 }
 
+extension ShortQuote: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -4853,6 +5233,18 @@ extension Abbreviation: AnyContent {
     }
 }
 
+extension Abbreviation: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -4981,6 +5373,18 @@ extension Ruby: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Ruby: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -5119,6 +5523,18 @@ extension Data: AnyContent {
     }
 }
 
+extension Data: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -5254,6 +5670,18 @@ extension Time: AnyContent {
     }
 }
 
+extension Time: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -5382,6 +5810,18 @@ extension Code: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Code: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -5516,6 +5956,18 @@ extension Variable: AnyContent {
     }
 }
 
+extension Variable: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -5644,6 +6096,18 @@ extension SampleOutput: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension SampleOutput: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -5778,6 +6242,18 @@ extension KeyboardInput: AnyContent {
     }
 }
 
+extension KeyboardInput: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -5906,6 +6382,18 @@ extension Subscript: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Subscript: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -6040,6 +6528,18 @@ extension Superscript: AnyContent {
     }
 }
 
+extension Superscript: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -6168,7 +6668,8 @@ extension Italic: Localizable {
 
     public init<B>(_ localizedKey: String, with context: TemplateValue<B>) where B : Encodable {
         self.content = [Localized(key: localizedKey, context: context)]
-    }}
+    }
+}
 
 extension Italic: AnyContent {
     
@@ -6178,6 +6679,18 @@ extension Italic: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+    
+extension Italic: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -6323,6 +6836,18 @@ extension Bold: AnyContent {
     }
 }
 
+extension Bold: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -6465,6 +6990,18 @@ extension Underline: AnyContent {
     }
 }
 
+extension Underline: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -6593,6 +7130,18 @@ extension Mark: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Mark: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -6727,6 +7276,18 @@ extension Bdi: AnyContent {
     }
 }
 
+extension Bdi: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -6850,6 +7411,18 @@ extension Bdo: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Bdo: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -6984,6 +7557,18 @@ extension Span: AnyContent {
     }
 }
 
+extension Span: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -7110,6 +7695,18 @@ extension LineBreak: AnyContent {
     }
 }
 
+extension LineBreak: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -7233,6 +7830,18 @@ extension WordBreak: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension WordBreak: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -7375,6 +7984,18 @@ extension InsertedText: AnyContent {
     }
 }
 
+extension InsertedText: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -7514,6 +8135,18 @@ extension DeletedText: AnyContent {
     }
 }
 
+extension DeletedText: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -7642,6 +8275,18 @@ extension Picture: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Picture: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -7803,6 +8448,18 @@ extension Image: AnyContent {
     }
 }
 
+extension Image: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -7954,6 +8611,18 @@ extension InlineFrame: AnyContent {
     }
 }
 
+extension InlineFrame: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -8093,6 +8762,18 @@ extension Embed: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Embed: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -8255,6 +8936,18 @@ extension Object: AnyContent {
     }
 }
 
+extension Object: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -8414,6 +9107,18 @@ extension Video: AnyContent {
     }
 }
 
+extension Video: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -8565,6 +9270,18 @@ extension Audio: AnyContent {
     }
 }
 
+extension Audio: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -8697,6 +9414,18 @@ extension Map: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Map: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -8867,6 +9596,18 @@ extension Form: AnyContent {
     }
 }
 
+extension Form: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -8995,6 +9736,18 @@ extension DataList: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension DataList: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -9141,6 +9894,18 @@ extension Output: AnyContent {
     }
 }
 
+extension Output: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -9277,6 +10042,18 @@ extension Progress: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Progress: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -9431,6 +10208,18 @@ extension Meter: AnyContent {
     }
 }
 
+extension Meter: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -9570,6 +10359,18 @@ extension Details: AnyContent {
     }
 }
 
+extension Details: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -9702,6 +10503,18 @@ extension Dialog: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Dialog: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -9860,6 +10673,18 @@ extension Script: AnyContent {
     }
 }
 
+extension Script: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -9991,6 +10816,18 @@ extension NoScript: AnyContent {
     }
 }
 
+extension NoScript: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -10119,6 +10956,18 @@ extension Template: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Template: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -10261,6 +11110,18 @@ extension Canvas: AnyContent {
     }
 }
 
+extension Canvas: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -10397,5 +11258,17 @@ extension Table: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Table: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -1,17 +1,31 @@
+/// # Description:
+/// The file contains the definition elements. The html element DescriptionList only allows these
+/// elements to be its descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to TermName.
 ///
 public typealias Dt = TermName
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to TermDefinition.
 ///
 public typealias Dd = TermDefinition
 
-/// The element
+/// # Description:
+/// The element specifies a term name.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-dt-element
 ///
 public struct TermName: ContentNode, DescriptionElement {
 
@@ -161,8 +175,11 @@ extension TermName: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element specifies a term definition.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-dd-element
 ///
 public struct TermDefinition: ContentNode, DescriptionElement {
 

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -96,6 +96,10 @@ extension TermName: GlobalAttributes {
     public func id(_ value: String) -> TermName {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> TermName {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> TermName {
         return mutate(lang: type.rawValue)
@@ -238,6 +242,10 @@ extension TermDefinition: GlobalAttributes {
 
     public func id(_ value: String) -> TermDefinition {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> TermDefinition {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> TermDefinition {

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -92,6 +92,10 @@ extension TermName: GlobalAttributes {
     public func itemScope(_ value: String) -> TermName {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> TermName {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> TermName {
         return mutate(id: value)
@@ -238,6 +242,10 @@ extension TermDefinition: GlobalAttributes {
 
     public func itemScope(_ value: String) -> TermDefinition {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> TermDefinition {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> TermDefinition {

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -141,6 +141,18 @@ extension TermName: AnyContent {
     }
 }
 
+extension TermName: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -269,5 +281,17 @@ extension TermDefinition: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension TermDefinition: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -87,6 +87,10 @@ extension FigureCaption: GlobalAttributes {
     public func itemScope(_ value: String) -> FigureCaption {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> FigureCaption {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> FigureCaption {
         return mutate(id: value)

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -1,12 +1,26 @@
+/// # Description:
+/// The file contains the figure elements. The html element Figure only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to FigureCaption.
 ///
 public typealias Figcaption = FigureCaption
 
-/// The element
+/// # Description:
+/// The element is used to label a figure.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-figcaption-element
 ///
 public struct FigureCaption: ContentNode, FigureElement {
 

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -135,3 +135,15 @@ extension FigureCaption: AnyContent {
         try self.build(with: manager)
     }
 }
+
+extension FigureCaption: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -91,6 +91,10 @@ extension FigureCaption: GlobalAttributes {
     public func id(_ value: String) -> FigureCaption {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> FigureCaption {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> FigureCaption {
         return mutate(lang: type.rawValue)

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -1,7 +1,21 @@
+/// # Description:
+/// The file contains the form elements. The html element Form only allows these elements to be its
+/// descendants. There are some exceptions too.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element represents a typed data field to allow the user to edit the data.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-input-element
 ///
 public struct Input: EmptyNode, FormElement {
 
@@ -262,8 +276,11 @@ extension Input: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a caption for a form control.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-label-element
 ///
 public struct Label: ContentNode, FormElement {
 
@@ -428,8 +445,11 @@ extension Label: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a control for selecting amongst a set of options.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-select-element
 ///
 public struct Select: ContentNode, FormElement {
 
@@ -611,8 +631,11 @@ extension Select: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a multiline plain text edit control.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-textarea-element
 ///
 public struct TextArea: ContentNode, FormElement {
         
@@ -818,8 +841,11 @@ extension TextArea: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a comment output.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-button-element
 ///
 public struct Button: ContentNode, FormElement {
 
@@ -1012,8 +1038,11 @@ extension Button: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a set of form controls grouped together.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-fieldset-element
 ///
 public struct Fieldset: ContentNode, FormElement {
     

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -81,6 +81,10 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
     public func itemScope(_ value: String) -> Input {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Input {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Input {
         return mutate(id: value)
@@ -340,6 +344,10 @@ extension Label: GlobalAttributes, ForAttribute {
     public func itemScope(_ value: String) -> Label {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Label {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Label {
         return mutate(id: value)
@@ -501,6 +509,10 @@ extension Select: GlobalAttributes, AutocompleteAttribute, DisabledAttribute, Fo
 
     public func itemScope(_ value: String) -> Select {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Select {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Select {
@@ -680,6 +692,10 @@ extension TextArea: GlobalAttributes, AutocompleteAttribute, ColumnsAttribute, D
 
     public func itemScope(_ value: String) -> TextArea {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> TextArea {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> TextArea {
@@ -884,6 +900,10 @@ extension Button: GlobalAttributes, DisabledAttribute, FormAttribute, FormAction
     public func itemScope(_ value: String) -> Button {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Button {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Button {
         return mutate(id: value)
@@ -1073,6 +1093,10 @@ extension Fieldset: GlobalAttributes, DisabledAttribute, FormAttribute, NameAttr
 
     public func itemScope(_ value: String) -> Fieldset {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Fieldset {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Fieldset {

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -86,6 +86,10 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Input {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Input {
         return mutate(lang: type.rawValue)
     }
@@ -174,8 +178,12 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
         return mutate(multiple: "multiple")
     }
     
-    public func name(_ type: NameType) -> Input {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Input {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Input {
+        return mutate(name: value.rawValue)
     }
     
     public func pattern(_ regex: String) -> Input {
@@ -184,6 +192,10 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
     
     public func placeholder(_ value: String) -> Input {
         return mutate(placeholder: value)
+    }
+    
+    public func placeholder(_ value: TemplateValue<String>) -> Input {
+        return mutate(placeholder: value.rawValue)
     }
     
     public func readonly() -> Input {
@@ -206,12 +218,16 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
         return mutate(step: size)
     }
     
-    public func type(_ value: String) -> Input {
-        return mutate(type: value)
+    public func type(_ value: Inputs) -> Input {
+        return mutate(type: value.rawValue)
     }
     
     public func value(_ value: String) -> Input {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Input {
+        return mutate(value: value.rawValue)
     }
     
     public func width(_ size: Int) -> Input {
@@ -327,6 +343,10 @@ extension Label: GlobalAttributes, ForAttribute {
 
     public func id(_ value: String) -> Label {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Label {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Label {
@@ -486,6 +506,10 @@ extension Select: GlobalAttributes, AutocompleteAttribute, DisabledAttribute, Fo
     public func id(_ value: String) -> Select {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Select {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Select {
         return mutate(lang: type.rawValue)
@@ -535,8 +559,12 @@ extension Select: GlobalAttributes, AutocompleteAttribute, DisabledAttribute, Fo
         return mutate(multiple: "multiple")
     }
     
-    public func name(_ type: NameType) -> Select {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Select {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Select {
+        return mutate(name: value.rawValue)
     }
     
     public func required() -> Select {
@@ -657,6 +685,10 @@ extension TextArea: GlobalAttributes, AutocompleteAttribute, ColumnsAttribute, D
     public func id(_ value: String) -> TextArea {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> TextArea {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> TextArea {
         return mutate(lang: type.rawValue)
@@ -714,12 +746,20 @@ extension TextArea: GlobalAttributes, AutocompleteAttribute, ColumnsAttribute, D
         return mutate(minlength: value)
     }
     
-    public func name(_ type: NameType) -> TextArea {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> TextArea {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> TextArea {
+        return mutate(name: value.rawValue)
     }
     
     public func placeholder(_ value: String) -> TextArea {
         return mutate(placeholder: value)
+    }
+    
+    public func placeholder(_ value: TemplateValue<String>) -> TextArea {
+        return mutate(placeholder: value.rawValue)
     }
     
     public func readonly() -> TextArea {
@@ -849,6 +889,10 @@ extension Button: GlobalAttributes, DisabledAttribute, FormAttribute, FormAction
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> Button {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Button {
         return mutate(lang: type.rawValue)
     }
@@ -893,16 +937,24 @@ extension Button: GlobalAttributes, DisabledAttribute, FormAttribute, FormAction
         return mutate(formaction: value)
     }
     
-    public func name(_ type: NameType) -> Button {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Button {
+        return mutate(name: value)
     }
     
-    public func type(_ value: String) -> Button {
-        return mutate(type: value)
+    public func name(_ value: TemplateValue<String>) -> Button {
+        return mutate(name: value.rawValue)
+    }
+    
+    public func type(_ value: Buttons) -> Button {
+        return mutate(type: value.rawValue)
     }
     
     public func value(_ value: String) -> Button {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Button {
+        return mutate(value: value.rawValue)
     }
 }
 
@@ -1026,6 +1078,10 @@ extension Fieldset: GlobalAttributes, DisabledAttribute, FormAttribute, NameAttr
     public func id(_ value: String) -> Fieldset {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Fieldset {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Fieldset {
         return mutate(lang: type.rawValue)
@@ -1067,8 +1123,12 @@ extension Fieldset: GlobalAttributes, DisabledAttribute, FormAttribute, NameAttr
         return mutate(form: value)
     }
     
-    public func name(_ type: NameType) -> Fieldset {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Fieldset {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Fieldset {
+        return mutate(name: value.rawValue)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -230,6 +230,18 @@ extension Input: AnyContent {
     }
 }
 
+extension Input: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -354,6 +366,17 @@ extension Label: GlobalAttributes, ForAttribute {
     }
 }
 
+extension Label: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Label: Localizable {
     
     public init(_ localizedKey: String) {
@@ -365,14 +388,15 @@ extension Label: Localizable {
     }
 }
 
-extension Label: AnyContent {
+extension Label: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -532,6 +556,18 @@ extension Select: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Select: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -714,6 +750,18 @@ extension TextArea: AnyContent {
     }
 }
 
+extension TextArea: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -858,6 +906,17 @@ extension Button: GlobalAttributes, DisabledAttribute, FormAttribute, FormAction
     }
 }
 
+extension Button: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension Button: Localizable {
     
     public init(_ localizedKey: String) {
@@ -869,14 +928,15 @@ extension Button: Localizable {
     }
 }
 
-extension Button: AnyContent {
+extension Button: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1020,5 +1080,17 @@ extension Fieldset: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Fieldset: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -83,6 +83,10 @@ extension Title: GlobalAttributes {
         return mutate(itemscope: value)
     }
     
+    public func itemType(_ value: String) -> Title {
+        return mutate(itemtype: value)
+    }
+    
     public func id(_ value: String) -> Title {
         return mutate(id: value)
     }
@@ -223,6 +227,10 @@ extension Base: GlobalAttributes, ReferenceAttribute, TargetAttribute {
     
     public func itemScope(_ value: String) -> Base {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Base {
+        return mutate(itemtype: value)
     }
     
     public func id(_ value: String) -> Base {
@@ -377,6 +385,10 @@ extension Meta: GlobalAttributes, ContentAttribute, NameAttribute, PropertyAttri
 
     public func itemScope(_ value: String) -> Meta {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Meta {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Meta {
@@ -548,6 +560,10 @@ extension Style: GlobalAttributes, TypeAttribute, MediaAttribute, LoadEventAttri
 
     public func itemScope(_ value: String) -> Style {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Style {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Style {

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -131,6 +131,18 @@ extension Title: AnyContent {
     }
 }
 
+extension Title: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -262,6 +274,18 @@ extension Base: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Base: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -400,6 +424,18 @@ extension Meta: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Meta: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -543,5 +579,17 @@ extension Style: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Style: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -87,6 +87,10 @@ extension Title: GlobalAttributes {
         return mutate(id: value)
     }
     
+    public func id(_ value: TemplateValue<String>) -> Title {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Title {
         return mutate(lang: type.rawValue)
     }
@@ -225,6 +229,10 @@ extension Base: GlobalAttributes, ReferenceAttribute, TargetAttribute {
         return mutate(id: value)
     }
     
+    public func id(_ value: TemplateValue<String>) -> Base {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Base {
         return mutate(lang: type.rawValue)
     }
@@ -259,6 +267,10 @@ extension Base: GlobalAttributes, ReferenceAttribute, TargetAttribute {
     
     public func reference(_ value: String) -> Base {
         return mutate(href: value)
+    }
+    
+    public func reference(_ value: TemplateValue<String>) -> Base {
+        return mutate(href: value.rawValue)
     }
     
     public func target(_ type: Target) -> Base {
@@ -370,6 +382,10 @@ extension Meta: GlobalAttributes, ContentAttribute, NameAttribute, PropertyAttri
     public func id(_ value: String) -> Meta {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Meta {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Meta {
         return mutate(lang: type.rawValue)
@@ -407,8 +423,16 @@ extension Meta: GlobalAttributes, ContentAttribute, NameAttribute, PropertyAttri
         return mutate(content: value)
     }
     
-    public func name(_ type: NameType) -> Meta {
-        return mutate(name: type.rawValue)
+    public func content(_ value: TemplateValue<String>) -> Meta {
+        return mutate(content: value.rawValue)
+    }
+    
+    public func name(_ value: NameType) -> Meta {
+        return mutate(name: value.rawValue)
+    }
+    
+    public func name(_ value: TemplateValue<NameType>) -> Meta {
+        return mutate(name: value.rawValue)
     }
     
     public func property(_ type: Graphs) -> Meta {
@@ -529,6 +553,10 @@ extension Style: GlobalAttributes, TypeAttribute, MediaAttribute, LoadEventAttri
     public func id(_ value: String) -> Style {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Style {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Style {
         return mutate(lang: type.rawValue)
@@ -562,8 +590,8 @@ extension Style: GlobalAttributes, TypeAttribute, MediaAttribute, LoadEventAttri
         return mutate(translate: value)
     }
 
-    public func type(_ value: String) -> Style {
-        return mutate(type: value)
+    public func type(_ value: MediaType) -> Style {
+        return mutate(type: value.rawValue)
     }
     
     public func media(_ value: String) -> Style {

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -1,7 +1,23 @@
+/// # Description:
+/// The file contains the figure elements. The html element Head only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element represents the document's title.
 ///
+/// There must be no more than one title element per document.
+///
+/// # References:
+/// https://html.spec.whatwg.org/#the-title-element
 ///
 public struct Title: ContentNode, HeadElement {
 
@@ -151,8 +167,14 @@ extension Title: Modifiable {
     }
 }
 
-/// The element
+
+/// # Description:
+/// The element specifies the document base url.
 ///
+/// There must be no more than one base element per document.
+///
+/// # References:
+/// https://html.spec.whatwg.org/#the-base-element
 ///
 public struct Base: EmptyNode, HeadElement {
 
@@ -309,8 +331,12 @@ extension Base: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element provides meta information about the document.
 ///
+///
+/// # References:
+/// https://html.spec.whatwg.org/#the-meta-element
 ///
 public struct Meta: EmptyNode, HeadElement {
 
@@ -475,8 +501,12 @@ extension Meta: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element contains style information for the document.
 ///
+///
+/// # References:
+/// https://html.spec.whatwg.org/#the-style-element
 ///
 public struct Style: ContentNode, HeadElement {
 

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -131,6 +131,18 @@ extension Head: AnyContent {
     }
 }
 
+extension Head: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -295,5 +307,17 @@ extension Body: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Body: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -1,7 +1,21 @@
+/// # Description:
+/// The file contains the html elements. The html element Html only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element contains the information about the document's content.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-head-element
 ///
 public struct Head: ContentNode, HtmlElement {
 
@@ -151,8 +165,11 @@ extension Head: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element contains the document's content.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-body-element
 ///
 public struct Body: ContentNode, HtmlElement {
 

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -83,6 +83,10 @@ extension Head: GlobalAttributes {
         return mutate(itemscope: value)
     }
     
+    public func itemType(_ value: String) -> Head {
+        return mutate(itemtype: value)
+    }
+    
     public func id(_ value: String) -> Head {
         return mutate(id: value)
     }
@@ -264,6 +268,10 @@ extension Body: GlobalAttributes, AfterPrintEventAttribute, BeforePrintEventAttr
 
     public func itemScope(_ value: String) -> Body {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Body {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Body {

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -87,6 +87,10 @@ extension Head: GlobalAttributes {
         return mutate(id: value)
     }
     
+    public func id(_ value: TemplateValue<String>) -> Head {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> Head {
         return mutate(lang: type.rawValue)
     }
@@ -264,6 +268,10 @@ extension Body: GlobalAttributes, AfterPrintEventAttribute, BeforePrintEventAttr
 
     public func id(_ value: String) -> Body {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Body {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Body {

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -144,6 +144,18 @@ extension OptionGroup: AnyContent {
     }
 }
 
+extension OptionGroup: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -287,6 +299,18 @@ extension Option: AnyContent {
     }
 }
 
+extension Option: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -418,6 +442,18 @@ extension Legend: AnyContent {
     }
 }
 
+extension Legend: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -546,5 +582,17 @@ extension Summary: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Summary: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -87,6 +87,10 @@ extension OptionGroup: GlobalAttributes, DisabledAttribute, LabelAttribute {
     public func itemScope(_ value: String) -> OptionGroup {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> OptionGroup {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> OptionGroup {
         return mutate(id: value)
@@ -241,6 +245,10 @@ extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttr
 
     public func itemScope(_ value: String) -> Option {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Option {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Option {
@@ -405,6 +413,10 @@ extension Legend: GlobalAttributes {
     public func itemScope(_ value: String) -> Legend {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Legend {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Legend {
         return mutate(id: value)
@@ -551,6 +563,10 @@ extension Summary: GlobalAttributes {
 
     public func itemScope(_ value: String) -> Summary {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> Summary {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> Summary {

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -1,12 +1,26 @@
+/// # Description:
+/// The file contains the input elements. The html element Input only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to OptionGroup.
 ///
 public typealias Optgroup = OptionGroup
 
-/// The element
+/// # Description:
+/// The element represents a group of options.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-optgroup-element
 ///
 public struct OptionGroup: ContentNode, InputElement {
 
@@ -164,8 +178,11 @@ extension OptionGroup: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents an option.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-option-element
 ///
 public struct Option: ContentNode, InputElement {
 
@@ -331,8 +348,11 @@ extension Option: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a caption for the rest of the contents of a fieldset.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-legend-element
 ///
 public struct Legend: ContentNode, InputElement {
 
@@ -482,8 +502,11 @@ extension Legend: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a summary, caption, or legend for the rest of the content.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-summary-element
 ///
 public struct Summary: ContentNode, InputElement {
 

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -91,6 +91,10 @@ extension OptionGroup: GlobalAttributes, DisabledAttribute, LabelAttribute {
     public func id(_ value: String) -> OptionGroup {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> OptionGroup {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> OptionGroup {
         return mutate(lang: type.rawValue)
@@ -242,6 +246,10 @@ extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttr
     public func id(_ value: String) -> Option {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Option {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Option {
         return mutate(lang: type.rawValue)
@@ -285,6 +293,10 @@ extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttr
     
     public func value(_ value: String) -> Option {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Option {
+        return mutate(value: value.rawValue)
     }
 }
 
@@ -396,6 +408,10 @@ extension Legend: GlobalAttributes {
 
     public func id(_ value: String) -> Legend {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Legend {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Legend {
@@ -539,6 +555,10 @@ extension Summary: GlobalAttributes {
 
     public func id(_ value: String) -> Summary {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Summary {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Summary {

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -87,6 +87,10 @@ extension ListItem: GlobalAttributes, ValueAttribute {
     public func itemScope(_ value: String) -> ListItem {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> ListItem {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> ListItem {
         return mutate(id: value)

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -139,3 +139,15 @@ extension ListItem: AnyContent {
         try self.build(with: manager)
     }
 }
+
+extension ListItem: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -1,12 +1,26 @@
+/// # Description:
+/// The file contains the list elements. The html elements OrderedList or UnorderedList only
+/// allows these elements to be its descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to ListItem.
 ///
 public typealias Li = ListItem
 
-/// The element
+/// # Description:
+/// The element represents a item of a list.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-li-element
 ///
 public struct ListItem: ContentNode, ListElement {
 

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -91,6 +91,10 @@ extension ListItem: GlobalAttributes, ValueAttribute {
     public func id(_ value: String) -> ListItem {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> ListItem {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> ListItem {
         return mutate(lang: type.rawValue)
@@ -126,6 +130,10 @@ extension ListItem: GlobalAttributes, ValueAttribute {
     
     public func value(_ value: String) -> ListItem {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> ListItem {
+        return mutate(value: value.rawValue)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -1,7 +1,21 @@
+/// # Description:
+/// The file contains the map elements. The html element Map only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element defines an image map.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-area-element
 ///
 public struct Area: ContentNode, MapElement {
 

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -86,6 +86,10 @@ extension Area: GlobalAttributes, AlternateAttribute, CoordinatesAttribute, Shap
     public func id(_ value: String) -> Area {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Area {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Area {
         return mutate(lang: type.rawValue)
@@ -133,6 +137,10 @@ extension Area: GlobalAttributes, AlternateAttribute, CoordinatesAttribute, Shap
     
     public func reference(_ value: String) -> Area {
         return mutate(href: value)
+    }
+    
+    public func reference(_ value: TemplateValue<String>) -> Area {
+        return mutate(href: value.rawValue)
     }
     
     public func target(_ type: Target) -> Area {

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -82,6 +82,10 @@ extension Area: GlobalAttributes, AlternateAttribute, CoordinatesAttribute, Shap
     public func itemScope(_ value: String) -> Area {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Area {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Area {
         return mutate(id: value)

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -166,3 +166,15 @@ extension Area: AnyContent {
         try self.build(with: manager)
     }
 }
+
+extension Area: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -81,6 +81,10 @@ extension Source: GlobalAttributes, TypeAttribute, SourceAttribute, SizesAttribu
     public func id(_ value: String) -> Source {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Source {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Source {
         return mutate(lang: type.rawValue)
@@ -114,8 +118,8 @@ extension Source: GlobalAttributes, TypeAttribute, SourceAttribute, SizesAttribu
         return mutate(translate: value)
     }
 
-    public func type(_ value: String) -> Source {
-        return mutate(type: value)
+    public func type(_ value: MediaType) -> Source {
+        return mutate(type: value.rawValue)
     }
     
     public func source(_ value: String) -> Source {
@@ -242,6 +246,10 @@ extension Track: GlobalAttributes, KindAttribute, SourceAttribute, LabelAttribut
 
     public func id(_ value: String) -> Track {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Track {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Track {

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -1,7 +1,21 @@
+/// # Description:
+/// The file contains the media elements. The html elements Audio or Video only allows these elements
+/// to be its descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element allows authors to specify multiple alternative source for other elements.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-source-element
 ///
 public struct Source: EmptyNode, MediaElement {
 
@@ -170,8 +184,11 @@ extension Source: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element allows to specify explicit external timed text tracks for media elements.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-track-element
 ///
 public struct Track: EmptyNode, MediaElement {
 

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -78,6 +78,10 @@ extension Source: GlobalAttributes, TypeAttribute, SourceAttribute, SizesAttribu
         return mutate(itemscope: value)
     }
 
+    public func itemType(_ value: String) -> Source {
+        return mutate(itemtype: value)
+    }
+    
     public func id(_ value: String) -> Source {
         return mutate(id: value)
     }
@@ -238,6 +242,10 @@ extension Track: GlobalAttributes, KindAttribute, SourceAttribute, LabelAttribut
 
     public func itemReference(_ value: String) -> Track {
         return mutate(itemref: value)
+    }
+    
+    public func itemType(_ value: String) -> Track {
+        return mutate(itemtype: value)
     }
 
     public func itemScope(_ value: String) -> Track {

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -150,6 +150,18 @@ extension Source: AnyContent {
     }
 }
 
+extension Source: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -289,5 +301,17 @@ extension Track: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Track: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -77,6 +77,10 @@ extension Parameter: GlobalAttributes, NameAttribute, ValueAttribute {
     public func itemScope(_ value: String) -> Parameter {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Parameter {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Parameter {
         return mutate(id: value)

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -1,7 +1,21 @@
+/// # Description:
+/// The file contains the object elements. The html element Object only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The element
+/// # Description:
+/// The element defines parameters for plugins invoked by an object element.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-param-element
 ///
 public struct Parameter: EmptyNode, ObjectElement {
     

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -81,6 +81,10 @@ extension Parameter: GlobalAttributes, NameAttribute, ValueAttribute {
     public func id(_ value: String) -> Parameter {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Parameter {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Parameter {
         return mutate(lang: type.rawValue)
@@ -114,12 +118,20 @@ extension Parameter: GlobalAttributes, NameAttribute, ValueAttribute {
         return mutate(translate: value)
     }
 
-    public func name(_ type: NameType) -> Parameter {
-        return mutate(name: type.rawValue)
+    public func name(_ value: String) -> Parameter {
+        return mutate(name: value)
+    }
+    
+    public func name(_ value: TemplateValue<String>) -> Parameter {
+        return mutate(name: value.rawValue)
     }
     
     public func value(_ value: String) -> Parameter {
         return mutate(value: value)
+    }
+    
+    public func value(_ value: TemplateValue<String>) -> Parameter {
+        return mutate(value: value.rawValue)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -133,3 +133,15 @@ extension Parameter: AnyContent {
         try self.build(with: manager)
     }
 }
+
+extension Parameter: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -1,17 +1,31 @@
+/// # Description:
+/// The file contains the ruby elements. The html element Ruby only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to RubyText.
 ///
 public typealias Rt = RubyText
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to RubyPronunciation.
 ///
 public typealias Rp = RubyPronunciation
 
-/// The element
+/// # Description:
+/// The element marks the ruby text component of a ruby annotation.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-rt-element
 ///
 public struct RubyText: ContentNode, RubyElement {
 
@@ -161,8 +175,11 @@ extension RubyText: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents nothing.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-rp-element
 ///
 public struct RubyPronunciation: ContentNode, RubyElement {
 

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -92,6 +92,10 @@ extension RubyText: GlobalAttributes {
     public func itemScope(_ value: String) -> RubyText {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> RubyText {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> RubyText {
         return mutate(id: value)
@@ -238,6 +242,10 @@ extension RubyPronunciation: GlobalAttributes {
 
     public func itemScope(_ value: String) -> RubyPronunciation {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> RubyPronunciation {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> RubyPronunciation {

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -141,6 +141,18 @@ extension RubyText: AnyContent {
     }
 }
 
+extension RubyText: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -269,5 +281,17 @@ extension RubyPronunciation: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension RubyPronunciation: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -96,6 +96,10 @@ extension RubyText: GlobalAttributes {
     public func id(_ value: String) -> RubyText {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> RubyText {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> RubyText {
         return mutate(lang: type.rawValue)
@@ -238,6 +242,10 @@ extension RubyPronunciation: GlobalAttributes {
 
     public func id(_ value: String) -> RubyPronunciation {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> RubyPronunciation {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> RubyPronunciation {

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -126,6 +126,10 @@ extension Caption: GlobalAttributes {
     public func id(_ value: String) -> Caption {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> Caption {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> Caption {
         return mutate(lang: type.rawValue)
@@ -268,6 +272,10 @@ extension ColumnGroup: GlobalAttributes, SpanAttribute {
 
     public func id(_ value: String) -> ColumnGroup {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> ColumnGroup {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> ColumnGroup {
@@ -415,6 +423,10 @@ extension Column: GlobalAttributes, SpanAttribute {
 
     public func id(_ value: String) -> Column {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> Column {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> Column {
@@ -564,6 +576,10 @@ extension TableBody: GlobalAttributes, WidthAttribute, HeightAttribute {
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> TableBody {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> TableBody {
         return mutate(lang: type.rawValue)
     }
@@ -713,6 +729,10 @@ extension TableHead: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func id(_ value: String) -> TableHead {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> TableHead {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> TableHead {
@@ -865,6 +885,10 @@ extension TableFoot: GlobalAttributes {
     public func id(_ value: String) -> TableFoot {
         return mutate(id: value)
     }
+    
+    public func id(_ value: TemplateValue<String>) -> TableFoot {
+        return mutate(id: value.rawValue)
+    }
 
     public func language(_ type: Language) -> TableFoot {
         return mutate(lang: type.rawValue)
@@ -1007,6 +1031,10 @@ extension TableRow: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func id(_ value: String) -> TableRow {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> TableRow {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> TableRow {
@@ -1158,6 +1186,10 @@ extension DataCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, Hea
 
     public func id(_ value: String) -> DataCell {
         return mutate(id: value)
+    }
+    
+    public func id(_ value: TemplateValue<String>) -> DataCell {
+        return mutate(id: value.rawValue)
     }
 
     public func language(_ type: Language) -> DataCell {
@@ -1315,6 +1347,10 @@ extension HeaderCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, H
         return mutate(id: value)
     }
 
+    public func id(_ value: TemplateValue<String>) -> HeaderCell {
+        return mutate(id: value.rawValue)
+    }
+    
     public func language(_ type: Language) -> HeaderCell {
         return mutate(lang: type.rawValue)
     }

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -158,7 +158,6 @@ extension Caption: GlobalAttributes {
     public func translate(_ value: String) -> Caption {
         return mutate(translate: value)
     }
-
 }
 
 extension Caption: AnyContent {
@@ -169,6 +168,18 @@ extension Caption: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Caption: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -307,6 +318,18 @@ extension ColumnGroup: AnyContent {
     }
 }
 
+extension ColumnGroup: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -439,6 +462,18 @@ extension Column: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension Column: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -581,6 +616,18 @@ extension TableBody: AnyContent {
     }
 }
 
+extension TableBody: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -720,6 +767,18 @@ extension TableHead: AnyContent {
     }
 }
 
+extension TableHead: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -848,6 +907,18 @@ extension TableFoot: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension TableFoot: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -987,6 +1058,18 @@ extension TableRow: AnyContent {
     
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         try self.build(with: manager)
+    }
+}
+
+extension TableRow: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }
 
@@ -1133,6 +1216,18 @@ extension DataCell: AnyContent {
     }
 }
 
+extension DataCell: Modifiable {
+    
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
+    }
+}
+
 /// The element
 ///
 ///
@@ -1269,6 +1364,17 @@ extension HeaderCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, H
     }
 }
 
+extension HeaderCell: AnyContent {
+    
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+    
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
 extension HeaderCell: Localizable {
     
     public init(_ localizedKey: String) {
@@ -1280,13 +1386,14 @@ extension HeaderCell: Localizable {
     }
 }
 
-extension HeaderCell: AnyContent {
+extension HeaderCell: Modifiable {
     
-    public func prerender(_ formula: Renderer.Formula) throws {
-        try self.build(formula)
-    }
-    
-    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
-        try self.build(with: manager)
+    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
+        
+        if condition {
+            return modify(element(self))
+        }
+        
+        return self
     }
 }

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -1,47 +1,61 @@
+/// # Description:
+/// The file contains the table elements. The html element Table only allows these elements to be its
+/// descendants.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to ColumnGroup.
 ///
 public typealias Colgroup = ColumnGroup
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to Column.
 ///
 public typealias Col = Column
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to TableBody.
 ///
 public typealias Tbody = TableBody
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to TableHead.
 ///
 public typealias Thead = TableHead
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to TableFoot.
 ///
 public typealias Tfoot = TableFoot
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to TableRow.
 ///
 public typealias Tr = TableRow
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to DataCell.
 ///
 public typealias Td = DataCell
 
-/// The alias points
-///
+/// # Description:
+/// The alias points to HeaderCell.
 ///
 public typealias Th = HeaderCell
 
-/// The element
+/// # Description:
+/// The element represents the title of the table.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-caption-element
 ///
 public struct Caption: ContentNode, TableElement {
 
@@ -191,8 +205,11 @@ extension Caption: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element specifies a group of one or more columns.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-colgroup-element
 ///
 public struct ColumnGroup: ContentNode, TableElement {
 
@@ -346,8 +363,11 @@ extension ColumnGroup: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a column in a table.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-col-element
 ///
 public struct Column: ContentNode, TableElement {
 
@@ -501,8 +521,11 @@ extension Column: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a block of rows in a table.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-tbody-element
 ///
 public struct TableBody: ContentNode, TableElement {
 
@@ -660,8 +683,11 @@ extension TableBody: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the block of rows that consist of the column labels.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-thead-element
 ///
 public struct TableHead: ContentNode, TableElement {
 
@@ -819,8 +845,11 @@ extension TableHead: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents the block of rows that consist of the column summaries.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-tfoot-element
 ///
 public struct TableFoot: ContentNode, TableElement {
 
@@ -970,8 +999,11 @@ extension TableFoot: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a row of cells in a table.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-tr-element
 ///
 public struct TableRow: ContentNode, TableElement {
 
@@ -1129,8 +1161,11 @@ extension TableRow: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a data cell in a table.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-td-element
 ///
 public struct DataCell: ContentNode, TableElement {
 
@@ -1292,8 +1327,11 @@ extension DataCell: Modifiable {
     }
 }
 
-/// The element
+/// # Description:
+/// The element represents a header cell in a table.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#the-th-element
 ///
 public struct HeaderCell: ContentNode, TableElement {
 

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -122,6 +122,10 @@ extension Caption: GlobalAttributes {
     public func itemScope(_ value: String) -> Caption {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Caption {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Caption {
         return mutate(id: value)
@@ -268,6 +272,10 @@ extension ColumnGroup: GlobalAttributes, SpanAttribute {
 
     public func itemScope(_ value: String) -> ColumnGroup {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> ColumnGroup {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> ColumnGroup {
@@ -420,6 +428,10 @@ extension Column: GlobalAttributes, SpanAttribute {
     public func itemScope(_ value: String) -> Column {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> Column {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> Column {
         return mutate(id: value)
@@ -570,6 +582,10 @@ extension TableBody: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func itemScope(_ value: String) -> TableBody {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> TableBody {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> TableBody {
@@ -726,6 +742,10 @@ extension TableHead: GlobalAttributes, WidthAttribute, HeightAttribute {
     public func itemScope(_ value: String) -> TableHead {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> TableHead {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> TableHead {
         return mutate(id: value)
@@ -881,6 +901,10 @@ extension TableFoot: GlobalAttributes {
     public func itemScope(_ value: String) -> TableFoot {
         return mutate(itemscope: value)
     }
+    
+    public func itemType(_ value: String) -> TableFoot {
+        return mutate(itemtype: value)
+    }
 
     public func id(_ value: String) -> TableFoot {
         return mutate(id: value)
@@ -1027,6 +1051,10 @@ extension TableRow: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func itemScope(_ value: String) -> TableRow {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> TableRow {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> TableRow {
@@ -1182,6 +1210,10 @@ extension DataCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, Hea
 
     public func itemScope(_ value: String) -> DataCell {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> DataCell {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> DataCell {
@@ -1341,6 +1373,10 @@ extension HeaderCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, H
 
     public func itemScope(_ value: String) -> HeaderCell {
         return mutate(itemscope: value)
+    }
+    
+    public func itemType(_ value: String) -> HeaderCell {
+        return mutate(itemtype: value)
     }
 
     public func id(_ value: String) -> HeaderCell {

--- a/Sources/HTMLKit/External/Functions.swift
+++ b/Sources/HTMLKit/External/Functions.swift
@@ -1,5 +1,17 @@
+/// # Description:
+/// The file contains basic functions.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
 /// The function is for
 ///
+/// # References:
 ///
 public struct Unwrap: Component {
 

--- a/Sources/HTMLKit/External/Layouts.swift
+++ b/Sources/HTMLKit/External/Layouts.swift
@@ -1,5 +1,17 @@
-/// The protocol defines
+/// # Description:
+/// The file contains layout components.
 ///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
+/// The protocol is for
+///
+/// # References:
 ///
 public protocol Page: AnyContent {
     
@@ -19,8 +31,10 @@ extension Page {
     public var scripts: AnyContent { body.scripts }
 }
 
-/// The protocol defines
+/// # Description:
+/// The protocol is for
 ///
+/// # References:
 ///
 public protocol View: AnyContent {
     
@@ -46,8 +60,10 @@ extension View {
     public var scripts: AnyContent { body.scripts }
 }
 
-/// The protocol defines
+/// # Description:
+/// The protocol is for
 ///
+/// # References:
 ///
 public protocol Component: AnyContent {
     

--- a/Sources/HTMLKit/External/Statements.swift
+++ b/Sources/HTMLKit/External/Statements.swift
@@ -1,32 +1,32 @@
-/// A struct making it possible to have a if in the template
+/// # Description:
+/// The file contains basic statements.
 ///
-///     runtimeIf(\.name == "Name", view: ...)
-public struct IF {
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
 
-    /// One condition in the if
+/// # Description:
+/// The statement is for
+///
+/// # References:
+///
+public struct IF {
+    
     public class Condition {
 
-        /// The condition to evaluate
         let condition: Conditionable
-
-        /// The local formula for optimazation
         var localFormula: Renderer.Formula
-
-        /// The view to render.
-        /// Set to an empty string in order to create a condition on `\.name == ""`
-        /// This should probably be re designed a little
         var view: AnyContent = ""
-
-        /// Creates an if condition
-        ///
-        /// - Parameter condition: The condition to evaluate
+        
         init(condition: Conditionable) {
             self.condition = condition
             localFormula = Renderer.Formula()
         }
     }
 
-    /// The different conditions that can happen
     let conditions: [Condition]
 
     public init(_ condition: Conditionable, @ContentBuilder<AnyContent> content: () -> AnyContent) {
@@ -42,17 +42,14 @@ public struct IF {
 
 extension IF.Condition: Conditionable {
 
-    // View `Conditionable` documentation
     public func evaluate<T>(with manager: Renderer.ContextManager<T>) throws -> Bool {
         return try condition.evaluate(with: manager)
     }
 
-    // View `CompiledTemplate` documentation
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         return try localFormula.render(with: manager)
     }
-
-    // View `BrewableFormula` documentation
+    
     public func prerender(_ formula: Renderer.Formula) throws {
         try view.prerender(localFormula)
     }
@@ -74,8 +71,7 @@ extension IF: AnyContent {
             return scriptCondition
         })
     }
-
-    // View `CompiledTemplate` documentation
+    
     public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
         for condition in conditions {
             if try condition.evaluate(with: manager) {
@@ -85,7 +81,6 @@ extension IF: AnyContent {
         return ""
     }
 
-    // View `BrewableFormula` documentation
     public func prerender(_ formula: Renderer.Formula) throws {
         var isStaticallyEvaluated = true
         for condition in conditions {
@@ -159,8 +154,10 @@ extension IF: AnyContent {
     }
 }
 
-/// A struct making it possible to have a for each loop in the template
+/// # Description:
+/// The statement is for
 ///
+/// # References:
 ///
 public struct ForEach<Values> where Values: Sequence {
 

--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -1,7 +1,17 @@
-// MARK: types
+/// # Description:
+/// The file contains html types.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public struct NameType: RawRepresentable {
     
@@ -22,8 +32,10 @@ extension NameType {
     static let applicationName = NameType(rawValue: "application-name")!
 }
 
-/// The enum is for
+/// # Description:
+/// The type is for
 ///
+/// # References:
 ///
 public enum Buttons: String {
 
@@ -32,8 +44,10 @@ public enum Buttons: String {
     case reset
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Encoding: String {
     
@@ -42,8 +56,10 @@ public enum Encoding: String {
     case plainText = "text/plain"
 }
 
-/// The enum is for
+/// # Description:
+/// The type is for
 ///
+/// # References:
 ///
 public enum Method: String {
     
@@ -51,8 +67,10 @@ public enum Method: String {
     case get
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Inputs: String {
     
@@ -80,8 +98,10 @@ public enum Inputs: String {
     case phone = "tel"
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Language: String {
     
@@ -271,8 +291,10 @@ public enum Language: String {
     case zulu = "zu"
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Policy: String {
     
@@ -286,8 +308,10 @@ public enum Policy: String {
     case unsafeUrl = "unsafe-url"
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Relation: String {
     
@@ -314,8 +338,10 @@ public enum Relation: String {
     case shortcutIcon = "shortcut icon"
 }
 
-/// The enum is for
+/// # Description:
+/// The type is for
 ///
+/// # References:
 ///
 public enum Target: String {
     
@@ -336,8 +362,10 @@ public enum Shape: String {
     case rectangle = "rect"
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Wrapping: String {
     
@@ -345,8 +373,10 @@ public enum Wrapping: String {
     case hard
 }
 
-/// The enum is for
+/// # Description:
+/// The type is for
 ///
+/// # References:
 ///
 public enum Direction: String {
     
@@ -355,8 +385,10 @@ public enum Direction: String {
     case auto
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public struct MediaType: RawRepresentable {
     
@@ -378,8 +410,10 @@ extension MediaType {
     static let javascript = MediaType(rawValue: "application/javascript")!
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Marker: String {
     
@@ -390,8 +424,10 @@ public enum Marker: String {
     case lowercaseRoman = "i"
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum DocumentType: String {
         
@@ -405,8 +441,10 @@ public enum DocumentType: String {
     case xhtml = #"html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd""#
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Graphs: String {
 
@@ -419,8 +457,10 @@ public enum Graphs: String {
     case siteName = "og:site_name"
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Hint: String {
     
@@ -433,8 +473,10 @@ public enum Hint: String {
     case send
 }
 
+/// # Description:
 /// The type is for
 ///
+/// # References:
 ///
 public enum Capitalization: String {
     

--- a/Sources/HTMLKit/Internal/Core/Anys/AnyAttribute.swift
+++ b/Sources/HTMLKit/Internal/Core/Anys/AnyAttribute.swift
@@ -1,7 +1,19 @@
+/// # Description:
+/// The file contains the attribute definition.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a html attribute.
 ///
+/// # References:
 ///
 public protocol AnyAttribute {
 }

--- a/Sources/HTMLKit/Internal/Core/Anys/AnyContent.swift
+++ b/Sources/HTMLKit/Internal/Core/Anys/AnyContent.swift
@@ -1,7 +1,19 @@
+/// # Description:
+/// The file contains the content definition.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import Foundation
 
-/// The protocol defines
+/// # Description:
+/// The protocol defines a html content.
 ///
+/// # References:
 ///
 public protocol AnyContent {
 

--- a/Sources/HTMLKit/Internal/Core/Anys/AnyElement.swift
+++ b/Sources/HTMLKit/Internal/Core/Anys/AnyElement.swift
@@ -1,5 +1,17 @@
-/// The protocol is for
+/// # Description:
+/// The file contains the element definition.
 ///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
+/// The protocol defines a html element.
+///
+/// # References:
 ///
 public protocol AnyElement: AnyContent {
 }

--- a/Sources/HTMLKit/Internal/Core/Anys/AnyNode.swift
+++ b/Sources/HTMLKit/Internal/Core/Anys/AnyNode.swift
@@ -1,5 +1,17 @@
-/// The protocol is for
+/// # Description:
+/// The file contains the node definition.
 ///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
+/// The protocol defines a html node.
+///
+/// # References:
 ///
 public protocol AnyNode {
 }

--- a/Sources/HTMLKit/Internal/Core/Builders/ContentBuilder.swift
+++ b/Sources/HTMLKit/Internal/Core/Builders/ContentBuilder.swift
@@ -1,5 +1,17 @@
-/// The builder is for
+/// # Description:
+/// The file contains the basic attribute handlers.
 ///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
+/// The builder builds up a result value from a sequence of the content.
+///
+/// # References:
 ///
 @resultBuilder public class ContentBuilder<T> {
 

--- a/Sources/HTMLKit/Internal/Core/Elements.swift
+++ b/Sources/HTMLKit/Internal/Core/Elements.swift
@@ -1,83 +1,121 @@
-/// The protocol is for
+/// # Description:
+/// The file contains the element definitions.
 ///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+/// # Description:
+/// The protocol defines a body element.
+///
+/// # References:
 ///
 public protocol BodyElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a description element.
 ///
+/// # References:
 ///
 public protocol DescriptionElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a figure element.
 ///
+/// # References:
 ///
 public protocol FigureElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a form element.
 ///
+/// # References:
 ///
 public protocol FormElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a basic element.
 ///
+/// # References:
 ///
 public protocol BasicElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a head element.
 ///
+/// # References:
 ///
 public protocol HeadElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a input element.
 ///
+/// # References:
 ///
 public protocol InputElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a list element.
 ///
+/// # References:
 ///
 public protocol ListElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a map element.
 ///
+/// # References:
 ///
 public protocol MapElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a media element.
 ///
+/// # References:
 ///
 public protocol MediaElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a object element.
 ///
+/// # References:
 ///
 public protocol ObjectElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a ruby element.
 ///
+/// # References:
 ///
 public protocol RubyElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a table element.
 ///
+/// # References:
 ///
 public protocol TableElement: AnyElement {
 }
 
-/// The protocol is for
+/// # Description:
+/// The protocol defines a html element.
 ///
+/// # References:
 ///
 public protocol HtmlElement: AnyElement {
 }

--- a/Sources/HTMLKit/Internal/Core/Nodes.swift
+++ b/Sources/HTMLKit/Internal/Core/Nodes.swift
@@ -564,6 +564,19 @@ extension EmptyNode {
     }
 }
 
+extension EmptyNode where Self: Modifiable {
+    
+    internal func modify(_ element: Self) -> Self {
+        
+        guard var attributes = self.attributes else {
+
+            return .init(attributes: element.attributes!)
+        }
+        
+        return .init(attributes: merge(element.attributes!, with: &attributes))
+    }
+}
+
 /// The node is for
 ///
 ///

--- a/Sources/HTMLKit/Internal/Core/Nodes.swift
+++ b/Sources/HTMLKit/Internal/Core/Nodes.swift
@@ -1,7 +1,19 @@
+/// # Description:
+/// The file contains the node definitions.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
 import OrderedCollections
 
-/// The node is for
+/// # Description:
+/// The protocol defines a node with content.
 ///
+/// # References:
 ///
 internal protocol ContentNode: AnyNode {
 
@@ -519,8 +531,11 @@ extension ContentNode where Content == String {
     }
 }
 
-/// The node is for
+/// # Description:
+/// The protocol defines a node without content.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#void-elements
 ///
 internal protocol EmptyNode: AnyNode {
 
@@ -577,8 +592,11 @@ extension EmptyNode where Self: Modifiable {
     }
 }
 
-/// The node is for
+/// # Description:
+/// The protocol defines a node for comments.
 ///
+/// # References:
+/// https://html.spec.whatwg.org/#comments
 ///
 internal protocol CommentNode: AnyNode {
     
@@ -600,8 +618,10 @@ extension CommentNode {
     }
 }
 
-/// The node is for
+/// # Description:
+/// The protocol defines the document node.
 ///
+/// # References:
 ///
 internal protocol DocumentNode: AnyNode {
     

--- a/Sources/HTMLKit/Internal/Core/Nodes.swift
+++ b/Sources/HTMLKit/Internal/Core/Nodes.swift
@@ -20,9 +20,22 @@ extension ContentNode {
     
     internal func merge(_ new: OrderedDictionary<String, Any>, with current: inout OrderedDictionary<String, Any>) -> OrderedDictionary<String, Any> {
         
-        current.merge(new) { (current, _) in current }
+        current.merge(new) { (_, new) in new }
         
         return current
+    }
+}
+
+extension ContentNode where Self: Modifiable {
+    
+    internal func modify(_ element: Self) -> Self {
+        
+        guard var attributes = self.attributes else {
+
+            return .init(attributes: element.attributes!, content: self.content)
+        }
+        
+        return .init(attributes: merge(element.attributes!, with: &attributes), content: self.content)
     }
 }
 

--- a/Sources/HTMLKit/Internal/Core/Properties/Modifiable.swift
+++ b/Sources/HTMLKit/Internal/Core/Properties/Modifiable.swift
@@ -6,10 +6,5 @@ public protocol Modifiable {
     /// The func is for
     ///
     ///
-    func modify(if condition: Bool, modifyer: (Self) -> Self) -> Self
-    
-    /// The func is for
-    ///
-    ///
-    func modify<Value>(unwrap value: TemplateValue<Value?>, modifyer: (TemplateValue<Value>, Self) -> Self) -> Self
+    func modify(if condition: Bool, element: (Self) -> Self) -> Self
 }

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -186,6 +186,50 @@ final class RenderingTests: XCTestCase {
                        """
         )
     }
+    
+    func testModified() throws {
+        
+        let isModified: Bool = true
+        
+        let view = TestPage {
+            Division {
+            }
+            .class("unmodified")
+            .modify(if: isModified) {
+                $0.class("modified")
+            }
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <div class="modified"></div>
+                       """
+        )
+    }
+    
+    func testUnmodified() throws {
+        
+        let isModified: Bool = false
+        
+        let view = TestPage {
+            Division {
+            }
+            .class("unmodified")
+            .modify(if: isModified) {
+                $0.class("modified")
+            }
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <div class="unmodified"></div>
+                       """
+        )
+    }
 }
 
 extension RenderingTests {
@@ -199,6 +243,8 @@ extension RenderingTests {
         ("testRenderingAttributesWithUnterscore", testRenderingAttributesWithUnterscore),
         ("testRenderingAttributesWithHyphens", testRenderingAttributesWithHyphens),
         ("testNesting", testNesting),
-        ("testEscaping", testEscaping)
+        ("testEscaping", testEscaping),
+        ("testModified", testModified),
+        ("testUnmodified", testUnmodified)
     ]
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import HTMLKitTests
 
 XCTMain([
-    testCase(ComponentTests.allTests)
+    testCase(ComponentTests.allTests),
     testCase(ContextTests.allTests),
     testCase(ElementTests.allTests),
     testCase(LocalizationTests.allTests),


### PR DESCRIPTION
This merge will add the modifier for each element again. It also extend some attribute handlers to accept TemplateValue as parameter value.

### Modifiable
```swift
extension Article: Modifiable {
    
    public func modify(if condition: Bool, element: (Self) -> Self) -> Self {
        
        if condition {
            return modify(element(self))
        }
        
        return self
    }
}
```

```swift
extension ContentNode where Self: Modifiable {
    
    internal func modify(_ element: Self) -> Self {
        
        guard var attributes = self.attributes else {

            return .init(attributes: element.attributes!, content: self.content)
        }
        
        return .init(attributes: merge(element.attributes!, with: &attributes), content: self.content)
    }
}
```

### Attribute
```swift
public protocol IdentifierAttribute: AnyAttribute {
 
    func id(_ value: String) -> Self
    
    func id(_ value: TemplateValue<String>) -> Self
}
```