### PR TITLE
Minor fix

### DIFF
--- a/Instructions/Features/Conversion.md
+++ b/Instructions/Features/Conversion.md
@@ -1,10 +1,12 @@
 # Conversion
 
-The converter translates HTML into HTMLKit.
+With HTMLKit you can convert your existing HTML code into Swift. It makes the change easier, faster and it can give you an idea how the library works.
 
 ## Essential
 
 ### Call
+
+Call the converter and use the convert function. Pass the directory, where your html files are located and choose the output. We recommend to use the print option first, to get a quick preview on the output. The print shows up in the debug window of your IDE. If you choose the file option, the converter creates the swift files at the same directory you have given to the converter.
 
 ```swift
 /// [configure.swift]
@@ -45,3 +47,7 @@ struct IndexPage: Page {
     }
 }
 ```
+
+## Note
+
+Keep in mind, that maybe the converter has not covered every case. If you miss something, file an [issue](https://github.com/vapor-community/HTMLKit/issues) and let us know to make the converter better.

--- a/Instructions/Features/Localization.md
+++ b/Instructions/Features/Localization.md
@@ -1,19 +1,67 @@
 # Localization
 
-The localization is
+HTMLKit can render your content in different languages by using Localization.
 
 ## Essential
 
 ### Registration
 
+The localization is optional, so if you want to use it, you need to register it first. Pass the directory path and the local identifier to the renderer. Keep in mind, that the directory path is the root directory where your localization files are located.
+
 ```swift
 /// [configure.swift]
+
 ...
-try Renderer().registerLocalization(atPath: path, defaultLocale: "en")
+try app.htmlkit.renderer.registerLocalization(atPath: path, defaultLocale: "en")
 ...
 ```
 
 ### Definition
 
+Define your localizations in a .json file. If you want to get to know more about definitions, take a a look at the [Lingo library](https://github.com/miroslavkovac/Lingo#usage).
+
 ```swift
+/// [en.json]
+
+{
+    "Hallo.Welt": "Hello World"
+}
+```
+
+### Implementation
+
+You can retrieve the definition by calling the localized initialiser of a localizable element. Most of the phrasing elements in HTMLKit should be localizable and provide you with the specific initialiser. Please [open an issue](https://github.com/vapor-community/HTMLKit/issues), if you find an element without it.
+
+```swift
+/// [IndexView.swift]
+
+struct IndexView: View {
+
+    var body: AnyContent {
+        Article {
+            Heading1("Hallo.Welt")
+        }
+    }
+}
+```
+
+Also the locale for the environment can be changed for example by user input. Use the environment modifier on the element and pass the specific local identifier for it.
+
+```swift
+/// [IndexView.swift]
+
+struct IndexView: View {
+
+    struct Context {
+        let date: Date
+        let locale: String
+    }
+
+    var body: AnyContent {
+        Article {
+            ...
+        }
+        .environment(locale: context.locale)
+    }
+}
 ```

--- a/Instructions/Installation.md
+++ b/Instructions/Installation.md
@@ -1,10 +1,14 @@
 # Installation
 
-## Essential
+## Requirements
+
+The requirements are
+
+## Configuration
 
 ### Packages
 
-Add the packages as dependecies to your package.
+To use HTMLKit in your project, you have to add the packages as dependecies first. Be sure to add it to your desired targets as well.
 
 ```swift
 /// [Package.swift]
@@ -27,6 +31,21 @@ targets: [
     ...
 ```
 
-## Vapor 3
+From time to time you want to update the packages. You can do it, by changing the version tags manually and saving it. You find the current version tag in the [release history](https://github.com/vapor-community/HTMLKit/releases). We recommand to read the release description first, to understand the possible changes.
+
+### Import
+
+Use the import keyword to load the module in your project files.
+
+```swift
+/// [SimpleTemplate.swift]
+
+import HTMLKit
+...
+```
+
+## Compatibiltiy
+
+### Vapor 3
 
 Check the [provider](https://github.com/vapor-community/htmlkit-vapor-provider) to learn more about supporting Vapor 3.

--- a/Instructions/Overview.md
+++ b/Instructions/Overview.md
@@ -2,45 +2,49 @@
 
 The instructions will provide you with information how to integrate HTMLKit in your project and how you can use it to write HTML by using Swift. Keep in mind, that the instructions are mainly based on a use in a vapor project.
 
-If still things are unclear, dont hesitate to [open an issue](https://github.com/vapor-community/HTMLKit/issues) or [join the discussion](https://github.com/vapor-community/HTMLKit/discussions). Also you find us on the vapor discord server.
+If still things are unclear, dont hesitate to [open an issue](https://github.com/vapor-community/HTMLKit/issues) or [join the discussions](https://github.com/vapor-community/HTMLKit/discussions). Also you find us on the vapor discord server.
 
 ## Index
 
 1. [Installation](Instructions/Installation.md)
-    Informations about the installations.
+
+    This section explains how to integrate the library in your project.
 
 2. Essential
 
-    2.1 [Elements](Instructions/Essential/Elements.md)
-    Informations about the element definitions.
+    2.1 [Elements](Essential/Elements.md)
     
-    2.2 [Layouts](Instructions/Essential/Layouts.md)
-    Informations about the layout definitions.
+    This section gives an insight about the elements and how you can use it to write html.
     
-    2.3 [Context](Instructions/Essential/Context.md)
-    Informations about the context definition.
+    2.2 [Layouts](Essential/Layouts.md)
     
-    2.4 [Statements](Instructions/Essential/Statements.md)
-    Informations about the control flow.
+    This section gives an insight about the layouts and how you can use it to build a template system.
+    
+    2.3 [Context](Essential/Context.md)
+    
+    This section teaches you...
+    
+    2.4 [Statements](Essential/Statements.md)
+    
+    This section teaches you, how you can use statements for control flow.
 
 3. Features
 
-    3.1 [Localization](Instructions/Features/Localization.md)
-    Information, about Localization.
+    3.1 [Localization](Features/Localization.md)
     
-    3.2 [Conversion](Instructions/Features/Conversion.md)
-    Information, about Conversion.
+    3.2 [Conversion](Features/Conversion.md)
     
-    3.3 [Templating](Instructions/Features/Templating.md)
-    Information about Templateing.
+    3.3 [Templating](Features/Templating.md)
     
 
 4. Example
 
     4.1 [Code](https://github.com/vapor-community/HTMLKit/tree/main/Instructions/Example/Page)
+    
     Shows a code example.
     
     4.2 [Wiki](https://github.com/vapor-community/HTMLKit/wiki)
+    
     Informations about the public api.
 
-## References
+## License

--- a/Instructions/Overview.md
+++ b/Instructions/Overview.md
@@ -1,22 +1,46 @@
 # Overview
 
-Render dynamic HTML templates in a *typesafe* and **performant** way!
-By using Swift's powerful language features and a pre-rendering algorithm, HTMLKit will render insanely fast templates but also catch bugs that otherwise might occur with other templating options.
+The instructions will provide you with information how to integrate HTMLKit in your project and how you can use it to write HTML by using Swift. Keep in mind, that the instructions are mainly based on a use in a vapor project.
+
+If still things are unclear, dont hesitate to [open an issue](https://github.com/vapor-community/HTMLKit/issues) or [join the discussion](https://github.com/vapor-community/HTMLKit/discussions). Also you find us on the vapor discord server.
 
 ## Index
-1. Installation
+
+1. [Installation](Instructions/Installation.md)
+    Informations about the installations.
 
 2. Essential
-2.1 Elements
-2.2 Layouts
-2.3 Context
-2.4 Statements
+
+    2.1 [Elements](Instructions/Essential/Elements.md)
+    Informations about the element definitions.
+    
+    2.2 [Layouts](Instructions/Essential/Layouts.md)
+    Informations about the layout definitions.
+    
+    2.3 [Context](Instructions/Essential/Context.md)
+    Informations about the context definition.
+    
+    2.4 [Statements](Instructions/Essential/Statements.md)
+    Informations about the control flow.
 
 3. Features
-3.1 Localization
-3.2 Conversion
-3.3 Templating
+
+    3.1 [Localization](Instructions/Features/Localization.md)
+    Information, about Localization.
+    
+    3.2 [Conversion](Instructions/Features/Conversion.md)
+    Information, about Conversion.
+    
+    3.3 [Templating](Instructions/Features/Templating.md)
+    Information about Templateing.
+    
 
 4. Example
+
+    4.1 [Code](https://github.com/vapor-community/HTMLKit/tree/main/Instructions/Example/Page)
+    Shows a code example.
+    
+    4.2 [Wiki](https://github.com/vapor-community/HTMLKit/wiki)
+    Informations about the public api.
 
 ## References

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # HTMLKit
 
-Render dynamic HTML templates in a *typesafe* and **performant** way!
-By using Swift's powerful language features and a pre-rendering algorithm, HTMLKit will render insanely fast templates but also catch bugs that otherwise might occur with other templating options.
+Render dynamic HTML templates in a typesafe and performant way! By using Swift's powerful language features and a pre-rendering algorithm, HTMLKit will render insanely fast templates but also catch bugs that otherwise might occur with other templating options.
 
 ## Getting Started
 
 ### Installation
 
-Add the packages as dependecies to your package.
+Add the packages as dependecies and targets to your package file.
 
 ```swift
 /// [Package.swift]
@@ -32,9 +31,11 @@ targets: [
     ...
 ```
 
+Read the [installation instructions](https://github.com/vapor-community/HTMLKit/blob/main/Instructions/Installation.md) for more information.
+
 ### Definition
 
-Create a new file. Add the import and declare a new structure with the Protocol `Page`. Add some content to the `body` property. If you want to learn more about the definitions, take a look here.
+Create a new file in your project. Add the import at the top of your file and declare a new structure. Extend your structure by adding a [layout definition](https://github.com/vapor-community/HTMLKit/blob/main/Instructions/Essential/Layouts.md) to adopt the required properties and methods. Add your content to the `body` property.
 
 ```swift
 /// [SimplePage.swift]
@@ -66,19 +67,16 @@ struct SimplePage: Page {
 
 ### Implementation
 
-Add the import to your controller and call the structure in your handler. Use the `render(for:)` method to render the structure for the request.
+Call the structure you have created in your controller handler and use the render method to render the view for the request.
 
 ```swift
 /// [SimpleController.swift]
 
 ...
-/// 1. Add the import
-import HTMLKit
-
 final class SimpleController {
     ...
     func getPage(req: Request) throws -> EventLoopFuture<View> {
-        /// 2. Call the structure
+        /// 1. Call the structure
         return SimplePage().render(for: req)
     }
     ...
@@ -91,4 +89,10 @@ final class SimpleController {
 
 ### Conversion
 
+### Validation
+
 ## Resources
+
+### Instructions
+
+See the [instructions](https://github.com/vapor-community/HTMLKit/blob/main/Instructions/Overview.md) to learn more about the library and the features.

--- a/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
@@ -3412,6 +3412,11 @@ public protocol RoleAttribute: AnyAttribute {
     ///
     ///
     func role(_ value: String) -> Self
+    
+    /// The func adds
+    ///
+    ///
+    func role(_ value: Roles) -> Self
 }
 
 extension RoleAttribute {

--- a/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
@@ -3411,11 +3411,6 @@ public protocol RoleAttribute: AnyAttribute {
     /// The func adds
     ///
     ///
-    func role(_ value: String) -> Self
-    
-    /// The func adds
-    ///
-    ///
     func role(_ value: Roles) -> Self
 }
 

--- a/Sources/HTMLKit/External/Components.swift
+++ b/Sources/HTMLKit/External/Components.swift
@@ -38,7 +38,7 @@ public struct MetaTitle: Component {
         }
         IF(useTwitter) {
             Meta()
-                .name(.init(rawValue: "twitter:title")!)
+                .custom(key: "name", value: "twitter:title")
                 .content(self.title.rawValue)
         }
     }
@@ -68,7 +68,7 @@ public struct MetaDescription: Component {
         }
         IF(useTwitter) {
             Meta()
-                .name(.init(rawValue: "twitter:description")!)
+                .custom(key: "name", value: "twitter:description")
                 .content(self.description.rawValue)
         }
     }
@@ -151,7 +151,7 @@ public struct Viewport: Component {
     public var body: AnyContent {
         Meta()
             .name(.viewport)
-            .content("width=\(mode.width), initial-scale=\(internalScale)")
+            .content("width=\(self.mode.width), initial-scale=\(self.internalScale)")
     }
 }
 
@@ -170,9 +170,9 @@ public struct Author: Component {
         Meta()
             .name(.author)
             .content(self.author)
-        Unwrap(handle) { handle in
+        Unwrap(self.handle) { handle in
             Meta()
-                .name(.init(rawValue: "twitter:creator")!)
+                .custom(key: "name", value: "twitter:creator")
                 .content(handle)
         }
     }

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -168,6 +168,7 @@ extension Html: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Html {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -46,7 +46,7 @@ public struct Document: DocumentNode, BasicElement {
     
     public var content: String
     
-    public init(type: DocumentType) {
+    public init(type: Doctypes) {
         self.content = type.rawValue
     }
 }

--- a/Sources/HTMLKit/External/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/External/Elements/BasicElements.swift
@@ -171,6 +171,10 @@ extension Html: GlobalAttributes {
     public func role(_ value: String) -> Html {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Html {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Html {
         return mutate(spellcheck: condition)

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -297,6 +297,7 @@ extension Article: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Article {
         return mutate(role: value)
     }
@@ -483,6 +484,7 @@ extension Section: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Section {
         return mutate(role: value)
     }
@@ -669,6 +671,7 @@ extension Navigation: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Navigation {
         return mutate(role: value)
     }
@@ -855,6 +858,7 @@ extension Aside: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Aside {
         return mutate(role: value)
     }
@@ -1041,6 +1045,7 @@ extension Heading1: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Heading1 {
         return mutate(role: value)
     }
@@ -1237,7 +1242,8 @@ extension Heading2: GlobalAttributes {
     public func nonce(_ value: String) -> Heading2 {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Heading2 {
         return mutate(role: value)
     }
@@ -1435,6 +1441,7 @@ extension Heading3: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Heading3 {
         return mutate(role: value)
     }
@@ -1632,6 +1639,7 @@ extension Heading4: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Heading4 {
         return mutate(role: value)
     }
@@ -1829,6 +1837,7 @@ extension Heading5: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Heading5 {
         return mutate(role: value)
     }
@@ -2026,6 +2035,7 @@ extension Heading6: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Heading6 {
         return mutate(role: value)
     }
@@ -2223,6 +2233,7 @@ extension HeadingGroup: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> HeadingGroup {
         return mutate(role: value)
     }
@@ -2409,6 +2420,7 @@ extension Header: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Header {
         return mutate(role: value)
     }
@@ -2595,6 +2607,7 @@ extension Footer: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Footer {
         return mutate(role: value)
     }
@@ -2781,6 +2794,7 @@ extension Address: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Address {
         return mutate(role: value)
     }
@@ -2967,6 +2981,7 @@ extension Paragraph: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Paragraph {
         return mutate(role: value)
     }
@@ -3159,6 +3174,7 @@ extension HorizontalRule: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> HorizontalRule {
         return mutate(role: value)
     }
@@ -3345,6 +3361,7 @@ extension PreformattedText: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> PreformattedText {
         return mutate(role: value)
     }
@@ -3531,6 +3548,7 @@ extension Blockquote: GlobalAttributes, CiteAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Blockquote {
         return mutate(role: value)
     }
@@ -3732,6 +3750,7 @@ extension OrderedList: GlobalAttributes, ReversedAttribute, StartAttribute, Type
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> OrderedList {
         return mutate(role: value)
     }
@@ -3929,7 +3948,8 @@ extension UnorderedList: GlobalAttributes {
     public func nonce(_ value: String) -> UnorderedList {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> UnorderedList {
         return mutate(role: value)
     }
@@ -4115,7 +4135,8 @@ extension DescriptionList: GlobalAttributes {
     public func nonce(_ value: String) -> DescriptionList {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> DescriptionList {
         return mutate(role: value)
     }
@@ -4301,7 +4322,8 @@ extension Figure: GlobalAttributes {
     public func nonce(_ value: String) -> Figure {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Figure {
         return mutate(role: value)
     }
@@ -4488,6 +4510,7 @@ extension Anchor: GlobalAttributes, DownloadAttribute, ReferenceAttribute, Refer
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Anchor {
         return mutate(role: value)
     }
@@ -4725,6 +4748,7 @@ extension Emphasize: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Emphasize {
         return mutate(role: value)
     }
@@ -4911,6 +4935,7 @@ extension Strong: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Strong {
         return mutate(role: value)
     }
@@ -5097,6 +5122,7 @@ extension Small: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Small {
         return mutate(role: value)
     }
@@ -5294,6 +5320,7 @@ extension StrikeThrough: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> StrikeThrough {
         return mutate(role: value)
     }
@@ -5491,6 +5518,7 @@ extension Main: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Main {
         return mutate(role: value)
     }
@@ -5677,6 +5705,7 @@ extension Division: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Division {
         return mutate(role: value)
     }
@@ -5863,6 +5892,7 @@ extension Definition: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Definition {
         return mutate(role: value)
     }
@@ -6049,6 +6079,7 @@ extension Cite: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Cite {
         return mutate(role: value)
     }
@@ -6235,6 +6266,7 @@ extension ShortQuote: GlobalAttributes, CiteAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> ShortQuote {
         return mutate(role: value)
     }
@@ -6425,6 +6457,7 @@ extension Abbreviation: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Abbreviation {
         return mutate(role: value)
     }
@@ -6611,6 +6644,7 @@ extension Ruby: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Ruby {
         return mutate(role: value)
     }
@@ -6796,7 +6830,8 @@ extension Data: GlobalAttributes, ValueAttribute {
     public func nonce(_ value: String) -> Data {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Data {
         return mutate(role: value)
     }
@@ -6991,6 +7026,7 @@ extension Time: GlobalAttributes, DateTimeAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Time {
         return mutate(role: value)
     }
@@ -7181,6 +7217,7 @@ extension Code: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Code {
         return mutate(role: value)
     }
@@ -7367,6 +7404,7 @@ extension Variable: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Variable {
         return mutate(role: value)
     }
@@ -7552,7 +7590,8 @@ extension SampleOutput: GlobalAttributes {
     public func nonce(_ value: String) -> SampleOutput {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> SampleOutput {
         return mutate(role: value)
     }
@@ -7739,6 +7778,7 @@ extension KeyboardInput: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> KeyboardInput {
         return mutate(role: value)
     }
@@ -7925,6 +7965,7 @@ extension Subscript: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Subscript {
         return mutate(role: value)
     }
@@ -8111,6 +8152,7 @@ extension Superscript: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Superscript {
         return mutate(role: value)
     }
@@ -8297,6 +8339,7 @@ extension Italic: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Italic {
         return mutate(role: value)
     }
@@ -8494,6 +8537,7 @@ extension Bold: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Bold {
         return mutate(role: value)
     }
@@ -8691,6 +8735,7 @@ extension Underline: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Underline {
         return mutate(role: value)
     }
@@ -8888,6 +8933,7 @@ extension Mark: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Mark {
         return mutate(role: value)
     }
@@ -9074,6 +9120,7 @@ extension Bdi: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Bdi {
         return mutate(role: value)
     }
@@ -9255,6 +9302,7 @@ extension Bdo: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Bdo {
         return mutate(role: value)
     }
@@ -9441,6 +9489,7 @@ extension Span: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Span {
         return mutate(role: value)
     }
@@ -9622,6 +9671,7 @@ extension LineBreak: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> LineBreak {
         return mutate(role: value)
     }
@@ -9803,6 +9853,7 @@ extension WordBreak: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> WordBreak {
         return mutate(role: value)
     }
@@ -9989,6 +10040,7 @@ extension InsertedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> InsertedText {
         return mutate(role: value)
     }
@@ -10183,6 +10235,7 @@ extension DeletedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> DeletedText {
         return mutate(role: value)
     }
@@ -10376,7 +10429,8 @@ extension Picture: GlobalAttributes {
     public func nonce(_ value: String) -> Picture {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Picture {
         return mutate(role: value)
     }
@@ -10566,6 +10620,7 @@ extension Image: GlobalAttributes, AlternateAttribute, SourceAttribute, SizesAtt
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Image {
         return mutate(role: value)
     }
@@ -10776,6 +10831,7 @@ extension InlineFrame: GlobalAttributes, SourceAttribute, NameAttribute, WidthAt
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> InlineFrame {
         return mutate(role: value)
     }
@@ -10981,6 +11037,7 @@ extension Embed: GlobalAttributes, SourceAttribute, TypeAttribute, WidthAttribut
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Embed {
         return mutate(role: value)
     }
@@ -11187,6 +11244,7 @@ extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute,
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Object {
         return mutate(role: value)
     }
@@ -11401,6 +11459,7 @@ extension Video: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Video {
         return mutate(role: value)
     }
@@ -11615,6 +11674,7 @@ extension Audio: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Audio {
         return mutate(role: value)
     }
@@ -11821,6 +11881,7 @@ extension Map: GlobalAttributes, NameAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Map {
         return mutate(role: value)
     }
@@ -12023,6 +12084,7 @@ extension Form: GlobalAttributes, ActionAttribute, AutocompleteAttribute, Encodi
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Form {
         return mutate(role: value)
     }
@@ -12241,6 +12303,7 @@ extension DataList: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> DataList {
         return mutate(role: value)
     }
@@ -12427,6 +12490,7 @@ extension Output: GlobalAttributes, ForAttribute, FormAttribute, NameAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Output {
         return mutate(role: value)
     }
@@ -12628,7 +12692,8 @@ extension Progress: GlobalAttributes, ValueAttribute, MaximumValueAttribute {
     public func nonce(_ value: String) -> Progress {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Progress {
         return mutate(role: value)
     }
@@ -12827,6 +12892,7 @@ extension Meter: GlobalAttributes, ValueAttribute, MinimumValueAttribute, Maximu
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Meter {
         return mutate(role: value)
     }
@@ -13041,6 +13107,7 @@ extension Details: GlobalAttributes, OpenAttribute, ToggleEventAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Details {
         return mutate(role: value)
     }
@@ -13231,6 +13298,7 @@ extension Dialog: GlobalAttributes, OpenAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Dialog {
         return mutate(role: value)
     }
@@ -13428,7 +13496,8 @@ extension Script: GlobalAttributes, AsynchronouslyAttribute, ReferrerPolicyAttri
     public func nonce(_ value: String) -> Script {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Script {
         return mutate(role: value)
     }
@@ -13631,6 +13700,7 @@ extension NoScript: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> NoScript {
         return mutate(role: value)
     }
@@ -13817,6 +13887,7 @@ extension Template: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Template {
         return mutate(role: value)
     }
@@ -14003,6 +14074,7 @@ extension Canvas: GlobalAttributes, WidthAttribute, HeightAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Canvas {
         return mutate(role: value)
     }
@@ -14197,6 +14269,7 @@ extension Table: GlobalAttributes, WidthAttribute, HeightAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Table {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -300,6 +300,10 @@ extension Article: GlobalAttributes {
     public func role(_ value: String) -> Article {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Article {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Article {
         return mutate(spellcheck: condition)
@@ -481,6 +485,10 @@ extension Section: GlobalAttributes {
     
     public func role(_ value: String) -> Section {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Section {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Section {
@@ -664,6 +672,10 @@ extension Navigation: GlobalAttributes {
     public func role(_ value: String) -> Navigation {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Navigation {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Navigation {
         return mutate(spellcheck: condition)
@@ -846,6 +858,10 @@ extension Aside: GlobalAttributes {
     public func role(_ value: String) -> Aside {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Aside {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Aside {
         return mutate(spellcheck: condition)
@@ -1027,6 +1043,10 @@ extension Heading1: GlobalAttributes {
     
     public func role(_ value: String) -> Heading1 {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Heading1 {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Heading1 {
@@ -1221,6 +1241,10 @@ extension Heading2: GlobalAttributes {
     public func role(_ value: String) -> Heading2 {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Heading2 {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Heading2 {
         return mutate(spellcheck: condition)
@@ -1413,6 +1437,10 @@ extension Heading3: GlobalAttributes {
 
     public func role(_ value: String) -> Heading3 {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Heading3 {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Heading3 {
@@ -1607,6 +1635,10 @@ extension Heading4: GlobalAttributes {
     public func role(_ value: String) -> Heading4 {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Heading4 {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Heading4 {
         return mutate(spellcheck: condition)
@@ -1800,6 +1832,10 @@ extension Heading5: GlobalAttributes {
     public func role(_ value: String) -> Heading5 {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Heading5 {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Heading5 {
         return mutate(spellcheck: condition)
@@ -1992,6 +2028,10 @@ extension Heading6: GlobalAttributes {
 
     public func role(_ value: String) -> Heading6 {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Heading6 {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Heading6 {
@@ -2187,6 +2227,10 @@ extension HeadingGroup: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> HeadingGroup {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> HeadingGroup {
         return mutate(spellcheck: condition)
     }
@@ -2367,6 +2411,10 @@ extension Header: GlobalAttributes {
 
     public func role(_ value: String) -> Header {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Header {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Header {
@@ -2550,6 +2598,10 @@ extension Footer: GlobalAttributes {
     public func role(_ value: String) -> Footer {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Footer {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Footer {
         return mutate(spellcheck: condition)
@@ -2732,6 +2784,10 @@ extension Address: GlobalAttributes {
     public func role(_ value: String) -> Address {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Address {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Address {
         return mutate(spellcheck: condition)
@@ -2913,6 +2969,10 @@ extension Paragraph: GlobalAttributes {
 
     public func role(_ value: String) -> Paragraph {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Paragraph {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Paragraph {
@@ -3102,6 +3162,10 @@ extension HorizontalRule: GlobalAttributes {
     public func role(_ value: String) -> HorizontalRule {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> HorizontalRule {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> HorizontalRule {
         return mutate(spellcheck: condition)
@@ -3284,6 +3348,10 @@ extension PreformattedText: GlobalAttributes {
     public func role(_ value: String) -> PreformattedText {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> PreformattedText {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> PreformattedText {
         return mutate(spellcheck: condition)
@@ -3465,6 +3533,10 @@ extension Blockquote: GlobalAttributes, CiteAttribute {
 
     public func role(_ value: String) -> Blockquote {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Blockquote {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Blockquote {
@@ -3663,6 +3735,10 @@ extension OrderedList: GlobalAttributes, ReversedAttribute, StartAttribute, Type
     public func role(_ value: String) -> OrderedList {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> OrderedList {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> OrderedList {
         return mutate(spellcheck: condition)
@@ -3857,6 +3933,10 @@ extension UnorderedList: GlobalAttributes {
     public func role(_ value: String) -> UnorderedList {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> UnorderedList {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> UnorderedList {
         return mutate(spellcheck: condition)
@@ -4038,6 +4118,10 @@ extension DescriptionList: GlobalAttributes {
 
     public func role(_ value: String) -> DescriptionList {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> DescriptionList {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> DescriptionList {
@@ -4221,6 +4305,10 @@ extension Figure: GlobalAttributes {
     public func role(_ value: String) -> Figure {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Figure {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Figure {
         return mutate(spellcheck: condition)
@@ -4402,6 +4490,10 @@ extension Anchor: GlobalAttributes, DownloadAttribute, ReferenceAttribute, Refer
 
     public func role(_ value: String) -> Anchor {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Anchor {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Anchor {
@@ -4636,6 +4728,10 @@ extension Emphasize: GlobalAttributes {
     public func role(_ value: String) -> Emphasize {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Emphasize {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Emphasize {
         return mutate(spellcheck: condition)
@@ -4818,6 +4914,10 @@ extension Strong: GlobalAttributes {
     public func role(_ value: String) -> Strong {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Strong {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Strong {
         return mutate(spellcheck: condition)
@@ -4999,6 +5099,10 @@ extension Small: GlobalAttributes {
 
     public func role(_ value: String) -> Small {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Small {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Small {
@@ -5193,6 +5297,10 @@ extension StrikeThrough: GlobalAttributes {
     public func role(_ value: String) -> StrikeThrough {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> StrikeThrough {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> StrikeThrough {
         return mutate(spellcheck: condition)
@@ -5386,6 +5494,10 @@ extension Main: GlobalAttributes {
     public func role(_ value: String) -> Main {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Main {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Main {
         return mutate(spellcheck: condition)
@@ -5568,6 +5680,10 @@ extension Division: GlobalAttributes {
     public func role(_ value: String) -> Division {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Division {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Division {
         return mutate(spellcheck: condition)
@@ -5749,6 +5865,10 @@ extension Definition: GlobalAttributes {
 
     public func role(_ value: String) -> Definition {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Definition {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Definition {
@@ -5933,6 +6053,10 @@ extension Cite: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Cite {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Cite {
         return mutate(spellcheck: condition)
     }
@@ -6113,6 +6237,10 @@ extension ShortQuote: GlobalAttributes, CiteAttribute {
 
     public func role(_ value: String) -> ShortQuote {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> ShortQuote {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> ShortQuote {
@@ -6301,6 +6429,10 @@ extension Abbreviation: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Abbreviation {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Abbreviation {
         return mutate(spellcheck: condition)
     }
@@ -6481,6 +6613,10 @@ extension Ruby: GlobalAttributes {
 
     public func role(_ value: String) -> Ruby {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Ruby {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Ruby {
@@ -6663,6 +6799,10 @@ extension Data: GlobalAttributes, ValueAttribute {
 
     public func role(_ value: String) -> Data {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Data {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Data {
@@ -6854,6 +6994,10 @@ extension Time: GlobalAttributes, DateTimeAttribute {
     public func role(_ value: String) -> Time {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Time {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Time {
         return mutate(spellcheck: condition)
@@ -7040,6 +7184,10 @@ extension Code: GlobalAttributes {
     public func role(_ value: String) -> Code {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Code {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Code {
         return mutate(spellcheck: condition)
@@ -7221,6 +7369,10 @@ extension Variable: GlobalAttributes {
 
     public func role(_ value: String) -> Variable {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Variable {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Variable {
@@ -7404,6 +7556,10 @@ extension SampleOutput: GlobalAttributes {
     public func role(_ value: String) -> SampleOutput {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> SampleOutput {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> SampleOutput {
         return mutate(spellcheck: condition)
@@ -7585,6 +7741,10 @@ extension KeyboardInput: GlobalAttributes {
 
     public func role(_ value: String) -> KeyboardInput {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> KeyboardInput {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> KeyboardInput {
@@ -7769,6 +7929,10 @@ extension Subscript: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Subscript {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Subscript {
         return mutate(spellcheck: condition)
     }
@@ -7949,6 +8113,10 @@ extension Superscript: GlobalAttributes {
 
     public func role(_ value: String) -> Superscript {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Superscript {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Superscript {
@@ -8131,6 +8299,10 @@ extension Italic: GlobalAttributes {
 
     public func role(_ value: String) -> Italic {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Italic {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Italic {
@@ -8325,6 +8497,10 @@ extension Bold: GlobalAttributes {
     public func role(_ value: String) -> Bold {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Bold {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Bold {
         return mutate(spellcheck: condition)
@@ -8517,6 +8693,10 @@ extension Underline: GlobalAttributes {
 
     public func role(_ value: String) -> Underline {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Underline {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Underline {
@@ -8711,6 +8891,10 @@ extension Mark: GlobalAttributes {
     public func role(_ value: String) -> Mark {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Mark {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Mark {
         return mutate(spellcheck: condition)
@@ -8893,6 +9077,10 @@ extension Bdi: GlobalAttributes {
     public func role(_ value: String) -> Bdi {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Bdi {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Bdi {
         return mutate(spellcheck: condition)
@@ -9069,6 +9257,10 @@ extension Bdo: GlobalAttributes {
     
     public func role(_ value: String) -> Bdo {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Bdo {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Bdo {
@@ -9252,6 +9444,10 @@ extension Span: GlobalAttributes {
     public func role(_ value: String) -> Span {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Span {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Span {
         return mutate(spellcheck: condition)
@@ -9429,6 +9625,10 @@ extension LineBreak: GlobalAttributes {
     public func role(_ value: String) -> LineBreak {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> LineBreak {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> LineBreak {
         return mutate(spellcheck: condition)
@@ -9605,6 +9805,10 @@ extension WordBreak: GlobalAttributes {
 
     public func role(_ value: String) -> WordBreak {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> WordBreak {
+        return mutate(role: value.rawValue)
     }
     
     public func hasSpellCheck(_ condition: Bool) -> WordBreak {
@@ -9787,6 +9991,10 @@ extension InsertedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
 
     public func role(_ value: String) -> InsertedText {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> InsertedText {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> InsertedText {
@@ -9978,6 +10186,10 @@ extension DeletedText: GlobalAttributes, CiteAttribute, DateTimeAttribute {
     public func role(_ value: String) -> DeletedText {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> DeletedText {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> DeletedText {
         return mutate(spellcheck: condition)
@@ -10168,6 +10380,10 @@ extension Picture: GlobalAttributes {
     public func role(_ value: String) -> Picture {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Picture {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Picture {
         return mutate(spellcheck: condition)
@@ -10352,6 +10568,10 @@ extension Image: GlobalAttributes, AlternateAttribute, SourceAttribute, SizesAtt
     
     public func role(_ value: String) -> Image {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Image {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Image {
@@ -10560,6 +10780,10 @@ extension InlineFrame: GlobalAttributes, SourceAttribute, NameAttribute, WidthAt
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> InlineFrame {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> InlineFrame {
         return mutate(spellcheck: condition)
     }
@@ -10761,6 +10985,10 @@ extension Embed: GlobalAttributes, SourceAttribute, TypeAttribute, WidthAttribut
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Embed {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Embed {
         return mutate(spellcheck: condition)
     }
@@ -10961,6 +11189,10 @@ extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute,
 
     public func role(_ value: String) -> Object {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Object {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Object {
@@ -11173,6 +11405,10 @@ extension Video: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Video {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Video {
         return mutate(spellcheck: condition)
     }
@@ -11382,6 +11618,10 @@ extension Audio: GlobalAttributes, SourceAttribute, AutoplayAttribute, LoopAttri
     public func role(_ value: String) -> Audio {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Audio {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Audio {
         return mutate(spellcheck: condition)
@@ -11584,6 +11824,10 @@ extension Map: GlobalAttributes, NameAttribute {
     public func role(_ value: String) -> Map {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Map {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Map {
         return mutate(spellcheck: condition)
@@ -11781,6 +12025,10 @@ extension Form: GlobalAttributes, ActionAttribute, AutocompleteAttribute, Encodi
 
     public func role(_ value: String) -> Form {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Form {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Form {
@@ -11996,6 +12244,10 @@ extension DataList: GlobalAttributes {
     public func role(_ value: String) -> DataList {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> DataList {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> DataList {
         return mutate(spellcheck: condition)
@@ -12177,6 +12429,10 @@ extension Output: GlobalAttributes, ForAttribute, FormAttribute, NameAttribute {
 
     public func role(_ value: String) -> Output {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Output {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Output {
@@ -12376,6 +12632,10 @@ extension Progress: GlobalAttributes, ValueAttribute, MaximumValueAttribute {
     public func role(_ value: String) -> Progress {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Progress {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Progress {
         return mutate(spellcheck: condition)
@@ -12569,6 +12829,10 @@ extension Meter: GlobalAttributes, ValueAttribute, MinimumValueAttribute, Maximu
 
     public func role(_ value: String) -> Meter {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Meter {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Meter {
@@ -12781,6 +13045,10 @@ extension Details: GlobalAttributes, OpenAttribute, ToggleEventAttribute {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Details {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Details {
         return mutate(spellcheck: condition)
     }
@@ -12967,6 +13235,10 @@ extension Dialog: GlobalAttributes, OpenAttribute {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Dialog {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Dialog {
         return mutate(spellcheck: condition)
     }
@@ -13159,6 +13431,10 @@ extension Script: GlobalAttributes, AsynchronouslyAttribute, ReferrerPolicyAttri
 
     public func role(_ value: String) -> Script {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Script {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Script {
@@ -13359,6 +13635,10 @@ extension NoScript: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> NoScript {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> NoScript {
         return mutate(spellcheck: condition)
     }
@@ -13539,6 +13819,10 @@ extension Template: GlobalAttributes {
 
     public func role(_ value: String) -> Template {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Template {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Template {
@@ -13721,6 +14005,10 @@ extension Canvas: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func role(_ value: String) -> Canvas {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Canvas {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Canvas {
@@ -13911,6 +14199,10 @@ extension Table: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func role(_ value: String) -> Table {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Table {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Table {

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -10785,7 +10785,7 @@ extension Embed: GlobalAttributes, SourceAttribute, TypeAttribute, WidthAttribut
         return mutate(source: value)
     }
     
-    public func type(_ value: MediaType) -> Embed {
+    public func type(_ value: Medias) -> Embed {
         return mutate(type: value.rawValue)
     }
     
@@ -10987,7 +10987,7 @@ extension Object: GlobalAttributes, DataAttribute, TypeAttribute, NameAttribute,
         return mutate(data: value)
     }
     
-    public func type(_ value: MediaType) -> Object {
+    public func type(_ value: Medias) -> Object {
         return mutate(type: value.rawValue)
     }
     
@@ -13193,7 +13193,7 @@ extension Script: GlobalAttributes, AsynchronouslyAttribute, ReferrerPolicyAttri
         return mutate(source: value)
     }
     
-    public func type(_ value: MediaType) -> Script {
+    public func type(_ value: Medias) -> Script {
         return mutate(type: value.rawValue)
     }
     

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -131,6 +131,10 @@ extension TermName: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> TermName {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> TermName {
         return mutate(spellcheck: condition)
     }
@@ -313,6 +317,10 @@ extension TermDefinition: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> TermDefinition {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> TermDefinition {
         return mutate(spellcheck: condition)
     }

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -127,6 +127,7 @@ extension TermName: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TermName {
         return mutate(role: value)
     }
@@ -312,7 +313,8 @@ extension TermDefinition: GlobalAttributes {
     public func nonce(_ value: String) -> TermDefinition {
         return mutate(nonce: value)
     }
-
+    
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TermDefinition {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -122,6 +122,7 @@ extension FigureCaption: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> FigureCaption {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -125,6 +125,10 @@ extension FigureCaption: GlobalAttributes {
     public func role(_ value: String) -> FigureCaption {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> FigureCaption {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> FigureCaption {
         return mutate(spellcheck: condition)

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -119,6 +119,10 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
     public func role(_ value: String) -> Input {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Input {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Input {
         return mutate(spellcheck: condition)
@@ -413,6 +417,10 @@ extension Label: GlobalAttributes, ForAttribute {
     public func role(_ value: String) -> Label {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Label {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Label {
         return mutate(spellcheck: condition)
@@ -609,6 +617,10 @@ extension Select: GlobalAttributes, AutocompleteAttribute, DisabledAttribute, Fo
 
     public func role(_ value: String) -> Select {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Select {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Select {
@@ -823,6 +835,10 @@ extension TextArea: GlobalAttributes, AutocompleteAttribute, ColumnsAttribute, D
 
     public func role(_ value: String) -> TextArea {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> TextArea {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> TextArea {
@@ -1062,6 +1078,10 @@ extension Button: GlobalAttributes, DisabledAttribute, FormAttribute, FormAction
     public func role(_ value: String) -> Button {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Button {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Button {
         return mutate(spellcheck: condition)
@@ -1286,6 +1306,10 @@ extension Fieldset: GlobalAttributes, DisabledAttribute, FormAttribute, NameAttr
 
     public func role(_ value: String) -> Fieldset {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Fieldset {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Fieldset {

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -116,6 +116,7 @@ extension Input: GlobalAttributes, AcceptAttribute, AlternateAttribute, Autocomp
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Input {
         return mutate(role: value)
     }
@@ -414,6 +415,7 @@ extension Label: GlobalAttributes, ForAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Label {
         return mutate(role: value)
     }
@@ -615,6 +617,7 @@ extension Select: GlobalAttributes, AutocompleteAttribute, DisabledAttribute, Fo
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Select {
         return mutate(role: value)
     }
@@ -833,6 +836,7 @@ extension TextArea: GlobalAttributes, AutocompleteAttribute, ColumnsAttribute, D
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TextArea {
         return mutate(role: value)
     }
@@ -1075,6 +1079,7 @@ extension Button: GlobalAttributes, DisabledAttribute, FormAttribute, FormAction
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Button {
         return mutate(role: value)
     }
@@ -1304,6 +1309,7 @@ extension Fieldset: GlobalAttributes, DisabledAttribute, FormAttribute, NameAttr
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Fieldset {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -521,11 +521,11 @@ extension Meta: GlobalAttributes, ContentAttribute, NameAttribute, PropertyAttri
         return mutate(content: value.rawValue)
     }
     
-    public func name(_ value: NameType) -> Meta {
+    public func name(_ value: Names) -> Meta {
         return mutate(name: value.rawValue)
     }
     
-    public func name(_ value: TemplateValue<NameType>) -> Meta {
+    public func name(_ value: TemplateValue<Names>) -> Meta {
         return mutate(name: value.rawValue)
     }
     
@@ -728,7 +728,7 @@ extension Style: GlobalAttributes, TypeAttribute, MediaAttribute, LoadEventAttri
         return mutate(translate: value)
     }
 
-    public func type(_ value: MediaType) -> Style {
+    public func type(_ value: Medias) -> Style {
         return mutate(type: value.rawValue)
     }
     
@@ -949,7 +949,7 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
         return mutate(sizes: size)
     }
     
-    public func type(_ value: MediaType) -> Link {
+    public func type(_ value: Medias) -> Link {
         return mutate(type: value.rawValue)
     }
     

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -119,6 +119,7 @@ extension Title: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Title {
         return mutate(role: value)
     }
@@ -303,6 +304,7 @@ extension Base: GlobalAttributes, ReferenceAttribute, TargetAttribute {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Base {
         return mutate(role: value)
     }
@@ -497,6 +499,7 @@ extension Meta: GlobalAttributes, ContentAttribute, NameAttribute, PropertyAttri
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Meta {
         return mutate(role: value)
     }
@@ -716,6 +719,7 @@ extension Style: GlobalAttributes, TypeAttribute, MediaAttribute, LoadEventAttri
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Style {
         return mutate(role: value)
     }
@@ -913,6 +917,7 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Link {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/External/Elements/HeadElements.swift
@@ -123,6 +123,10 @@ extension Title: GlobalAttributes {
         return mutate(role: value)
     }
     
+    public func role(_ value: Roles) -> Title {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Title {
         return mutate(spellcheck: condition)
     }
@@ -301,6 +305,10 @@ extension Base: GlobalAttributes, ReferenceAttribute, TargetAttribute {
     
     public func role(_ value: String) -> Base {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Base {
+        return mutate(role: value.rawValue)
     }
     
     public func hasSpellCheck(_ condition: Bool) -> Base {
@@ -491,6 +499,10 @@ extension Meta: GlobalAttributes, ContentAttribute, NameAttribute, PropertyAttri
     
     public func role(_ value: String) -> Meta {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Meta {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Meta {
@@ -708,6 +720,10 @@ extension Style: GlobalAttributes, TypeAttribute, MediaAttribute, LoadEventAttri
         return mutate(role: value)
     }
     
+    public func role(_ value: Roles) -> Style {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Style {
         return mutate(spellcheck: condition)
     }
@@ -899,6 +915,10 @@ extension Link: GlobalAttributes, ReferenceAttribute, ReferenceLanguageAttribute
     
     public func role(_ value: String) -> Link {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Link {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Link {

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -117,6 +117,7 @@ extension Head: GlobalAttributes {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Head {
         return mutate(role: value)
     }
@@ -339,6 +340,7 @@ extension Body: GlobalAttributes, AfterPrintEventAttribute, BeforePrintEventAttr
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Body {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -121,6 +121,10 @@ extension Head: GlobalAttributes {
         return mutate(role: value)
     }
     
+    public func role(_ value: Roles) -> Head {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Head {
         return mutate(spellcheck: condition)
     }
@@ -337,6 +341,10 @@ extension Body: GlobalAttributes, AfterPrintEventAttribute, BeforePrintEventAttr
     
     public func role(_ value: String) -> Body {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Body {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Body {

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -122,6 +122,7 @@ extension OptionGroup: GlobalAttributes, DisabledAttribute, LabelAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> OptionGroup {
         return mutate(role: value)
     }
@@ -316,6 +317,7 @@ extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttr
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Option {
         return mutate(role: value)
     }
@@ -520,6 +522,7 @@ extension Legend: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Legend {
         return mutate(role: value)
     }
@@ -706,6 +709,7 @@ extension Summary: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Summary {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -125,6 +125,10 @@ extension OptionGroup: GlobalAttributes, DisabledAttribute, LabelAttribute {
     public func role(_ value: String) -> OptionGroup {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> OptionGroup {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> OptionGroup {
         return mutate(spellcheck: condition)
@@ -314,6 +318,10 @@ extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttr
 
     public func role(_ value: String) -> Option {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Option {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Option {
@@ -516,6 +524,10 @@ extension Legend: GlobalAttributes {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> Legend {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> Legend {
         return mutate(spellcheck: condition)
     }
@@ -696,6 +708,10 @@ extension Summary: GlobalAttributes {
 
     public func role(_ value: String) -> Summary {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Summary {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Summary {

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -122,6 +122,7 @@ extension ListItem: GlobalAttributes, ValueAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> ListItem {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -126,6 +126,10 @@ extension ListItem: GlobalAttributes, ValueAttribute {
         return mutate(role: value)
     }
 
+    public func role(_ value: Roles) -> ListItem {
+        return mutate(role: value.rawValue)
+    }
+    
     public func hasSpellCheck(_ condition: Bool) -> ListItem {
         return mutate(spellcheck: condition)
     }

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -120,6 +120,10 @@ extension Area: GlobalAttributes, AlternateAttribute, CoordinatesAttribute, Shap
     public func role(_ value: String) -> Area {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Area {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Area {
         return mutate(spellcheck: condition)

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -117,6 +117,7 @@ extension Area: GlobalAttributes, AlternateAttribute, CoordinatesAttribute, Shap
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Area {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -136,7 +136,7 @@ extension Source: GlobalAttributes, TypeAttribute, SourceAttribute, SizesAttribu
         return mutate(translate: value)
     }
 
-    public func type(_ value: MediaType) -> Source {
+    public func type(_ value: Medias) -> Source {
         return mutate(type: value.rawValue)
     }
     

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -112,6 +112,7 @@ extension Source: GlobalAttributes, TypeAttribute, SourceAttribute, SizesAttribu
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Source {
         return mutate(role: value)
     }
@@ -317,6 +318,7 @@ extension Track: GlobalAttributes, KindAttribute, SourceAttribute, LabelAttribut
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Track {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/External/Elements/MediaElements.swift
@@ -115,6 +115,10 @@ extension Source: GlobalAttributes, TypeAttribute, SourceAttribute, SizesAttribu
     public func role(_ value: String) -> Source {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Source {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Source {
         return mutate(spellcheck: condition)
@@ -315,6 +319,10 @@ extension Track: GlobalAttributes, KindAttribute, SourceAttribute, LabelAttribut
     
     public func role(_ value: String) -> Track {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> Track {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> Track {

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -112,6 +112,7 @@ extension Parameter: GlobalAttributes, NameAttribute, ValueAttribute {
         return mutate(nonce: value)
     }
     
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Parameter {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/External/Elements/ObjectElements.swift
@@ -115,6 +115,10 @@ extension Parameter: GlobalAttributes, NameAttribute, ValueAttribute {
     public func role(_ value: String) -> Parameter {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Parameter {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Parameter {
         return mutate(spellcheck: condition)

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -130,6 +130,10 @@ extension RubyText: GlobalAttributes {
     public func role(_ value: String) -> RubyText {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> RubyText {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> RubyText {
         return mutate(spellcheck: condition)
@@ -311,6 +315,10 @@ extension RubyPronunciation: GlobalAttributes {
 
     public func role(_ value: String) -> RubyPronunciation {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> RubyPronunciation {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> RubyPronunciation {

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -127,6 +127,7 @@ extension RubyText: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> RubyText {
         return mutate(role: value)
     }
@@ -313,6 +314,7 @@ extension RubyPronunciation: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> RubyPronunciation {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -160,6 +160,10 @@ extension Caption: GlobalAttributes {
     public func role(_ value: String) -> Caption {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Caption {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Caption {
         return mutate(spellcheck: condition)
@@ -341,6 +345,10 @@ extension ColumnGroup: GlobalAttributes, SpanAttribute {
 
     public func role(_ value: String) -> ColumnGroup {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> ColumnGroup {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> ColumnGroup {
@@ -528,6 +536,10 @@ extension Column: GlobalAttributes, SpanAttribute {
     public func role(_ value: String) -> Column {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> Column {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> Column {
         return mutate(spellcheck: condition)
@@ -713,6 +725,10 @@ extension TableBody: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func role(_ value: String) -> TableBody {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> TableBody {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> TableBody {
@@ -904,6 +920,10 @@ extension TableHead: GlobalAttributes, WidthAttribute, HeightAttribute {
     public func role(_ value: String) -> TableHead {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> TableHead {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> TableHead {
         return mutate(spellcheck: condition)
@@ -1094,6 +1114,10 @@ extension TableFoot: GlobalAttributes {
     public func role(_ value: String) -> TableFoot {
         return mutate(role: value)
     }
+    
+    public func role(_ value: Roles) -> TableFoot {
+        return mutate(role: value.rawValue)
+    }
 
     public func hasSpellCheck(_ condition: Bool) -> TableFoot {
         return mutate(spellcheck: condition)
@@ -1275,6 +1299,10 @@ extension TableRow: GlobalAttributes, WidthAttribute, HeightAttribute {
 
     public func role(_ value: String) -> TableRow {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> TableRow {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> TableRow {
@@ -1465,6 +1493,10 @@ extension DataCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, Hea
 
     public func role(_ value: String) -> DataCell {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> DataCell {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> DataCell {
@@ -1659,6 +1691,10 @@ extension HeaderCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, H
 
     public func role(_ value: String) -> HeaderCell {
         return mutate(role: value)
+    }
+    
+    public func role(_ value: Roles) -> HeaderCell {
+        return mutate(role: value.rawValue)
     }
 
     public func hasSpellCheck(_ condition: Bool) -> HeaderCell {

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -157,6 +157,7 @@ extension Caption: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Caption {
         return mutate(role: value)
     }
@@ -343,6 +344,7 @@ extension ColumnGroup: GlobalAttributes, SpanAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> ColumnGroup {
         return mutate(role: value)
     }
@@ -533,6 +535,7 @@ extension Column: GlobalAttributes, SpanAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> Column {
         return mutate(role: value)
     }
@@ -723,6 +726,7 @@ extension TableBody: GlobalAttributes, WidthAttribute, HeightAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TableBody {
         return mutate(role: value)
     }
@@ -917,6 +921,7 @@ extension TableHead: GlobalAttributes, WidthAttribute, HeightAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TableHead {
         return mutate(role: value)
     }
@@ -1111,6 +1116,7 @@ extension TableFoot: GlobalAttributes {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TableFoot {
         return mutate(role: value)
     }
@@ -1297,6 +1303,7 @@ extension TableRow: GlobalAttributes, WidthAttribute, HeightAttribute {
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> TableRow {
         return mutate(role: value)
     }
@@ -1491,6 +1498,7 @@ extension DataCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, Hea
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> DataCell {
         return mutate(role: value)
     }
@@ -1689,6 +1697,7 @@ extension HeaderCell: GlobalAttributes, ColumnSpanAttribute, RowSpanAttribute, H
         return mutate(nonce: value)
     }
 
+    @available(*, deprecated, message: "use role(_ value: Roles) instead")
     public func role(_ value: String) -> HeaderCell {
         return mutate(role: value)
     }

--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -492,3 +492,91 @@ public enum Equivalent: String {
     case `default` = "default-style"
     case refresh = "refresh"
 }
+
+/// ## Description
+/// The type is for
+///
+/// ## References
+///
+public enum Roles: String {
+    
+    case alert
+    case alertDialog = "alertdialog"
+    case application
+    case article
+    case banner
+    case button
+    case cell
+    case checkbox
+    case columnHeader = "columnheader"
+    case combobox
+    case command
+    case comment
+    case complementary
+    case composite
+    case contentInfo = "contentinfo"
+    case definition
+    case dialog
+    case directory
+    case document
+    case feed
+    case figure
+    case form
+    case grid
+    case gridCell = "gridcell"
+    case group
+    case heading
+    case img
+    case input
+    case landmark
+    case list
+    case listBox = "listbox"
+    case listItem = "listitem"
+    case log
+    case main
+    case mark
+    case marquee
+    case math
+    case menu
+    case menuBar = "menubar"
+    case menuItem = "menuitem"
+    case menuItemCheckbox = "menuitemcheckbox"
+    case menuItemRadio = "menuitemradio"
+    case meter
+    case navigation
+    case none
+    case note
+    case option
+    case presentation
+    case radio
+    case range
+    case region
+    case roleType = "roletype"
+    case row
+    case rowGroup = "rowgroup"
+    case rowHeader = "rowheader"
+    case scrollbar
+    case search
+    case searchBox = "searchbox"
+    case sectionHead = "sectionhead"
+    case select
+    case separator
+    case status
+    case structure
+    case suggestion
+    case `switch`
+    case tab
+    case table
+    case tabList = "tablist"
+    case tabPanel = "tabpanel"
+    case term
+    case textbox
+    case timer
+    case toolbar
+    case tooltip
+    case tree
+    case treeGrid = "treegrid"
+    case treeItem = "treeitem"
+    case widget
+    case window
+}

--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -13,23 +13,14 @@
 ///
 /// ## References
 ///
-public struct NameType: RawRepresentable {
+public enum NameType: String {
     
-    public var rawValue: String
-    
-    public init?(rawValue: String) {
-        self.rawValue = rawValue
-    }    
-}
-
-extension NameType {
-    
-    static let author = NameType(rawValue: "author")!
-    static let description = NameType(rawValue: "description")!
-    static let generator = NameType(rawValue: "generator")!
-    static let keywords = NameType(rawValue: "keywords")!
-    static let viewport = NameType(rawValue: "viewport")!
-    static let applicationName = NameType(rawValue: "application-name")!
+    case author = "author"
+    case description = "description"
+    case generator = "generator"
+    case keywords = "keywords"
+    case viewport = "viewport"
+    case applicationName = "application-name"
 }
 
 /// ## Description
@@ -390,24 +381,15 @@ public enum Direction: String {
 ///
 /// ## References
 ///
-public struct MediaType: RawRepresentable {
+public enum MediaType: String {
     
-    public var rawValue: String
-    
-    public init?(rawValue: String) {
-        self.rawValue = rawValue
-    }
-}
-
-extension MediaType {
-    
-    static let html = MediaType(rawValue: "text/html")!
-    static let css = MediaType(rawValue: "text/css")!
-    static let ogg = MediaType(rawValue: "video/ogg")!
-    static let mp4 = MediaType(rawValue: "video/mp4")!
-    static let webm = MediaType(rawValue: "video/webm")!
-    static let mpeg = MediaType(rawValue: "audio/mpeg")!
-    static let javascript = MediaType(rawValue: "application/javascript")!
+    case html = "text/html"
+    case css = "text/css"
+    case ogg = "video/ogg"
+    case mp4 = "video/mp4"
+    case webm = "video/webm"
+    case mpeg = "audio/mpeg"
+    case javascript = "application/javascript"
 }
 
 /// ## Description
@@ -491,21 +473,12 @@ public enum Capitalization: String {
 ///
 /// ## References
 ///
-public struct Charset: RawRepresentable {
+public enum Charset: String {
     
-    public var rawValue: String
-    
-    public init?(rawValue: String) {
-        self.rawValue = rawValue
-    }
-}
-
-extension Charset {
-    
-    static let utf8 = Charset(rawValue: "UTF-8")!
-    static let utf16 = Charset(rawValue: "UTF-16")!
-    static let ansi = Charset(rawValue: "Windows-1252")!
-    static let iso = Charset(rawValue: "ISO-8859-1")!
+    case utf8 = "utf-8"
+    case utf16 = "utf-16"
+    case ansi = "windows-1252"
+    case iso = "iso-8859-1"
 }
 
 /// ## Description
@@ -513,18 +486,9 @@ extension Charset {
 ///
 /// ## References
 ///
-public struct Equivalent: RawRepresentable {
+public enum Equivalent: String {
     
-    public var rawValue: String
-    
-    public init?(rawValue: String) {
-        self.rawValue = rawValue
-    }
-}
-
-extension Equivalent {
-    
-    static let content = Equivalent(rawValue: "content-type")!
-    static let `default` = Equivalent(rawValue: "default-style")!
-    static let refresh = Equivalent(rawValue: "refresh")!
+    case content = "content-type"
+    case `default` = "default-style"
+    case refresh = "refresh"
 }

--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -13,7 +13,7 @@
 ///
 /// ## References
 ///
-public enum NameType: String {
+public enum Names: String {
     
     case author = "author"
     case description = "description"
@@ -381,7 +381,7 @@ public enum Direction: String {
 ///
 /// ## References
 ///
-public enum MediaType: String {
+public enum Medias: String {
     
     case html = "text/html"
     case css = "text/css"
@@ -411,7 +411,7 @@ public enum Marker: String {
 ///
 /// ## References
 ///
-public enum DocumentType: String {
+public enum Doctypes: String {
         
     case html5 = "html"
     case html4Strict = #"HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd""#

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -262,7 +262,7 @@ public class Converter {
         case "reversed":
             EmptyProperty(node: attribute).build()
         case "role":
-            ValueProperty(node: attribute).build()
+            TypeProperty<Roles>(node: attribute).build()
         case "rows":
             ValueProperty(node: attribute).build()
         case "rowspan":

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -300,7 +300,7 @@ public class Converter {
         case "property":
             TypeProperty<Graphs>(node: attribute).build()
         default:
-            "attribute is not listed. contact the author"
+            CustomProperty(node: attribute).build()
         }
     }
     

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -68,7 +68,7 @@ public class Converter {
             
             if let dtd = document.dtd {
                 
-                let layout = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root).build()
+                let layout = PageLayout<Doctypes>(name: fileName, doctype: dtd, root: root).build()
                 
                 print(layout)
                 
@@ -83,7 +83,7 @@ public class Converter {
             
             if let dtd = document.dtd {
                 
-                let layout = PageLayout<DocumentType>(name: fileName, doctype: dtd, root: root).build()
+                let layout = PageLayout<Doctypes>(name: fileName, doctype: dtd, root: root).build()
                 
                 try layout.write(to: file.deletingPathExtension().appendingPathExtension("swift"),
                               atomically: true,
@@ -225,7 +225,7 @@ public class Converter {
                 
                 switch parent.localName {
                 case "meta":
-                    TypeProperty<NameType>(node: attribute).build()
+                    TypeProperty<Names>(node: attribute).build()
                 default:
                     ValueProperty(node: attribute).build()
                 }
@@ -309,11 +309,11 @@ public class Converter {
                 case "button":
                     TypeProperty<Buttons>(node: attribute).build()
                 case "link":
-                    TypeProperty<MediaType>(node: attribute).build()
+                    TypeProperty<Medias>(node: attribute).build()
                 case "script":
-                    TypeProperty<MediaType>(node: attribute).build()
+                    TypeProperty<Medias>(node: attribute).build()
                 case "audio":
-                    TypeProperty<MediaType>(node: attribute).build()
+                    TypeProperty<Medias>(node: attribute).build()
                 default:
                     ValueProperty(node: attribute).build()
                 }

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -299,6 +299,10 @@ public class Converter {
             TypeProperty<Wrapping>(node: attribute).build()
         case "property":
             TypeProperty<Graphs>(node: attribute).build()
+        case "charset":
+            TypeProperty<Charset>(node: attribute).build()
+        case "http-equiv":
+            TypeProperty<Equivalent>(node: attribute).build()
         default:
             CustomProperty(node: attribute).build()
         }

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -220,7 +220,17 @@ public class Converter {
         case "muted":
             EmptyProperty(node: attribute).build()
         case "name":
-            ValueProperty(node: attribute).build()
+            
+            if let parent = attribute.parent {
+                
+                switch parent.localName {
+                case "meta":
+                    TypeProperty<NameType>(node: attribute).build()
+                default:
+                    ValueProperty(node: attribute).build()
+                }
+            }
+            
         case "nonce":
             ValueProperty(node: attribute).build()
         case "novalidate":
@@ -290,7 +300,25 @@ public class Converter {
         case "translate":
             ValueProperty(node: attribute).build()
         case "type":
-            TypeProperty<Inputs>(node: attribute).build()
+
+            if let parent = attribute.parent {
+                
+                switch parent.localName {
+                case "input":
+                    TypeProperty<Inputs>(node: attribute).build()
+                case "button":
+                    TypeProperty<Buttons>(node: attribute).build()
+                case "link":
+                    TypeProperty<MediaType>(node: attribute).build()
+                case "script":
+                    TypeProperty<MediaType>(node: attribute).build()
+                case "audio":
+                    TypeProperty<MediaType>(node: attribute).build()
+                default:
+                    ValueProperty(node: attribute).build()
+                }
+            }
+            
         case "value":
             ValueProperty(node: attribute).build()
         case "width":

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -400,7 +400,7 @@ internal struct TypeProperty<T: RawRepresentable>{
             return nil
         }
 
-        if let type = T(rawValue: value as! T.RawValue) {
+        if let type = T(rawValue: value.lowercased() as! T.RawValue) {
             return ".\(type)"
         }
         

--- a/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Stencils.swift
@@ -437,3 +437,38 @@ internal struct TypeProperty<T: RawRepresentable>{
         }
     }
 }
+
+@available(macOS 11.0, *)
+internal struct CustomProperty {
+    
+    private var name: String? {
+        
+        guard let name = node.name else {
+            return nil
+        }
+        
+        return name
+    }
+    
+    private var value: String? {
+        
+        guard let value = node.stringValue else {
+            return nil
+        }
+        
+        return value
+    }
+    
+    private let node: XMLNode
+    
+    internal init(node: XMLNode) {
+        self.node = node
+    }
+    
+    @StringBuilder internal func build() -> String {
+
+        if let name = name {
+            ".custom(key: \"\(name)\", value: \"\(value ?? "")\")\n"
+        }
+    }
+}

--- a/Tests/HTMLKitTests/Conversion/index.html
+++ b/Tests/HTMLKitTests/Conversion/index.html
@@ -3,6 +3,7 @@
     <!--This is an example-->
     <head>
         <title>test</title>
+        <meta charset="utf-8" />
     </head>
     <body>
         <h1 class="class">headline</h1>

--- a/Tests/HTMLKitTests/PerformanceTests.swift
+++ b/Tests/HTMLKitTests/PerformanceTests.swift
@@ -77,7 +77,7 @@ final class PerformanceTests: XCTestCase {
                         }
                         .id("test")
                         .class("class")
-                        .role("role")
+                        .role(.heading)
                     }
                     Main {
                         Article {
@@ -86,12 +86,12 @@ final class PerformanceTests: XCTestCase {
                             }
                             .id("test")
                             .class("class")
-                            .role("role")
+                            .role(.heading)
                         }
                     }
                     .id("test")
                     .class("class")
-                    .role("role")
+                    .role(.main)
                 }
             }
         }

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -95,7 +95,6 @@ final class RenderingTests: XCTestCase {
             Paragraph {
                 "text"
             }
-            .role("role")
             .class("class")
         } 
         
@@ -115,7 +114,6 @@ final class RenderingTests: XCTestCase {
             Paragraph {
                 "text"
             }
-            .role("ro_le")
             .class("cl_ass")
         }
         
@@ -134,7 +132,6 @@ final class RenderingTests: XCTestCase {
             Paragraph {
                 "text"
             }
-            .role("ro-le")
             .class("cl-ass")
         }
         
@@ -174,7 +171,6 @@ final class RenderingTests: XCTestCase {
             Paragraph {
                 "text"
             }
-            .role("role")
             .class("cl'ass")
         }
         

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -102,7 +102,7 @@ final class RenderingTests: XCTestCase {
         
         XCTAssertEqual(try renderer.render(raw: TestPage.self),
                        """
-                       <p role="role" class="class">text</p>
+                       <p class="class">text</p>
                        """
         )
     }
@@ -121,7 +121,7 @@ final class RenderingTests: XCTestCase {
         
         XCTAssertEqual(try renderer.render(raw: TestPage.self),
                        """
-                       <p role="ro_le" class="cl_ass">text</p>
+                       <p class="cl_ass">text</p>
                        """
         )
     }
@@ -139,7 +139,7 @@ final class RenderingTests: XCTestCase {
         
         XCTAssertEqual(try renderer.render(raw: TestPage.self),
                        """
-                       <p role="ro-le" class="cl-ass">text</p>
+                       <p class="cl-ass">text</p>
                        """
         )
     }
@@ -178,7 +178,7 @@ final class RenderingTests: XCTestCase {
         
         XCTAssertEqual(try renderer.render(raw: TestPage.self),
                        """
-                       <p role="role" class="cl'ass">text</p>
+                       <p class="cl'ass">text</p>
                        """
         )
     }


### PR DESCRIPTION
This merge will extend the converter by adding the missing attributes from the previous fix and adds differentiation, when an attribute expects a different content type.

And it will undo the RawRepresentable on the types. Now if there is attribute or option missing, you can use the custom property (#59), I have mentioned in the previous fix. 

I think the custom property covers it in the future, so we don't have to look for solution to add custom options.

This merge will also add a new role type and some content to the instructions.