### PR TITLE
Implement a converter

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
           inputs: "Sources"
           output: "dcov.json"
       - name: Check Documentation Percent
-        run: sudo bash Scripts/DocCoverage/check-percentage.sh dcov.json 13
+        run: sudo bash Scripts/DocCoverage/check-percentage.sh dcov.json 10
         
   xenial:
     needs: check-doc-coverage

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,8 @@ let package = Package(
             name: "HTMLKitTests",
             dependencies: ["HTMLKit"],
             resources: [
-                .process("Localization")
+                .process("Localization"),
+                .process("Conversion")
             ]
         )
     ]

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -16,7 +16,7 @@ import OrderedCollections
 /// # References:
 /// https://html.spec.whatwg.org/#comments
 ///
-public struct Comment: CommentNode {
+public struct Comment: CommentNode, GlobalElement {
     
     public var content: String
     

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -214,4 +214,28 @@ extension Html: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -378,6 +378,30 @@ extension Link: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -531,6 +555,30 @@ extension Article: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -686,6 +734,30 @@ extension Section: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -840,6 +912,30 @@ extension Navigation: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -993,6 +1089,30 @@ extension Aside: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -1159,6 +1279,30 @@ extension Heading1: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -1323,6 +1467,30 @@ extension Heading2: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -1489,6 +1657,30 @@ extension Heading3: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -1653,6 +1845,30 @@ extension Heading4: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -1819,6 +2035,30 @@ extension Heading5: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -1984,6 +2224,30 @@ extension Heading6: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -2137,6 +2401,30 @@ extension HeadingGroup: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -2292,6 +2580,30 @@ extension Header: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -2446,6 +2758,30 @@ extension Footer: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -2599,6 +2935,30 @@ extension Address: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -2765,6 +3125,30 @@ extension Paragraph: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -2913,6 +3297,30 @@ extension HorizontalRule: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -3067,6 +3475,30 @@ extension PreformattedText: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -3237,6 +3669,30 @@ extension Blockquote: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -3403,6 +3859,30 @@ extension OrderedList: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -3556,6 +4036,30 @@ extension UnorderedList: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -3711,6 +4215,30 @@ extension DescriptionList: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -3864,6 +4392,30 @@ extension Figure: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -4070,6 +4622,30 @@ extension Anchor: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -4224,6 +4800,30 @@ extension Emphasize: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -4377,6 +4977,30 @@ extension Strong: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -4543,6 +5167,30 @@ extension Small: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -4708,6 +5356,30 @@ extension StrikeThrough: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -4861,6 +5533,30 @@ extension Main: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -5016,6 +5712,30 @@ extension Division: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -5170,6 +5890,30 @@ extension Definition: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -5323,6 +6067,30 @@ extension Cite: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -5482,6 +6250,30 @@ extension ShortQuote: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -5636,6 +6428,30 @@ extension Abbreviation: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -5789,6 +6605,30 @@ extension Ruby: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -5952,6 +6792,30 @@ extension Data: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -6110,6 +6974,30 @@ extension Time: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -6263,6 +7151,30 @@ extension Code: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -6418,6 +7330,30 @@ extension Variable: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -6571,6 +7507,30 @@ extension SampleOutput: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -6726,6 +7686,30 @@ extension KeyboardInput: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -6880,6 +7864,30 @@ extension Subscript: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -7033,6 +8041,30 @@ extension Superscript: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -7199,6 +8231,30 @@ extension Italic: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -7363,6 +8419,30 @@ extension Bold: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -7529,6 +8609,30 @@ extension Underline: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -7682,6 +8786,30 @@ extension Mark: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -7837,6 +8965,30 @@ extension Bdi: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -7985,6 +9137,30 @@ extension Bdo: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -8140,6 +9316,30 @@ extension Span: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -8289,6 +9489,30 @@ extension LineBreak: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -8437,6 +9661,30 @@ extension WordBreak: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -8600,6 +9848,30 @@ extension InsertedText: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -8762,6 +10034,30 @@ extension DeletedText: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -8915,6 +10211,30 @@ extension Picture: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -9097,6 +10417,30 @@ extension Image: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -9275,6 +10619,30 @@ extension InlineFrame: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -9439,6 +10807,30 @@ extension Embed: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -9626,6 +11018,30 @@ extension Object: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -9808,6 +11224,30 @@ extension Video: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -9982,6 +11422,30 @@ extension Audio: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -10143,6 +11607,30 @@ extension Map: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -10338,6 +11826,30 @@ extension Form: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -10491,6 +12003,30 @@ extension DataList: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -10662,6 +12198,30 @@ extension Output: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -10827,6 +12387,30 @@ extension Progress: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -11006,6 +12590,30 @@ extension Meter: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -11168,6 +12776,30 @@ extension Details: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -11325,6 +12957,30 @@ extension Dialog: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -11504,6 +13160,30 @@ extension Script: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -11658,6 +13338,30 @@ extension NoScript: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -11811,6 +13515,30 @@ extension Template: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -11974,6 +13702,30 @@ extension Canvas: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -12135,5 +13887,29 @@ extension Table: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -173,6 +173,30 @@ extension TermName: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -326,5 +350,29 @@ extension TermDefinition: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -168,4 +168,28 @@ extension FigureCaption: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -274,6 +274,30 @@ extension Input: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -442,6 +466,30 @@ extension Label: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -628,6 +676,30 @@ extension Select: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -839,6 +911,30 @@ extension TextArea: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -1036,6 +1132,30 @@ extension Button: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -1205,5 +1325,29 @@ extension Fieldset: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -165,6 +165,30 @@ extension Title: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 
@@ -328,6 +352,30 @@ extension Base: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -499,6 +547,30 @@ extension Meta: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -665,5 +737,29 @@ extension Style: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -163,6 +163,30 @@ extension Head: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -352,5 +376,29 @@ extension Body: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -176,6 +176,30 @@ extension OptionGroup: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -346,6 +370,30 @@ extension Option: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -500,6 +548,30 @@ extension Legend: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -653,5 +725,29 @@ extension Summary: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -176,4 +176,28 @@ extension ListItem: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -203,4 +203,28 @@ extension Area: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -182,6 +182,30 @@ extension Source: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -346,5 +370,29 @@ extension Track: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -174,4 +174,28 @@ extension Parameter: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -173,6 +173,30 @@ extension RubyText: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -326,5 +350,29 @@ extension RubyPronunciation: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -203,6 +203,30 @@ extension Caption: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -361,6 +385,30 @@ extension ColumnGroup: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -518,6 +566,30 @@ extension Column: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -681,6 +753,30 @@ extension TableBody: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -843,6 +939,30 @@ extension TableHead: Modifiable {
         
         return self
     }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
+    }
 }
 
 /// # Description:
