### PR TITLE
Fix deprecated rename issue

### DIFF
--- a/Sources/HTMLKit/Compatibility/Deprecations.swift
+++ b/Sources/HTMLKit/Compatibility/Deprecations.swift
@@ -13,10 +13,10 @@ public protocol HTMLContent {}
 @available(*, deprecated, renamed: "AnyContent")
 public protocol Content {}
 
-@available(*, deprecated, renamed: "Page")
+@available(*, deprecated, renamed: "View")
 public protocol HTMLTemplate {}
 
-@available(*, deprecated, renamed: "View")
+@available(*, deprecated, renamed: "Page")
 public protocol HTMLPage {}
 
 @available(*, deprecated, renamed: "Component")


### PR DESCRIPTION
When I upgrade from v2.1.4 to v2.4.3, some API got changed.

And I found the renamed suggestion seems to be wrongly placed.

The original "HTMLTemplate" needs a context which corresponds to current "View".
The original "HTMLPage" does not need a context which corresponds to current "Page"