@@ -996,6 +1116,30 @@ extension TableFoot: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -1158,6 +1302,30 @@ extension TableRow: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -1324,6 +1492,30 @@ extension DataCell: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }
 
@@ -1505,5 +1697,29 @@ extension HeaderCell: Modifiable {
         }
         
         return self
+    }
+    
+    public func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self {
+        
+        switch value {
+        case .constant(let optional):
+            
+            guard let value = optional else {
+                return self
+            }
+            
+            return modify(element(self, .constant(value)))
+            
+        case .dynamic(let context):
+            
+            if context.isMascadingOptional {
+                
+                return modify(element(self, .dynamic(context.unsafeCast(to: T.self))))
+            
+            } else {
+                
+                return modify(element(self, .dynamic(context.unsafelyUnwrapped)))
+            }
+        }
     }
 }

--- a/Sources/HTMLKit/Internal/Core/Builders/StringBuilder.swift
+++ b/Sources/HTMLKit/Internal/Core/Builders/StringBuilder.swift
@@ -1,0 +1,32 @@
+/// # Description:
+/// The file contains the result builder for string.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+@resultBuilder public class StringBuilder {
+
+    public static func buildBlock(_ component: String...) -> String {
+        return component.joined()
+    }
+    
+    public static func buildOptional(_ component: String?) -> String {
+        return component ?? ""
+    }
+    
+    public static func buildEither(first component: String) -> String {
+        return component
+    }
+
+    public static func buildEither(second component: String) -> String {
+        return component
+    }
+    
+    public static func buildArray(_ components: [String]) -> String {
+        return components.joined()
+    }
+}

--- a/Sources/HTMLKit/Internal/Core/Elements.swift
+++ b/Sources/HTMLKit/Internal/Core/Elements.swift
@@ -8,6 +8,8 @@
 /// Mats Moll: https://github.com/matsmoll
 /// Mattes Mohr: https://github.com/mattesmohr
 
+public typealias GlobalElement = BodyElement & DescriptionElement & FigureElement & FormElement & BasicElement & HeadElement & ListElement & MapElement & MediaElement & ObjectElement & RubyElement & TableElement & HtmlElement
+
 /// # Description:
 /// The protocol defines a body element.
 ///

--- a/Sources/HTMLKit/Internal/Core/Properties/Modifiable.swift
+++ b/Sources/HTMLKit/Internal/Core/Properties/Modifiable.swift
@@ -7,4 +7,9 @@ public protocol Modifiable {
     ///
     ///
     func modify(if condition: Bool, element: (Self) -> Self) -> Self
+    
+    /// The func is for
+    ///
+    ///
+    func modify<T>(unwrap value: TemplateValue<T?>, element: (Self, TemplateValue<T>) -> Self) -> Self
 }

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -1,0 +1,531 @@
+/// # Description:
+/// The file contains the converter.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+import Foundation
+
+public class Converter {
+    
+    public enum Extension: String {
+        case html
+        case leaf
+    }
+    
+    public enum Output: String {
+        case print
+        case file
+    }
+    
+    public enum Errors: Error {
+        case rootNotFound
+    }
+
+    public init() {}
+    
+    public func convert(directory: URL, fileExtension: Extension = .html, option: Output) throws {
+        
+        if let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) {
+            
+            for case let path as URL in enumerator {
+                
+                if !path.hasDirectoryPath {
+
+                    if path.pathExtension != fileExtension.rawValue {
+                        enumerator.skipDescendants()
+                    } else {
+                        try convert(file: path, option: option)
+                    }
+                    
+                }
+            }
+        }
+    }
+
+    public func convert(file: URL, option: Output) throws {
+        
+        let fileName = file.deletingPathExtension().lastPathComponent
+        
+        let document = try XMLDocument(contentsOf: file, options: [.documentIncludeContentTypeDeclaration])
+        
+        guard let root = document.rootElement() else {
+            throw Errors.rootNotFound
+        }
+        
+        switch option {
+        case .print:
+            
+            if let dtd = document.dtd {
+                
+                let layout = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root)
+                
+                print(layout.build())
+                
+            } else {
+                
+                let layout = ViewLayout(name: fileName, root: root)
+                
+                print(layout.build())
+            }
+            
+        case .file:
+            
+            if let dtd = document.dtd {
+                
+                let content = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root).build()
+                
+                try content.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
+                              atomically: true,
+                              encoding: .utf8)
+                
+            } else {
+                
+                let content = ViewLayout(name: fileName, root: root).build()
+                
+                try content.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
+                              atomically: true,
+                              encoding: .utf8)
+            }
+        }
+    }
+    
+    @StringBuilder internal func decode(attribute: XMLNode) -> String {
+        
+        switch attribute.localName {
+        case "accesskey":
+            ValueProperty(node: attribute).build()
+        case "accept":
+            ValueProperty(node: attribute).build()
+        case "action":
+            ValueProperty(node: attribute).build()
+        case "alt":
+            ValueProperty(node: attribute).build(verbatim: "alternate")
+        case "async":
+            EmptyProperty(node: attribute).build(verbatim: "asynchronously")
+        case "autocapitalize":
+            TypeProperty<Capitalization>(node: attribute).build()
+        case "autocomplete":
+            ValueProperty(node: attribute).build()
+        case "autofocus":
+            EmptyProperty(node: attribute).build()
+        case "autoplay":
+            EmptyProperty(node: attribute).build()
+        case "checked":
+            EmptyProperty(node: attribute).build()
+        case "cite":
+            ValueProperty(node: attribute).build()
+        case "class":
+            ValueProperty(node: attribute).build()
+        case "cols":
+            ValueProperty(node: attribute).build(verbatim: "columns")
+        case "colspan":
+            ValueProperty(node: attribute).build(verbatim: "columnSpan")
+        case "content":
+            ValueProperty(node: attribute).build()
+        case "contenteditable":
+            ValueProperty(node: attribute).build(verbatim: "isEditable")
+        case "controls":
+            EmptyProperty(node: attribute).build()
+        case "coords":
+            ValueProperty(node: attribute).build(verbatim: "coordinates")
+        case "data":
+            ValueProperty(node: attribute).build()
+        case "datetime":
+            ValueProperty(node: attribute).build(verbatim: "dateTime")
+        case "default":
+            EmptyProperty(node: attribute).build()
+        case "defer":
+            EmptyProperty(node: attribute).build()
+        case "dir":
+            TypeProperty<Direction>(node: attribute).build(verbatim: "direction")
+        case "disabled":
+            EmptyProperty(node: attribute).build()
+        case "download":
+            EmptyProperty(node: attribute).build()
+        case "draggable":
+            ValueProperty(node: attribute).build(verbatim: "isDraggable")
+        case "enctype":
+            TypeProperty<Encoding>(node: attribute).build(verbatim: "encoding")
+        case "enterkeyhint":
+            TypeProperty<Hint>(node: attribute).build(verbatim: "enterKeyHint")
+        case "for":
+            ValueProperty(node: attribute).build()
+        case "form":
+            ValueProperty(node: attribute).build()
+        case "formaction":
+            ValueProperty(node: attribute).build(verbatim: "formAction")
+        case "headers":
+            ValueProperty(node: attribute).build()
+        case "height":
+            ValueProperty(node: attribute).build()
+        case "hidden":
+            EmptyProperty(node: attribute).build()
+        case "high":
+            ValueProperty(node: attribute).build()
+        case "href":
+            ValueProperty(node: attribute).build(verbatim: "reference")
+        case "hreflang":
+            TypeProperty<Language>(node: attribute).build(verbatim: "referenceLanguage")
+        case "id":
+            ValueProperty(node: attribute).build()
+        case "ismap":
+            EmptyProperty(node: attribute).build(verbatim: "isMap")
+        case "inputmode":
+            ValueProperty(node: attribute).build(verbatim: "inputMode")
+        case "is":
+            ValueProperty(node: attribute).build()
+        case "itemid":
+            ValueProperty(node: attribute).build(verbatim: "itemId")
+        case "itemproperty":
+            ValueProperty(node: attribute).build(verbatim: "itemProperty")
+        case "itemref":
+            ValueProperty(node: attribute).build(verbatim: "itemReference")
+        case "itemscope":
+            ValueProperty(node: attribute).build(verbatim: "itemScope")
+        case "itemtype":
+            ValueProperty(node: attribute).build(verbatim: "itemType")
+        case "kind":
+            ValueProperty(node: attribute).build()
+        case "label":
+            ValueProperty(node: attribute).build()
+        case "lang":
+            TypeProperty<Language>(node: attribute).build(verbatim: "language")
+        case "list":
+            ValueProperty(node: attribute).build()
+        case "loop":
+            EmptyProperty(node: attribute).build()
+        case "low":
+            ValueProperty(node: attribute).build()
+        case "max":
+            ValueProperty(node: attribute).build(verbatim: "maximum")
+        case "media":
+            ValueProperty(node: attribute).build()
+        case "method":
+            TypeProperty<Method>(node: attribute).build()
+        case "min":
+            ValueProperty(node: attribute).build(verbatim: "minimum")
+        case "multiple":
+            EmptyProperty(node: attribute).build()
+        case "muted":
+            EmptyProperty(node: attribute).build()
+        case "name":
+            ValueProperty(node: attribute).build()
+        case "nonce":
+            ValueProperty(node: attribute).build()
+        case "novalidate":
+            EmptyProperty(node: attribute).build()
+        case "open":
+            ValueProperty(node: attribute).build(verbatim: "isOpen")
+        case "optimum":
+            ValueProperty(node: attribute).build()
+        case "pattern":
+            ValueProperty(node: attribute).build()
+        case "part":
+            ValueProperty(node: attribute).build()
+        case "ping":
+            ValueProperty(node: attribute).build()
+        case "placeholder":
+            ValueProperty(node: attribute).build()
+        case "poster":
+            ValueProperty(node: attribute).build()
+        case "preload":
+            ValueProperty(node: attribute).build()
+        case "readonly":
+            EmptyProperty(node: attribute).build()
+        case "referrerpolicy":
+            TypeProperty<Policy>(node: attribute).build(verbatim: "referrerPolicy")
+        case "rel":
+            TypeProperty<Relation>(node: attribute).build(verbatim: "relationship")
+        case "required":
+            EmptyProperty(node: attribute).build()
+        case "reversed":
+            EmptyProperty(node: attribute).build()
+        case "role":
+            ValueProperty(node: attribute).build()
+        case "rows":
+            ValueProperty(node: attribute).build()
+        case "rowspan":
+            ValueProperty(node: attribute).build(verbatim: "rowSpan")
+        case "sandbox":
+            EmptyProperty(node: attribute).build()
+        case "scope":
+            ValueProperty(node: attribute).build()
+        case "shape":
+            TypeProperty<Shape>(node: attribute).build()
+        case "size":
+            ValueProperty(node: attribute).build()
+        case "sizes":
+            ValueProperty(node: attribute).build()
+        case "slot":
+            ValueProperty(node: attribute).build()
+        case "span":
+            ValueProperty(node: attribute).build()
+        case "spellcheck":
+            ValueProperty(node: attribute).build(verbatim: "hasSpellCheck")
+        case "source":
+            ValueProperty(node: attribute).build()
+        case "start":
+            ValueProperty(node: attribute).build()
+        case "step":
+            ValueProperty(node: attribute).build()
+        case "style":
+            ValueProperty(node: attribute).build()
+        case "tabindex":
+            ValueProperty(node: attribute).build(verbatim: "tabIndex")
+        case "target":
+            TypeProperty<Target>(node: attribute).build()
+        case "title":
+            ValueProperty(node: attribute).build()
+        case "translate":
+            ValueProperty(node: attribute).build()
+        case "type":
+            TypeProperty<Inputs>(node: attribute).build()
+        case "value":
+            ValueProperty(node: attribute).build()
+        case "width":
+            ValueProperty(node: attribute).build()
+        case "wrap":
+            TypeProperty<Wrapping>(node: attribute).build()
+        case "property":
+            TypeProperty<Graphs>(node: attribute).build()
+        default:
+            "attribute is not listed. contact the author"
+        }
+    }
+    
+    @StringBuilder internal func decode(element: XMLNode, preindent: Int? = nil) -> String {
+        
+        switch element.kind {
+        case .text:
+            
+            TextElement(node: element).build(preindent: preindent)
+            
+        case .comment:
+            
+            CommentElement(node: element).build(preindent: preindent)
+            
+        default:
+            
+            if let element = element as? XMLElement {
+             
+                switch element.localName {
+                case "html":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "head":
+                    ContentElement(element: element).build(verbatim: "Head", preindent: preindent)
+                case "body":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "nav":
+                    ContentElement(element: element).build(verbatim: "Navigation", preindent: preindent)
+                case "link":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "aside":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "section":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "h1":
+                    ContentElement(element: element).build(verbatim: "Heading1", preindent: preindent)
+                case "h2":
+                    ContentElement(element: element).build(verbatim: "Heading2", preindent: preindent)
+                case "h3":
+                    ContentElement(element: element).build(verbatim: "Heading3", preindent: preindent)
+                case "h4":
+                    ContentElement(element: element).build(verbatim: "Heading4", preindent: preindent)
+                case "h5":
+                    ContentElement(element: element).build(verbatim: "Heading5", preindent: preindent)
+                case "h6":
+                    ContentElement(element: element).build(verbatim: "Heading6", preindent: preindent)
+                case "hgroup":
+                    ContentElement(element: element).build(verbatim: "HeadingGroup", preindent: preindent)
+                case "header":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "footer":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "address":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "p":
+                    ContentElement(element: element).build(verbatim: "Paragraph", preindent: preindent)
+                case "hr":
+                    EmptyElement(element: element).build(verbatim: "HorizontalRule", preindent: preindent)
+                case "pre":
+                    ContentElement(element: element).build(verbatim: "PreformattedText", preindent: preindent)
+                case "blockquote":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "ol":
+                    ContentElement(element: element).build(verbatim: "OrderdList", preindent: preindent)
+                case "ul":
+                    ContentElement(element: element).build(verbatim: "UnorderdList", preindent: preindent)
+                case "dl":
+                    ContentElement(element: element).build(verbatim: "DescriptionList", preindent: preindent)
+                case "figure":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "a":
+                    ContentElement(element: element).build(verbatim: "Anchor", preindent: preindent)
+                case "em":
+                    ContentElement(element: element).build(verbatim: "Emphasize", preindent: preindent)
+                case "small":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "s":
+                    ContentElement(element: element).build(verbatim: "StrikeThrough", preindent: preindent)
+                case "main":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "div":
+                    ContentElement(element: element).build(verbatim: "Division", preindent: preindent)
+                case "dfn":
+                    ContentElement(element: element).build(verbatim: "Definition", preindent: preindent)
+                case "cite":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "q":
+                    ContentElement(element: element).build(verbatim: "ShortQuote", preindent: preindent)
+                case "rt":
+                    ContentElement(element: element).build(verbatim: "RubyText", preindent: preindent)
+                case "rp":
+                    ContentElement(element: element).build(verbatim: "RubyPronunciation", preindent: preindent)
+                case "abbr":
+                    ContentElement(element: element).build(verbatim: "Abbreviation", preindent: preindent)
+                case "data":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "time":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "code":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "v":
+                    ContentElement(element: element).build(verbatim: "Variable", preindent: preindent)
+                case "samp":
+                    ContentElement(element: element).build(verbatim: "SampleOutput", preindent: preindent)
+                case "kbd":
+                    ContentElement(element: element).build(verbatim: "KeyboardOutput", preindent: preindent)
+                case "sub":
+                    ContentElement(element: element).build(verbatim: "Subscript", preindent: preindent)
+                case "sup":
+                    ContentElement(element: element).build(verbatim: "Superscript", preindent: preindent)
+                case "i":
+                    ContentElement(element: element).build(verbatim: "Italic", preindent: preindent)
+                case "b":
+                    ContentElement(element: element).build(verbatim: "Bold", preindent: preindent)
+                case "u":
+                    ContentElement(element: element).build(verbatim: "SampleOutput", preindent: preindent)
+                case "mark":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "bdi":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "bdo":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "span":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "br":
+                    EmptyElement(element: element).build(verbatim: "LineBreak", preindent: preindent)
+                case "wbr":
+                    EmptyElement(element: element).build(verbatim: "WordBreak", preindent: preindent)
+                case "ins":
+                    ContentElement(element: element).build(verbatim: "InsertedText", preindent: preindent)
+                case "del":
+                    ContentElement(element: element).build(verbatim: "DeletedText", preindent: preindent)
+                case "img":
+                    ContentElement(element: element).build(verbatim: "Image", preindent: preindent)
+                case "embed":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "iframe":
+                    ContentElement(element: element).build(verbatim: "InlineFrame", preindent: preindent)
+                case "param":
+                    EmptyElement(element: element).build(verbatim: "Parameter", preindent: preindent)
+                case "dt":
+                    ContentElement(element: element).build(verbatim: "TermName", preindent: preindent)
+                case "dd":
+                    ContentElement(element: element).build(verbatim: "TermDefinition", preindent: preindent)
+                case "figcaption":
+                    ContentElement(element: element).build(verbatim: "FigureCaption", preindent: preindent)
+                case "optgroup":
+                    ContentElement(element: element).build(verbatim: "OptionGroup", preindent: preindent)
+                case "option":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "legend":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "summary":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "li":
+                    ContentElement(element: element).build(verbatim: "ListItem", preindent: preindent)
+                case "colgroup":
+                    ContentElement(element: element).build(verbatim: "ColumnGroup", preindent: preindent)
+                case "col":
+                    ContentElement(element: element).build(verbatim: "Column", preindent: preindent)
+                case "tbody":
+                    ContentElement(element: element).build(verbatim: "TableBody", preindent: preindent)
+                case "thead":
+                    ContentElement(element: element).build(verbatim: "TableHead", preindent: preindent)
+                case "tfoot":
+                    ContentElement(element: element).build(verbatim: "TableFoot", preindent: preindent)
+                case "tr":
+                    ContentElement(element: element).build(verbatim: "TableRow", preindent: preindent)
+                case "td":
+                    ContentElement(element: element).build(verbatim: "DataCell", preindent: preindent)
+                case "th":
+                    ContentElement(element: element).build(verbatim: "HeaderCell", preindent: preindent)
+                case "textarea":
+                    ContentElement(element: element).build(verbatim: "TextArea", preindent: preindent)
+                case "input":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "video":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "audio":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "map":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "area":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "form":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "datalist":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "output":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "meter":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "details":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "dialog":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "script":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "noscript":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "template":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "canvas":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "table":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "fieldset":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "button":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "select":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "label":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "title":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "base":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "meta":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "style":
+                    ContentElement(element: element).build(preindent: preindent)
+                case "source":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "track":
+                    EmptyElement(element: element).build(preindent: preindent)
+                case "article":
+                    ContentElement(element: element).build(preindent: preindent)
+                default:
+                    "element is not listed. contact the author"
+                }
+            }
+        }
+    }
+}

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -8,7 +8,11 @@
 /// Mats Moll: https://github.com/matsmoll
 /// Mattes Mohr: https://github.com/mattesmohr
 
+#if canImport(FoundationXML)
+import FoundationXML
+#else
 import Foundation
+#endif
 
 public class Converter {
     

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -9,10 +9,8 @@
 /// Mattes Mohr: https://github.com/mattesmohr
 
 import Foundation
-#if canImport(FoundationXML)
-import FoundationXML
-#endif
 
+@available(macOS 11.0, *)
 public class Converter {
     
     public enum Extension: String {
@@ -65,32 +63,32 @@ public class Converter {
             
             if let dtd = document.dtd {
                 
-                let layout = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root)
+                let layout = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root).build()
                 
-                print(layout.build())
+                print(layout)
                 
             } else {
                 
-                let layout = ViewLayout(name: fileName, root: root)
+                let layout = ViewLayout(name: fileName, root: root).build()
                 
-                print(layout.build())
+                print(layout)
             }
             
         case .file:
             
             if let dtd = document.dtd {
                 
-                let content = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root).build()
+                let layout = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root).build()
                 
-                try content.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
+                try layout.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
                               atomically: true,
                               encoding: .utf8)
                 
             } else {
                 
-                let content = ViewLayout(name: fileName, root: root).build()
+                let layout = ViewLayout(name: fileName, root: root).build()
                 
-                try content.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
+                try layout.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
                               atomically: true,
                               encoding: .utf8)
             }

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -8,10 +8,9 @@
 /// Mats Moll: https://github.com/matsmoll
 /// Mattes Mohr: https://github.com/mattesmohr
 
+import Foundation
 #if canImport(FoundationXML)
 import FoundationXML
-#else
-import Foundation
 #endif
 
 public class Converter {

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -9,6 +9,9 @@
 /// Mattes Mohr: https://github.com/mattesmohr
 
 import Foundation
+ #if canImport(FoundationXML)
+ import FoundationXML
+ #endif
 
 @available(macOS 11.0, *)
 public class Converter {

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -8,7 +8,11 @@
 /// Mats Moll: https://github.com/matsmoll
 /// Mattes Mohr: https://github.com/mattesmohr
 
+#if canImport(FoundationXML)
+import FoundationXML
+#else
 import Foundation
+#endif
 
 internal struct CommentElement {
     

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -8,10 +8,9 @@
 /// Mats Moll: https://github.com/matsmoll
 /// Mattes Mohr: https://github.com/mattesmohr
 
+import Foundation
 #if canImport(FoundationXML)
 import FoundationXML
-#else
-import Foundation
 #endif
 
 internal struct CommentElement {

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -9,10 +9,8 @@
 /// Mattes Mohr: https://github.com/mattesmohr
 
 import Foundation
-#if canImport(FoundationXML)
-import FoundationXML
-#endif
 
+@available(macOS 11.0, *)
 internal struct CommentElement {
     
     private var comment: String? {
@@ -41,6 +39,7 @@ internal struct CommentElement {
     }
 }
 
+@available(macOS 11.0, *)
 internal struct TextElement {
     
     private var text: String? {
@@ -68,6 +67,7 @@ internal struct TextElement {
     }
 }
 
+@available(macOS 11.0, *)
 internal struct ContentElement {
 
     private var name: String? {
@@ -152,6 +152,7 @@ internal struct ContentElement {
     }
 }
 
+@available(macOS 11.0, *)
 internal struct EmptyElement {
 
     private var name: String? {
@@ -214,6 +215,7 @@ internal struct EmptyElement {
     }
 }
 
+@available(macOS 11.0, *)
 internal struct PageLayout<T: RawRepresentable> {
     
     private var name: String
@@ -260,6 +262,7 @@ internal struct PageLayout<T: RawRepresentable> {
     }
 }
 
+@available(macOS 11.0, *)
 internal struct ViewLayout {
     
     private var name: String
@@ -292,6 +295,7 @@ internal struct ViewLayout {
     }
 }
 
+@available(macOS 11.0, *)
 internal struct ValueProperty{
     
     private var name: String? {
@@ -342,6 +346,7 @@ internal struct ValueProperty{
     }
 }
 
+@available(macOS 11.0, *)
 internal struct EmptyProperty {
     
     private var name: String? {
@@ -374,7 +379,7 @@ internal struct EmptyProperty {
     }
 }
 
-
+@available(macOS 11.0, *)
 internal struct TypeProperty<T: RawRepresentable>{
     
     private var name: String? {

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -1,0 +1,428 @@
+/// # Description:
+/// The file contains the stencils for the converter.
+///
+/// # Note:
+/// If you about to add something to the file, stick to the official documentation to keep the code consistent.
+///
+/// # Authors:
+/// Mats Moll: https://github.com/matsmoll
+/// Mattes Mohr: https://github.com/mattesmohr
+
+import Foundation
+
+internal struct CommentElement {
+    
+    private var comment: String? {
+        
+        guard let comment = node.stringValue else {
+            return nil
+        }
+        
+        return comment
+    }
+    
+    private let node: XMLNode
+    
+    internal init(node: XMLNode) {
+        self.node = node
+    }
+    
+    @StringBuilder internal func build(preindent: Int? = nil) -> String {
+        
+        let indent = String(repeating: "\t", count: (node.level - 1) + (preindent ?? 0))
+        
+        if let comment = comment
+        {
+            "\(indent)Comment(\"\(comment)\")\n"
+        }
+    }
+}
+
+internal struct TextElement {
+    
+    private var text: String? {
+        
+        guard let text = node.stringValue else {
+            return nil
+        }
+        
+        return text
+    }
+    
+    private let node: XMLNode
+    
+    internal init(node: XMLNode) {
+        self.node = node
+    }
+    
+    @StringBuilder internal func build(preindent: Int? = nil) -> String {
+        
+        let indent = String(repeating: "\t", count: (node.level - 1) + (preindent ?? 0))
+        
+        if let text = text {
+            "\(indent)\"\(text)\"\n"
+        }
+    }
+}
+
+internal struct ContentElement {
+
+    private var name: String? {
+        
+        guard let name = element.name else {
+            return nil
+        }
+    
+        return name.capitalized
+    }
+    
+    private var attributes: [String]? {
+        
+        guard let attributes = element.attributes else {
+            return nil
+        }
+        
+        return attributes.map { attribute in
+            return Converter().decode(attribute: attribute)
+        }
+    }
+    
+    private var content: [String]? {
+        
+        guard let children = element.children else {
+            return nil
+        }
+        
+        return children.map { child in
+            return Converter().decode(element: child, preindent: 2)
+        }
+    }
+    
+    private var level: Int {
+        return element.level
+    }
+    
+    private let element: XMLElement
+    
+    internal init(element: XMLElement) {
+        self.element = element
+    }
+    
+    @StringBuilder internal func build(preindent: Int? = nil) -> String {
+        
+        let indent = String(repeating: "\t", count: (level - 1) + (preindent ?? 0))
+        
+        if let name = name {
+            
+            "\(indent)\(name) {\n"
+
+            if let content = content {
+                content.joined()
+            }
+            
+            "\(indent)}\n"
+            
+            if let attributes = attributes {
+                "\(indent)\(attributes.joined(separator: "\(indent)"))"
+            }
+        }
+    }
+    
+    @StringBuilder internal func build(verbatim: String? = nil, preindent: Int? = nil) -> String {
+        
+        let indent = String(repeating: "\t", count: (level - 1) + (preindent ?? 0))
+        
+        if let verbatim = verbatim {
+            
+            "\(indent)\(verbatim) {\n"
+
+            if let content = content {
+                content.joined()
+            }
+            
+            "\(indent)}\n"
+            
+            if let attributes = attributes {
+                "\(indent)\(attributes.joined(separator: "\(indent)"))"
+            }
+        }
+    }
+}
+
+internal struct EmptyElement {
+
+    private var name: String? {
+        
+        guard let name = element.name else {
+            return nil
+        }
+    
+        return name.capitalized
+    }
+    
+    private var attributes: [String]? {
+        
+        guard let attributes = element.attributes else {
+            return nil
+        }
+        
+        return attributes.map { attribute in
+            return Converter().decode(attribute: attribute)
+        }
+    }
+    
+    private var level: Int {
+        return element.level
+    }
+    
+    private let element: XMLElement
+    
+    internal init(element: XMLElement) {
+        self.element = element
+    }
+    
+    @StringBuilder internal func build(preindent: Int? = nil) -> String {
+
+        let indent = String(repeating: "\t", count: (level - 1) + (preindent ?? 0))
+
+        if let name = name {
+            
+            "\(indent)\(name)()\n"
+            
+            if let attributes = attributes {
+                "\(indent)\t\(attributes.joined(separator: "\t\(indent)"))"
+            }
+        }
+    }
+    
+    @StringBuilder internal func build(verbatim: String? = nil, preindent: Int? = nil) -> String {
+
+        let indent = String(repeating: "\t", count: (level - 1) + (preindent ?? 0))
+
+        if let verbatim = verbatim {
+    
+            "\(indent)\(verbatim)()\n"
+            
+            if let attributes = attributes {
+                "\(indent)\t\(attributes.joined(separator: "\t\(indent)"))"
+            }
+            
+        }
+    }
+}
+
+internal struct PageLayout<T: RawRepresentable> {
+    
+    private var name: String
+    
+    private var content: String {
+        return Converter().decode(element: root, preindent: 2)
+    }
+    
+    private var type: String {
+        
+        if let name = doctype.name, let publicId = doctype.publicID, let systemId = doctype.systemID {
+            
+            if let type = T(rawValue: "\(name) PUBLIC \"\(publicId)\" \"\(systemId)\"" as! T.RawValue) {
+                return ".\(type)"
+            }
+        }
+        
+        return ".html5"
+    }
+    
+    private var doctype: XMLDTD
+    
+    private var root: XMLElement
+    
+    internal init(name: String, doctype: XMLDTD, root: XMLElement) {
+        self.name = name.capitalized
+        self.doctype = doctype
+        self.root = root
+    }
+    
+    internal func build() -> String {
+        
+        """
+        import HTMLKit
+        
+        struct \(name)Page: Page {
+        
+            public var body: AnyContent {
+                Document(type: \(type))
+        \(content)
+            }
+        }
+        """
+    }
+}
+
+internal struct ViewLayout {
+    
+    private var name: String
+    
+    private var content: String {
+        return Converter().decode(element: root, preindent: 2)
+    }
+    
+    private var root: XMLElement
+    
+    internal init(name: String, root: XMLElement) {
+        self.name = name.capitalized
+        self.root = root
+    }
+    
+    internal func build() -> String {
+        
+        """
+        import HTMLKit
+        
+        struct \(name)View: View {
+        
+            var context: TemplateValue<String> = ""
+        
+            public var body: AnyContent {
+        \(content)
+            }
+        }
+        """
+    }
+}
+
+internal struct ValueProperty{
+    
+    private var name: String? {
+        
+        guard let name = node.name else {
+            return nil
+        }
+        
+        return name
+    }
+    
+    private var value: String? {
+        guard let value = node.stringValue else {
+            return nil
+        }
+        
+        return value
+    }
+    
+    private let node: XMLNode
+    
+    internal init(node: XMLNode) {
+        self.node = node
+    }
+    
+    @StringBuilder internal func build() -> String {
+
+        if let name = name, let value = value {
+            
+            ".\(name)(\"\(value)\")\n"
+            
+        } else if let name = name{
+            
+            ".\(name)()"
+        }
+    }
+    
+    @StringBuilder internal func build(verbatim: String? = nil) -> String {
+
+        if let verbatim = verbatim, let value = value {
+            
+            ".\(verbatim)(\"\(value)\")\n"
+            
+        } else if let verbatim = verbatim {
+            
+            ".\(verbatim)()"
+        }
+    }
+}
+
+internal struct EmptyProperty {
+    
+    private var name: String? {
+        
+        guard let name = node.name else {
+            return nil
+        }
+        
+        return name
+    }
+    
+    private let node: XMLNode
+    
+    internal init(node: XMLNode) {
+        self.node = node
+    }
+    
+    @StringBuilder internal func build() -> String {
+
+        if let name = name {
+            ".\(name)()\n"
+        }
+    }
+    
+    @StringBuilder internal func build(verbatim: String? = nil) -> String {
+
+        if let verbatim = verbatim {
+            ".\(verbatim)()\n"
+        }
+    }
+}
+
+
+internal struct TypeProperty<T: RawRepresentable>{
+    
+    private var name: String? {
+        
+        guard let name = node.name else {
+            return nil
+        }
+        
+        return name
+    }
+    
+    private var value: String? {
+
+        guard let value = node.stringValue  else {
+            return nil
+        }
+
+        if let type = T(rawValue: value as! T.RawValue) {
+            return ".\(type)"
+        }
+        
+        return ""
+    }
+    
+    private let node: XMLNode
+    
+    internal init(node: XMLNode) {
+        self.node = node
+    }
+    
+    @StringBuilder internal func build() -> String {
+
+        if let name = name, let value = value {
+            
+            ".\(name)(\(value))\n"
+            
+        } else if let name = name{
+            
+            ".\(name)()"
+        }
+    }
+    
+    @StringBuilder internal func build(verbatim: String? = nil) -> String {
+
+        if let verbatim = verbatim, let value = value {
+            
+            ".\(verbatim)(\(value))\n"
+            
+        } else if let verbatim = verbatim {
+            
+            ".\(verbatim)()"
+        }
+    }
+}

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -9,6 +9,9 @@
 /// Mattes Mohr: https://github.com/mattesmohr
 
 import Foundation
+ #if canImport(FoundationXML)
+ import FoundationXML
+ #endif
 
 @available(macOS 11.0, *)
 internal struct CommentElement {

--- a/Tests/HTMLKitTests/Conversion/articles/article.html
+++ b/Tests/HTMLKitTests/Conversion/articles/article.html
@@ -1,0 +1,7 @@
+<article>
+    <section>
+        <h1>headline</h1>
+        <h3>subtitle</h3>
+    </section>
+</article>
+

--- a/Tests/HTMLKitTests/Conversion/articles/article.html
+++ b/Tests/HTMLKitTests/Conversion/articles/article.html
@@ -1,7 +1,4 @@
 <article>
-    <section>
-        <h1>headline</h1>
-        <h3>subtitle</h3>
-    </section>
+    <h1>headline</h1>
+    <h3>subtitle</h3>
 </article>
-

--- a/Tests/HTMLKitTests/Conversion/index.html
+++ b/Tests/HTMLKitTests/Conversion/index.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <!--This is an example-->
     <head>
+        <title>test</title>
     </head>
     <body>
         <h1 class="class">headline</h1>
         <h3>subtitle</h3>
         <section>
-            <p>newsletter</p>
+            <h4>headline</h4>
             <input type="text" placeholder="enter your email here" />
         </section>
     </body>

--- a/Tests/HTMLKitTests/Conversion/index.html
+++ b/Tests/HTMLKitTests/Conversion/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <!--This is an example-->
+    <head>
+    </head>
+    <body>
+        <h1 class="class">headline</h1>
+        <h3>subtitle</h3>
+        <section>
+            <p>newsletter</p>
+            <input type="text" placeholder="enter your email here" />
+        </section>
+    </body>
+</html>

--- a/Tests/HTMLKitTests/ConversionTests.swift
+++ b/Tests/HTMLKitTests/ConversionTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ConversionTests: XCTestCase {
     
     var converter = Converter()
-    var currentDirectory: URL?
+    var directory: URL?
     
     override func setUp() {
         super.setUp()
@@ -12,26 +12,17 @@ final class ConversionTests: XCTestCase {
         try! setupConversion()
     }
     
-    func testConvertingDirectory() throws {
+    func testConversion() throws {
         
-        guard let directory = currentDirectory else {
-            return XCTFail()
+        guard let directory = directory else {
+            return XCTFail("No directory.")
+        }
+        
+        guard #available(macOS 11.0, *) else {
+            throw XCTSkip("Requires macOS >= 11.0")
         }
         
         XCTAssertNoThrow(try converter.convert(directory: directory, option: .print))
-    }
-    
-    func testConvertingFile() throws {
-        
-        guard let directory = currentDirectory else {
-            return XCTFail()
-        }
-        
-        let file = directory
-            .appendingPathComponent("index")
-            .appendingPathExtension("html")
-        
-        XCTAssertNoThrow(try converter.convert(file: file, option: .print))
     }
 }
 
@@ -41,14 +32,13 @@ extension ConversionTests {
         
         let currentFile = URL(fileURLWithPath: #file).deletingLastPathComponent()
         
-        self.currentDirectory = currentFile.appendingPathComponent("Conversion")
+        self.directory = currentFile.appendingPathComponent("Conversion")
     }
 }
 
 extension ConversionTests {
     
     static var allTests = [
-        ("testConvertingDirectory", testConvertingDirectory),
-        ("testConvertingFile", testConvertingFile),
+        ("testConversion", testConversion)
     ]
 }

--- a/Tests/HTMLKitTests/ConversionTests.swift
+++ b/Tests/HTMLKitTests/ConversionTests.swift
@@ -18,7 +18,7 @@ final class ConversionTests: XCTestCase {
             return XCTFail()
         }
         
-        try converter.convert(directory: directory, option: .file)
+        XCTAssertNoThrow(try converter.convert(directory: directory, option: .print))
     }
     
     func testConvertingFile() throws {
@@ -31,7 +31,7 @@ final class ConversionTests: XCTestCase {
             .appendingPathComponent("index")
             .appendingPathExtension("html")
         
-        try converter.convert(file: file, option: .file)
+        XCTAssertNoThrow(try converter.convert(file: file, option: .print))
     }
 }
 

--- a/Tests/HTMLKitTests/ConversionTests.swift
+++ b/Tests/HTMLKitTests/ConversionTests.swift
@@ -1,0 +1,54 @@
+import HTMLKit
+import XCTest
+
+final class ConversionTests: XCTestCase {
+    
+    var converter = Converter()
+    var currentDirectory: URL?
+    
+    override func setUp() {
+        super.setUp()
+        
+        try! setupConversion()
+    }
+    
+    func testConvertingDirectory() throws {
+        
+        guard let directory = currentDirectory else {
+            return XCTFail()
+        }
+        
+        try converter.convert(directory: directory, option: .file)
+    }
+    
+    func testConvertingFile() throws {
+        
+        guard let directory = currentDirectory else {
+            return XCTFail()
+        }
+        
+        let file = directory
+            .appendingPathComponent("index")
+            .appendingPathExtension("html")
+        
+        try converter.convert(file: file, option: .file)
+    }
+}
+
+extension ConversionTests {
+    
+    func setupConversion() throws {
+        
+        let currentFile = URL(fileURLWithPath: #file).deletingLastPathComponent()
+        
+        self.currentDirectory = currentFile.appendingPathComponent("Conversion")
+    }
+}
+
+extension ConversionTests {
+    
+    static var allTests = [
+        ("testConvertingDirectory", testConvertingDirectory),
+        ("testConvertingFile", testConvertingFile),
+    ]
+}

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -238,7 +238,7 @@ final class RenderingTests: XCTestCase {
         let view = TestPage {
             Input()
                 .modify(unwrap: passcode) {
-                    $0.value($1)
+                    $0.placeholder($1)
                 }
         }
         

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -230,6 +230,26 @@ final class RenderingTests: XCTestCase {
                        """
         )
     }
+    
+    func testModifiedAndUnwrapped() throws {
+        
+        let passcode: TemplateValue<String?> = .constant("test")
+        
+        let view = TestPage {
+            Input()
+                .modify(unwrap: passcode) {
+                    $0.value($1)
+                }
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <input placeholder="test">
+                       """
+        )
+    }
 }
 
 extension RenderingTests {
@@ -245,6 +265,7 @@ extension RenderingTests {
         ("testNesting", testNesting),
         ("testEscaping", testEscaping),
         ("testModified", testModified),
-        ("testUnmodified", testUnmodified)
+        ("testUnmodified", testUnmodified),
+        ("testModifiedAndUnwrapped", testModifiedAndUnwrapped)
     ]
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import HTMLKitTests
 
 XCTMain([
-    testCase(ConversionTests.allTests),
     testCase(ComponentTests.allTests),
     testCase(ContextTests.allTests),
     testCase(ElementTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import HTMLKitTests
 
 XCTMain([
+    testCase(ConversionTests.allTests),
     testCase(ComponentTests.allTests),
     testCase(ContextTests.allTests),
     testCase(ElementTests.allTests),


### PR DESCRIPTION
This merge will bring back the modifier for optional values and it also adds a converter for HTML to HTMLKit.

### Converter

```swift
let converter = Converter()
```

The converter has two methods. One for a directory and the other for a specific file.

```swift
/// goes through a directory and converts every file with the extension ".html"
convert(directory: URL, fileExtension: Extension = .html, option: Output)

/// converts the file
convert(file: URL, option: Output)
```

```swift 
public enum Extension: String {
      case html
     case leaf
}
```

The case `leaf` is for later, when the implementation for Leaf is done.


```swift
public enum Output: String {
      case print
      case file
}
```
Choose the case `print` first, to get sure everything will converted correctly. The output shows up in your console.

There could be slightly chance that I missed an element or attribute or I didn't think about a specific situation. Let me know if the converter is not working correctly for you.

You can reach me in the issues or mail@mattesmohr.de or on the Vapor Discord Server.