### PR TITLE
Minor fix

### DIFF
--- a/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/BasicAttributes.swift
@@ -4478,3 +4478,34 @@ extension CustomAttribute where Self: EmptyNode {
         return .init(attributes: update(key: key, value: value, on: &attributes))
     }
 }
+
+/// ## Description
+/// The protocol provides the element with the selected handler.
+///
+/// ## References
+/// https://html.spec.whatwg.org/#attr-option-selected
+///
+public protocol SelectedAttribute: AnyAttribute {
+    
+    /// The func adds
+    ///
+    ///
+    func selected() -> Self
+}
+
+extension SelectedAttribute {
+    
+    internal var key: String { "selected" }
+}
+
+extension SelectedAttribute where Self: ContentNode {
+    
+    internal func mutate(selected value: String) -> Self {
+        
+        guard var attributes = self.attributes else {
+            return .init(attributes: set(key: key, value: value), content: content)
+        }
+        
+        return .init(attributes: update(key: key, value: value, on: &attributes), content: content)
+    }
+}

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -197,7 +197,7 @@ public typealias Param = Parameter
 /// ## References
 /// https://html.spec.whatwg.org/#the-article-element
 ///
-public struct Article: ContentNode, BodyElement {
+public struct Article: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "article" }
 
@@ -384,7 +384,7 @@ extension Article: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-section-element
 ///
-public struct Section: ContentNode, BodyElement {
+public struct Section: ContentNode, HtmlElement, BodyElement, FigureElement, FormElement, ObjectElement {
 
     internal var name: String { "section" }
 
@@ -571,7 +571,7 @@ extension Section: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-nav-element)
 ///
-public struct Navigation: ContentNode, BodyElement {
+public struct Navigation: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "nav" }
 
@@ -758,7 +758,7 @@ extension Navigation: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-aside-element
 ///
-public struct Aside: ContentNode, BodyElement {
+public struct Aside: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "aside" }
 
@@ -945,7 +945,7 @@ extension Aside: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
-public struct Heading1: ContentNode, BodyElement {
+public struct Heading1: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "h1" }
 
@@ -1143,7 +1143,7 @@ extension Heading1: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
-public struct Heading2: ContentNode, BodyElement {
+public struct Heading2: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "h2" }
 
@@ -1341,7 +1341,7 @@ extension Heading2: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
-public struct Heading3: ContentNode, BodyElement {
+public struct Heading3: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "h3" }
 
@@ -1539,7 +1539,7 @@ extension Heading3: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
-public struct Heading4: ContentNode, BodyElement {
+public struct Heading4: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "h4" }
 
@@ -1737,7 +1737,7 @@ extension Heading4: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
-public struct Heading5: ContentNode, BodyElement {
+public struct Heading5: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "h5" }
 
@@ -1935,7 +1935,7 @@ extension Heading5: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 ///
-public struct Heading6: ContentNode, BodyElement {
+public struct Heading6: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "h6" }
 
@@ -2133,7 +2133,7 @@ extension Heading6: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-hgroup-element
 ///
-public struct HeadingGroup: ContentNode, BodyElement {
+public struct HeadingGroup: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "hgroup" }
 
@@ -2320,7 +2320,7 @@ extension HeadingGroup: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-header-element
 ///
-public struct Header: ContentNode, BodyElement {
+public struct Header: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "header" }
 
@@ -2507,7 +2507,7 @@ extension Header: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-footer-element
 ///
-public struct Footer: ContentNode, BodyElement {
+public struct Footer: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "footer" }
 
@@ -2694,7 +2694,7 @@ extension Footer: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-address-element
 ///
-public struct Address: ContentNode, BodyElement {
+public struct Address: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "address" }
 
@@ -2881,7 +2881,7 @@ extension Address: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-p-element
 ///
-public struct Paragraph: ContentNode, BodyElement {
+public struct Paragraph: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "p" }
 
@@ -3079,7 +3079,7 @@ extension Paragraph: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-hr-element
 ///
-public struct HorizontalRule: EmptyNode, BodyElement {
+public struct HorizontalRule: EmptyNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "hr" }
     
@@ -3261,7 +3261,7 @@ extension HorizontalRule: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-pre-element
 ///
-public struct PreformattedText: ContentNode, BodyElement {
+public struct PreformattedText: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "pre" }
 
@@ -3448,7 +3448,7 @@ extension PreformattedText: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-blockquote-element
 ///
-public struct Blockquote: ContentNode, BodyElement {
+public struct Blockquote: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "blockquote" }
 
@@ -3650,7 +3650,7 @@ extension Blockquote: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-ol-element
 ///
-public struct OrderedList: ContentNode, BodyElement {
+public struct OrderedList: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "ol" }
 
@@ -3849,7 +3849,7 @@ extension OrderedList: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-ul-element
 ///
-public struct UnorderedList: ContentNode, BodyElement {
+public struct UnorderedList: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "ul" }
 
@@ -4036,7 +4036,7 @@ extension UnorderedList: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-dl-element
 ///
-public struct DescriptionList: ContentNode, BodyElement {
+public struct DescriptionList: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "dl" }
 
@@ -4223,7 +4223,7 @@ extension DescriptionList: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-figure-element
 ///
-public struct Figure: ContentNode, BodyElement {
+public struct Figure: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "figure" }
 
@@ -4410,7 +4410,7 @@ extension Figure: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-a-element
 ///
-public struct Anchor: ContentNode, BodyElement {
+public struct Anchor: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "a" }
 
@@ -4648,7 +4648,7 @@ extension Anchor: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-em-element
 ///
-public struct Emphasize: ContentNode, BodyElement {
+public struct Emphasize: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "em" }
 
@@ -4835,7 +4835,7 @@ extension Emphasize: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-strong-element
 ///
-public struct Strong: ContentNode, BodyElement {
+public struct Strong: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "strong" }
 
@@ -5022,7 +5022,7 @@ extension Strong: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-small-element
 ///
-public struct Small: ContentNode, BodyElement {
+public struct Small: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "small" }
 
@@ -5220,7 +5220,7 @@ extension Small: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-s-element
 ///
-public struct StrikeThrough: ContentNode, BodyElement {
+public struct StrikeThrough: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "s" }
 
@@ -5418,7 +5418,7 @@ extension StrikeThrough: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-main-element
 ///
-public struct Main: ContentNode, BodyElement {
+public struct Main: ContentNode, HtmlElement, BodyElement, FormElement {
 
     internal var name: String { "main" }
 
@@ -5605,7 +5605,7 @@ extension Main: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-div-element
 ///
-public struct Division: ContentNode, BodyElement {
+public struct Division: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "div" }
 
@@ -5792,7 +5792,7 @@ extension Division: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-dfn-element
 ///
-public struct Definition: ContentNode, BodyElement {
+public struct Definition: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "dfn" }
 
@@ -5979,7 +5979,7 @@ extension Definition: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-cite-element
 ///
-public struct Cite: ContentNode, BodyElement {
+public struct Cite: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "cite" }
 
@@ -6166,7 +6166,7 @@ extension Cite: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-q-element
 ///
-public struct ShortQuote: ContentNode, BodyElement {
+public struct ShortQuote: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "q" }
 
@@ -6357,7 +6357,7 @@ extension ShortQuote: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-abbr-element
 ///
-public struct Abbreviation: ContentNode, BodyElement {
+public struct Abbreviation: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "abbr" }
 
@@ -6544,7 +6544,7 @@ extension Abbreviation: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-ruby-element
 ///
-public struct Ruby: ContentNode, BodyElement {
+public struct Ruby: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "ruby" }
 
@@ -6731,7 +6731,7 @@ extension Ruby: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-data-element
 ///
-public struct Data: ContentNode, BodyElement {
+public struct Data: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "data" }
 
@@ -6926,7 +6926,7 @@ extension Data: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-time-element
 ///
-public struct Time: ContentNode, BodyElement {
+public struct Time: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "time" }
 
@@ -7117,7 +7117,7 @@ extension Time: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-code-element
 ///
-public struct Code: ContentNode, BodyElement {
+public struct Code: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "code" }
 
@@ -7304,7 +7304,7 @@ extension Code: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-link-element
 ///
-public struct Variable: ContentNode, BodyElement {
+public struct Variable: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "v" }
 
@@ -7491,7 +7491,7 @@ extension Variable: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-samp-element
 ///
-public struct SampleOutput: ContentNode, BodyElement {
+public struct SampleOutput: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "samp" }
 
@@ -7678,7 +7678,7 @@ extension SampleOutput: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-kbd-element
 ///
-public struct KeyboardInput: ContentNode, BodyElement {
+public struct KeyboardInput: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "kbd" }
 
@@ -7865,7 +7865,7 @@ extension KeyboardInput: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-sub-and-sup-elements
 ///
-public struct Subscript: ContentNode, BodyElement {
+public struct Subscript: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "sub" }
 
@@ -8052,7 +8052,7 @@ extension Subscript: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-sub-and-sup-elements
 ///
-public struct Superscript: ContentNode, BodyElement {
+public struct Superscript: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "sup" }
 
@@ -8239,7 +8239,7 @@ extension Superscript: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-i-element
 ///
-public struct Italic: ContentNode, BodyElement {
+public struct Italic: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "i" }
 
@@ -8437,7 +8437,7 @@ extension Italic: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-b-element
 ///
-public struct Bold: ContentNode, BodyElement {
+public struct Bold: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "b" }
 
@@ -8635,7 +8635,7 @@ extension Bold: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-u-element
 ///
-public struct Underline: ContentNode, BodyElement {
+public struct Underline: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "u" }
     
@@ -8833,7 +8833,7 @@ extension Underline: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-mark-element
 ///
-public struct Mark: ContentNode, BodyElement {
+public struct Mark: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "mark" }
 
@@ -9020,7 +9020,7 @@ extension Mark: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-bdi-element
 ///
-public struct Bdi: ContentNode, BodyElement {
+public struct Bdi: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "bdi" }
 
@@ -9207,7 +9207,7 @@ extension Bdi: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-bdo-element
 ///
-public struct Bdo: EmptyNode, BodyElement {
+public struct Bdo: EmptyNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "bdo" }
 
@@ -9389,7 +9389,7 @@ extension Bdo: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-span-element
 ///
-public struct Span: ContentNode, BodyElement {
+public struct Span: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "span" }
 
@@ -9576,7 +9576,7 @@ extension Span: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-br-element
 ///
-public struct LineBreak: EmptyNode, BodyElement {
+public struct LineBreak: EmptyNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "br" }
 
@@ -9758,7 +9758,7 @@ extension LineBreak: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-wbr-element
 ///
-public struct WordBreak: EmptyNode, BodyElement {
+public struct WordBreak: EmptyNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "wbr" }
     
@@ -9940,7 +9940,7 @@ extension WordBreak: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-ins-element
 ///
-public struct InsertedText: ContentNode, BodyElement {
+public struct InsertedText: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "ins" }
 
@@ -10135,7 +10135,7 @@ extension InsertedText: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-del-element
 ///
-public struct DeletedText: ContentNode, BodyElement {
+public struct DeletedText: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "del" }
 
@@ -10330,7 +10330,7 @@ extension DeletedText: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-picture-element
 ///
-public struct Picture: ContentNode, BodyElement {
+public struct Picture: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "picture" }
 
@@ -10517,7 +10517,7 @@ extension Picture: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-img-element
 ///
-public struct Image: EmptyNode, BodyElement {
+public struct Image: EmptyNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "img" }
 
@@ -10731,7 +10731,7 @@ extension Image: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-iframe-element
 ///
-public struct InlineFrame: ContentNode, BodyElement {
+public struct InlineFrame: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
     
     internal var name: String { "iframe" }
 
@@ -10942,7 +10942,7 @@ extension InlineFrame: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-embed-element
 ///
-public struct Embed: EmptyNode, BodyElement {
+public struct Embed: EmptyNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "embed" }
 
@@ -11140,7 +11140,7 @@ extension Embed: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-object-element
 ///
-public struct Object: ContentNode, BodyElement {
+public struct Object: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
     
     internal var name: String { "object" }
 
@@ -11359,7 +11359,7 @@ extension Object: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-video-element
 ///
-public struct Video: ContentNode, BodyElement {
+public struct Video: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "video" }
 
@@ -11574,7 +11574,7 @@ extension Video: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-audio-element
 ///
-public struct Audio: ContentNode, BodyElement {
+public struct Audio: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "audio" }
 
@@ -11781,7 +11781,7 @@ extension Audio: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-map-elements
 ///
-public struct Map: ContentNode, BodyElement {
+public struct Map: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
     
     internal var name: String { "map" }
 
@@ -11976,7 +11976,7 @@ extension Map: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-form-element
 ///
-public struct Form: ContentNode, BodyElement {
+public struct Form: ContentNode, HtmlElement, BodyElement, FigureElement, ObjectElement {
 
     internal var name: String { "form" }
 
@@ -12203,7 +12203,7 @@ extension Form: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-datalist-element
 ///
-public struct DataList: ContentNode, BodyElement {
+public struct DataList: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "datalist" }
 
@@ -12390,7 +12390,7 @@ extension DataList: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-output-element
 ///
-public struct Output: ContentNode, BodyElement {
+public struct Output: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
     
     internal var name: String { "output" }
 
@@ -12593,7 +12593,7 @@ extension Output: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-progress-element
 ///
-public struct Progress: ContentNode, BodyElement {
+public struct Progress: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "progress" }
 
@@ -12792,7 +12792,7 @@ extension Progress: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-meter-element
 ///
-public struct Meter: ContentNode, BodyElement {
+public struct Meter: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "meter" }
 
@@ -13003,7 +13003,7 @@ extension Meter: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-details-element
 ///
-public struct Details: ContentNode, BodyElement {
+public struct Details: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "details" }
 
@@ -13389,7 +13389,7 @@ extension Dialog: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-script-element
 ///
-public struct Script: ContentNode, BodyElement, HeadElement {
+public struct Script: ContentNode, HeadElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "script" }
 
@@ -13600,7 +13600,7 @@ extension Script: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-template-element
 ///
-public struct NoScript: ContentNode, BodyElement {
+public struct NoScript: ContentNode, HtmlElement, HeadElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "noscript" }
 
@@ -13787,7 +13787,7 @@ extension NoScript: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-template-element
 ///
-public struct Template: ContentNode, BodyElement {
+public struct Template: ContentNode, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "template" }
 
@@ -13974,7 +13974,7 @@ extension Template: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-canvas-element
 ///
-public struct Canvas: ContentNode, BodyElement {
+public struct Canvas: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "canvas" }
 
@@ -14169,7 +14169,7 @@ extension Canvas: Modifiable {
 /// ## References
 /// https://html.spec.whatwg.org/#the-table-element
 ///
-public struct Table: ContentNode, BodyElement {
+public struct Table: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
     internal var name: String { "table" }
 

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -235,7 +235,7 @@ public struct Option: ContentNode, InputElement {
     }
 }
 
-extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttribute {
+extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttribute, SelectedAttribute {
     
     public func accessKey(_ value: String) -> Option {
         return mutate(accesskey: value)
@@ -364,6 +364,10 @@ extension Option: GlobalAttributes, DisabledAttribute, LabelAttribute, ValueAttr
     
     public func custom(key: String, value: Any) -> Option {
         return mutate(key: key, value: value)
+    }
+    
+    public func selected() -> Option {
+        return mutate(selected: "selected")
     }
 }
 

--- a/Sources/HTMLKit/Internal/Core/Builders/ContentBuilder.swift
+++ b/Sources/HTMLKit/Internal/Core/Builders/ContentBuilder.swift
@@ -18,12 +18,36 @@
     public static func buildBlock() -> [T] {
         return []
     }
+    
+    public static func buildBlock(_ component: T) -> [T] {
+        return [component]
+    }
 
-    public static func buildBlock(_ component: T...) -> [T] {
-        return component
+    public static func buildBlock(_ components: T...) -> [T] {
+        return components
     }
     
-    public static func buildBlock(_ component: [T]...) -> [T] {
-        return component.flatMap( { $0 } )
+    public static func buildBlock(_ components: [T], _ trailing: T...) -> [T] {
+        return components + trailing
+    }
+    
+    public static func buildBlock(_ c1: T, _ components: [T], _ trailing: T...) -> [T] {
+        return [c1] + components + trailing
+    }
+    
+    public static func buildBlock(_ c1: T, _ c2: T, _ components: [T], _ trailing: T...) -> [T] {
+        return [c1, c2] + components + trailing
+    }
+    
+    public static func buildBlock(_ c1: T, _ c2: T, _ c3: T, _ components: [T], _ trailing: T...) -> [T] {
+        return [c1, c2, c3] + components + trailing
+    }
+    
+    public static func buildBlock(_ cs1: [T], _ components: [T], _ trailing: T...) -> [T] {
+        return cs1 + components + trailing
+    }
+    
+    public static func buildBlock(_ cs1: [T], _ cs2: [T], _ components: [T], _ trailing: T...) -> [T] {
+        return cs1 + cs2 + components + trailing
     }
 }

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -331,6 +331,8 @@ public class Converter {
             TypeProperty<Charset>(node: attribute).build()
         case "http-equiv":
             TypeProperty<Equivalent>(node: attribute).build()
+        case "selected":
+            EmptyProperty(node: attribute).build()
         default:
             CustomProperty(node: attribute).build()
         }

--- a/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
+++ b/Sources/HTMLKit/Internal/Features/Conversion/Converter.swift
@@ -467,7 +467,7 @@ public class Converter {
                 case "del":
                     ContentElement(element: element).build(verbatim: "DeletedText", preindent: indent)
                 case "img":
-                    ContentElement(element: element).build(verbatim: "Image", preindent: indent)
+                    EmptyElement(element: element).build(verbatim: "Image", preindent: indent)
                 case "embed":
                     ContentElement(element: element).build(preindent: indent)
                 case "iframe":

--- a/Tests/HTMLKitTests/ElementTests.swift
+++ b/Tests/HTMLKitTests/ElementTests.swift
@@ -29,7 +29,7 @@ final class ElementTests: XCTestCase {
     func testTitleElement() throws {
         
         let view = TestPage {
-            Title{
+            Title {
             }
         }
         
@@ -90,7 +90,7 @@ final class ElementTests: XCTestCase {
     func testStyleElement() throws {
         
         let view = TestPage {
-            Style{
+            Style {
             }
         }
         
@@ -106,7 +106,7 @@ final class ElementTests: XCTestCase {
     func testHtmlElement() throws {
         
         let view = TestPage {
-            Html{
+            Html {
             }
         }
         
@@ -122,7 +122,7 @@ final class ElementTests: XCTestCase {
     func testBodyElement() throws {
         
         let view = TestPage {
-            Body{
+            Body {
             }
         }
         
@@ -138,7 +138,7 @@ final class ElementTests: XCTestCase {
     func testArticleElement() throws {
         
         let view = TestPage {
-            Article{
+            Article {
             }
         }
         
@@ -154,7 +154,7 @@ final class ElementTests: XCTestCase {
     func testSectionElement() throws {
         
         let view = TestPage {
-            Section{
+            Section {
             }
         }
         
@@ -170,7 +170,7 @@ final class ElementTests: XCTestCase {
     func testNavigationElement() throws {
         
         let view = TestPage {
-            Navigation{
+            Navigation {
             }
         }
         
@@ -186,7 +186,7 @@ final class ElementTests: XCTestCase {
     func testAsideElement() throws {
         
         let view = TestPage {
-            Aside{
+            Aside {
             }
         }
         
@@ -202,7 +202,7 @@ final class ElementTests: XCTestCase {
     func testHeading1Element() throws {
         
         let view = TestPage {
-            Heading1{
+            Heading1 {
             }
         }
         
@@ -218,7 +218,7 @@ final class ElementTests: XCTestCase {
     func testHeading2Element() throws {
         
         let view = TestPage {
-            Heading2{
+            Heading2 {
             }
         }
         
@@ -234,7 +234,7 @@ final class ElementTests: XCTestCase {
     func testHeading3Element() throws {
         
         let view = TestPage {
-            Heading3{
+            Heading3 {
             }
         }
         
@@ -250,7 +250,7 @@ final class ElementTests: XCTestCase {
     func testHeading4Element() throws {
         
         let view = TestPage {
-            Heading4{
+            Heading4 {
             }
         }
         
@@ -266,7 +266,7 @@ final class ElementTests: XCTestCase {
     func testHeading5Element() throws {
         
         let view = TestPage {
-            Heading5{
+            Heading5 {
             }
         }
         
@@ -282,7 +282,7 @@ final class ElementTests: XCTestCase {
     func testHeading6Element() throws {
         
         let view = TestPage {
-            Heading6{
+            Heading6 {
             }
         }
         
@@ -298,7 +298,7 @@ final class ElementTests: XCTestCase {
     func testHeadingGroupElement() throws {
         
         let view = TestPage {
-            HeadingGroup{
+            HeadingGroup {
             }
         }
         
@@ -314,7 +314,7 @@ final class ElementTests: XCTestCase {
     func testHeaderElement() throws {
         
         let view = TestPage {
-            Header{
+            Header {
             }
         }
         
@@ -330,7 +330,7 @@ final class ElementTests: XCTestCase {
     func testFooterElement() throws {
         
         let view = TestPage {
-            Footer{
+            Footer {
             }
         }
         
@@ -346,7 +346,7 @@ final class ElementTests: XCTestCase {
     func testAdressElement() throws {
         
         let view = TestPage {
-            Address{
+            Address {
             }
         }
         
@@ -362,7 +362,7 @@ final class ElementTests: XCTestCase {
     func testParagraphElement() throws {
         
         let view = TestPage {
-            Paragraph{
+            Paragraph {
             }
         }
         
@@ -393,7 +393,7 @@ final class ElementTests: XCTestCase {
     func testPreformattedTextElement() throws {
         
         let view = TestPage {
-            PreformattedText{
+            PreformattedText {
             }
         }
         
@@ -409,7 +409,7 @@ final class ElementTests: XCTestCase {
     func testBlockquoteElement() throws {
         
         let view = TestPage {
-            Blockquote{
+            Blockquote {
             }
         }
         
@@ -425,7 +425,7 @@ final class ElementTests: XCTestCase {
     func testOrderedListElement() throws {
         
         let view = TestPage {
-            OrderedList{
+            OrderedList {
             }
         }
         
@@ -441,7 +441,7 @@ final class ElementTests: XCTestCase {
     func testUnorderedListElement() throws {
         
         let view = TestPage {
-            UnorderedList{
+            UnorderedList {
             }
         }
         
@@ -457,7 +457,7 @@ final class ElementTests: XCTestCase {
     func testListItemElement() throws {
         
         let view = TestPage {
-            ListItem{
+            ListItem {
             }
         }
         
@@ -473,7 +473,7 @@ final class ElementTests: XCTestCase {
     func testDescriptionListElement() throws {
         
         let view = TestPage {
-            DescriptionList{
+            DescriptionList {
             }
         }
         
@@ -489,7 +489,7 @@ final class ElementTests: XCTestCase {
     func testTermNameElement() throws {
         
         let view = TestPage {
-            TermName{
+            TermName {
             }
         }
         
@@ -505,7 +505,7 @@ final class ElementTests: XCTestCase {
     func testTermDefinitionElement() throws {
         
         let view = TestPage {
-            TermDefinition{
+            TermDefinition {
             }
         }
         
@@ -521,7 +521,7 @@ final class ElementTests: XCTestCase {
     func testFigureElement() throws {
         
         let view = TestPage {
-            Figure{
+            Figure {
             }
         }
         
@@ -537,7 +537,7 @@ final class ElementTests: XCTestCase {
     func testFigureCaptionElement() throws {
         
         let view = TestPage {
-            FigureCaption{
+            FigureCaption {
             }
         }
         
@@ -553,7 +553,7 @@ final class ElementTests: XCTestCase {
     func testMainElement() throws {
         
         let view = TestPage {
-            Main{
+            Main {
             }
         }
         
@@ -569,7 +569,7 @@ final class ElementTests: XCTestCase {
     func testDivisionElement() throws {
         
         let view = TestPage {
-            Division{
+            Division {
             }
         }
         
@@ -585,7 +585,7 @@ final class ElementTests: XCTestCase {
     func testAnchorElement() throws {
         
         let view = TestPage {
-            Anchor{
+            Anchor {
             }
         }
         
@@ -617,7 +617,7 @@ final class ElementTests: XCTestCase {
     func testStrongElement() throws {
         
         let view = TestPage {
-            Strong{
+            Strong {
             }
         }
         
@@ -633,7 +633,7 @@ final class ElementTests: XCTestCase {
     func testSmallElement() throws {
         
         let view = TestPage {
-            Small{
+            Small {
             }
         }
         
@@ -649,7 +649,7 @@ final class ElementTests: XCTestCase {
     func testStrikeThroughElement() throws {
         
         let view = TestPage {
-            StrikeThrough{
+            StrikeThrough {
             }
         }
         
@@ -665,7 +665,7 @@ final class ElementTests: XCTestCase {
     func testCiteElement() throws {
         
         let view = TestPage {
-            Cite{
+            Cite {
             }
         }
         
@@ -681,7 +681,7 @@ final class ElementTests: XCTestCase {
     func testShortQuoteElement() throws {
         
         let view = TestPage {
-            ShortQuote{
+            ShortQuote {
             }
         }
         
@@ -697,7 +697,7 @@ final class ElementTests: XCTestCase {
     func testDefinitionElement() throws {
         
         let view = TestPage {
-            Definition{
+            Definition {
             }
         }
         
@@ -713,7 +713,7 @@ final class ElementTests: XCTestCase {
     func testAbbreviationElement() throws {
         
         let view = TestPage {
-            Abbreviation{
+            Abbreviation {
             }
         }
         
@@ -729,7 +729,7 @@ final class ElementTests: XCTestCase {
     func testRubyElement() throws {
         
         let view = TestPage {
-            Ruby{
+            Ruby {
             }
         }
         
@@ -745,7 +745,7 @@ final class ElementTests: XCTestCase {
     func testRubyTextElement() throws {
         
         let view = TestPage {
-            RubyText{
+            RubyText {
             }
         }
         
@@ -761,7 +761,7 @@ final class ElementTests: XCTestCase {
     func testRubyPronunciationElement() throws {
         
         let view = TestPage {
-            RubyPronunciation{
+            RubyPronunciation {
             }
         }
         
@@ -777,7 +777,7 @@ final class ElementTests: XCTestCase {
     func testDataElement() throws {
         
         let view = TestPage {
-            HTMLKit.Data{
+            HTMLKit.Data {
             }
         }
         
@@ -793,7 +793,7 @@ final class ElementTests: XCTestCase {
     func testTimeElement() throws {
         
         let view = TestPage {
-            Time{
+            Time {
             }
         }
         
@@ -809,7 +809,7 @@ final class ElementTests: XCTestCase {
     func testCodeElement() throws {
         
         let view = TestPage {
-            Code{
+            Code {
             }
         }
         
@@ -825,7 +825,7 @@ final class ElementTests: XCTestCase {
     func testVariableElement() throws {
         
         let view = TestPage {
-            Variable{
+            Variable {
             }
         }
         
@@ -841,7 +841,7 @@ final class ElementTests: XCTestCase {
     func testSampleOutputElement() throws {
         
         let view = TestPage {
-            SampleOutput{
+            SampleOutput {
             }
         }
         
@@ -857,7 +857,7 @@ final class ElementTests: XCTestCase {
     func testKeyboardInputElement() throws {
         
         let view = TestPage {
-            KeyboardInput{
+            KeyboardInput {
             }
         }
         
@@ -873,7 +873,7 @@ final class ElementTests: XCTestCase {
     func testSubscriptElement() throws {
         
         let view = TestPage {
-            Subscript{
+            Subscript {
             }
         }
         
@@ -889,7 +889,7 @@ final class ElementTests: XCTestCase {
     func testSuperscriptElement() throws {
         
         let view = TestPage {
-            Superscript{
+            Superscript {
             }
         }
         
@@ -905,7 +905,7 @@ final class ElementTests: XCTestCase {
     func testItalicElement() throws {
         
         let view = TestPage {
-            Italic{
+            Italic {
             }
         }
         
@@ -921,7 +921,7 @@ final class ElementTests: XCTestCase {
     func testBoldElement() throws {
         
         let view = TestPage {
-            Bold{
+            Bold {
             }
         }
         
@@ -937,7 +937,7 @@ final class ElementTests: XCTestCase {
     func testUnderlineElement() throws {
         
         let view = TestPage {
-            Underline{
+            Underline {
             }
         }
         
@@ -953,7 +953,7 @@ final class ElementTests: XCTestCase {
     func testMarkElement() throws {
         
         let view = TestPage {
-            Mark{
+            Mark {
             }
         }
         
@@ -969,7 +969,7 @@ final class ElementTests: XCTestCase {
     func testBdiElement() throws {
         
         let view = TestPage {
-            Bdi{
+            Bdi {
             }
         }
         
@@ -1000,7 +1000,7 @@ final class ElementTests: XCTestCase {
     func testSpanElement() throws {
         
         let view = TestPage {
-            Span{
+            Span {
             }
         }
         
@@ -1046,7 +1046,7 @@ final class ElementTests: XCTestCase {
     func testInsertedTextElement() throws {
         
         let view = TestPage {
-            InsertedText{
+            InsertedText {
             }
         }
         
@@ -1062,7 +1062,7 @@ final class ElementTests: XCTestCase {
     func testDeletedTextElement() throws {
         
         let view = TestPage {
-            DeletedText{
+            DeletedText {
             }
         }
         
@@ -1124,7 +1124,7 @@ final class ElementTests: XCTestCase {
     func testInlineFrameElement() throws {
         
         let view = TestPage {
-            InlineFrame{
+            InlineFrame {
             }
         }
         
@@ -1155,7 +1155,7 @@ final class ElementTests: XCTestCase {
     func testObjectElement() throws {
         
         let view = TestPage {
-            Object{
+            Object {
             }
         }
         
@@ -1186,7 +1186,7 @@ final class ElementTests: XCTestCase {
     func testVideoElement() throws {
         
         let view = TestPage {
-            Video{
+            Video {
             }
         }
         
@@ -1202,7 +1202,7 @@ final class ElementTests: XCTestCase {
     func testAudioElement() throws {
         
         let view = TestPage {
-            Audio{
+            Audio {
             }
         }
         
@@ -1233,7 +1233,7 @@ final class ElementTests: XCTestCase {
     func testMapElement() throws {
         
         let view = TestPage {
-            Map{
+            Map {
             }
         }
         
@@ -1249,7 +1249,7 @@ final class ElementTests: XCTestCase {
     func testAreaElement() throws {
         
         let view = TestPage {
-            Area{
+            Area {
             }
         }
         
@@ -1265,7 +1265,7 @@ final class ElementTests: XCTestCase {
     func testTableElement() throws {
         
         let view = TestPage {
-            Table{
+            Table {
             }
         }
         
@@ -1281,7 +1281,7 @@ final class ElementTests: XCTestCase {
     func testCaptionElement() throws {
         
         let view = TestPage {
-            Caption{
+            Caption {
             }
         }
         
@@ -1297,7 +1297,7 @@ final class ElementTests: XCTestCase {
     func testColumnGroupElement() throws {
         
         let view = TestPage {
-            ColumnGroup{
+            ColumnGroup {
             }
         }
         
@@ -1313,7 +1313,7 @@ final class ElementTests: XCTestCase {
     func testColumnElement() throws {
         
         let view = TestPage {
-            Column{
+            Column {
             }
         }
         
@@ -1329,7 +1329,7 @@ final class ElementTests: XCTestCase {
     func testTableBodyElement() throws {
         
         let view = TestPage {
-            TableBody{
+            TableBody {
             }
         }
         
@@ -1345,7 +1345,7 @@ final class ElementTests: XCTestCase {
     func testTableHeadElement() throws {
         
         let view = TestPage {
-            TableHead{
+            TableHead {
             }
         }
         
@@ -1361,7 +1361,7 @@ final class ElementTests: XCTestCase {
     func testTableFootElement() throws {
         
         let view = TestPage {
-            TableFoot{
+            TableFoot {
             }
         }
         
@@ -1377,7 +1377,7 @@ final class ElementTests: XCTestCase {
     func testTableRowElement() throws {
         
         let view = TestPage {
-            TableRow{
+            TableRow {
             }
         }
         
@@ -1393,7 +1393,7 @@ final class ElementTests: XCTestCase {
     func testDataCellElement() throws {
         
         let view = TestPage {
-            DataCell{
+            DataCell {
             }
         }
         
@@ -1409,7 +1409,7 @@ final class ElementTests: XCTestCase {
     func testHeaderCellElement() throws {
         
         let view = TestPage {
-            HeaderCell{
+            HeaderCell {
             }
         }
         
@@ -1425,7 +1425,7 @@ final class ElementTests: XCTestCase {
     func testFormElement() throws {
         
         let view = TestPage {
-            Form{
+            Form {
             }
         }
         
@@ -1472,7 +1472,7 @@ final class ElementTests: XCTestCase {
     func testButtonElement() throws {
         
         let view = TestPage {
-            Button{
+            Button {
             }
         }
         
@@ -1488,7 +1488,7 @@ final class ElementTests: XCTestCase {
     func testDataListElement() throws {
         
         let view = TestPage {
-            DataList{
+            DataList {
             }
         }
         
@@ -1504,7 +1504,7 @@ final class ElementTests: XCTestCase {
     func testOptionGroupElement() throws {
         
         let view = TestPage {
-            OptionGroup{
+            OptionGroup {
             }
         }
         
@@ -1520,7 +1520,7 @@ final class ElementTests: XCTestCase {
     func testOptionElement() throws {
         
         let view = TestPage {
-            Option{
+            Option {
             }
         }
         
@@ -1536,7 +1536,7 @@ final class ElementTests: XCTestCase {
     func testTextAreaElement() throws {
         
         let view = TestPage {
-            TextArea{
+            TextArea {
             }
         }
         
@@ -1552,7 +1552,7 @@ final class ElementTests: XCTestCase {
     func testOutputElement() throws {
         
         let view = TestPage {
-            Output{
+            Output {
             }
         }
         
@@ -1568,7 +1568,7 @@ final class ElementTests: XCTestCase {
     func testProgressElement() throws {
         
         let view = TestPage {
-            HTMLKit.Progress{
+            HTMLKit.Progress {
             }
         }
         
@@ -1584,7 +1584,7 @@ final class ElementTests: XCTestCase {
     func testMeterElement() throws {
         
         let view = TestPage {
-            Meter{
+            Meter {
             }
         }
         
@@ -1600,7 +1600,7 @@ final class ElementTests: XCTestCase {
     func testFieldsetElement() throws {
         
         let view = TestPage {
-            Fieldset{
+            Fieldset {
             }
         }
         
@@ -1616,7 +1616,7 @@ final class ElementTests: XCTestCase {
     func testLegendElement() throws {
         
         let view = TestPage {
-            Legend{
+            Legend {
             }
         }
         
@@ -1632,7 +1632,7 @@ final class ElementTests: XCTestCase {
     func testDetailsElement() throws {
         
         let view = TestPage {
-            Details{
+            Details {
             }
         }
         
@@ -1648,7 +1648,7 @@ final class ElementTests: XCTestCase {
     func testSummaryElement() throws {
         
         let view = TestPage {
-            Summary{
+            Summary {
             }
         }
         
@@ -1664,7 +1664,7 @@ final class ElementTests: XCTestCase {
     func testDialogElement() throws {
         
         let view = TestPage {
-            Dialog{
+            Dialog {
             }
         }
         
@@ -1680,7 +1680,7 @@ final class ElementTests: XCTestCase {
     func testScriptElement() throws {
         
         let view = TestPage {
-            Script{
+            Script {
             }
         }
         
@@ -1696,7 +1696,7 @@ final class ElementTests: XCTestCase {
     func testNoScriptElement() throws {
         
         let view = TestPage {
-            NoScript{
+            NoScript {
             }
         }
         
@@ -1712,7 +1712,7 @@ final class ElementTests: XCTestCase {
     func testTemplateElement() throws {
         
         let view = TestPage {
-            Template{
+            Template {
             }
         }
         
@@ -1728,7 +1728,7 @@ final class ElementTests: XCTestCase {
     func testCanvasElement() throws {
         
         let view = TestPage {
-            Canvas{
+            Canvas {
             }
         }
         

--- a/Tests/HTMLKitTests/Performance/Samples.swift
+++ b/Tests/HTMLKitTests/Performance/Samples.swift
@@ -1,0 +1,123 @@
+import HTMLKit
+import Foundation
+
+struct SampleContext {
+    
+    var id: Int
+    var title: String
+    var excerpt: String
+    var modified: Date
+    var posted: Date
+}
+
+struct SamplePage: Page {
+
+    var content: [BodyElement]
+    
+    init(@ContentBuilder<BodyElement> content: () -> [BodyElement]) {
+        self.content = content()
+    }
+
+    var body: AnyContent {
+        Document(type: .html5)
+        Html {
+            Head {
+                Meta()
+                    .charset(.utf8)
+                Meta()
+                    .name(.viewport)
+                    .content("width=device-width, initial-scale=1.0")
+                Title {
+                    "TestTemplatePage"
+                }
+                Link()
+                    .relationship(.stylesheet)
+                    .reference("/css/site.css")
+                Link()
+                    .relationship(.stylesheet)
+                    .reference("/bootstrap/css/all.css")
+                Link()
+                    .relationship(.stylesheet)
+                    .reference("/fontawesome/css/all.css")
+            }
+            Body {
+                content
+            }
+        }
+    }
+
+}
+
+struct SampleView: View {
+    
+    @TemplateValue(SampleContext.self) var context
+    
+    var body: AnyContent {
+        SamplePage {
+            Header {
+                Heading1 {
+                    context.title
+                }
+                Heading3 {
+                    context.excerpt
+                }
+            }
+            Navigation {
+                UnorderedList {
+                    ListItem {
+                        Anchor {
+                            "Item"
+                        }
+                        .reference("#")
+                    }
+                    ListItem {
+                        Anchor {
+                            "Item"
+                        }
+                        .reference("#")
+                    }
+                    ListItem {
+                        Anchor {
+                            "Item"
+                        }
+                        .reference("#")
+                    }
+                    ListItem {
+                        Anchor {
+                            "Item"
+                        }
+                        .reference("#")
+                    }
+                    ListItem {
+                        Anchor {
+                            "Item"
+                        }
+                        .reference("#")
+                    }
+                }
+            }
+            Main {
+                SampleComponent()
+            }
+            Footer {
+                Paragraph {
+                    context.modified.style(date: .full, time: .full)
+                }
+            }
+        }
+    }
+}
+
+struct SampleComponent: Component {
+ 
+    var body: AnyContent {
+        Section {
+            Heading1 {
+                "Heading1"
+            }
+            Paragraph {
+                "Paragraph"
+            }
+        }
+    }
+}

--- a/Tests/HTMLKitTests/PerformanceTests.swift
+++ b/Tests/HTMLKitTests/PerformanceTests.swift
@@ -2,132 +2,20 @@ import HTMLKit
 import XCTest
 
 final class PerformanceTests: XCTestCase {
-    
-    struct TestPage: Page {
-    
-        @ContentBuilder<AnyContent> var body: AnyContent
-    }
-    
+
     var renderer = Renderer()
     
-    func testPerformanceRenderingWhenUsingDefault() throws {
+    func testPerformance() throws {
         
-        let view = TestPage {
-            Html {
-                Body {
-                    Header {
-                        Heading1 {
-                            "Performance Test"
-                        }
-                    }
-                    Main {
-                        Article {
-                            Heading3 {
-                                "Test"
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        let context = SampleContext(id: 0, title: "TestPage", excerpt: "Testpage", modified: Date(), posted: Date())
         
-        try renderer.add(view: view)
+        try renderer.add(view: SampleView())
         
         measure {
-            _ = try! renderer.render(raw: TestPage.self)
-        }
-    }
-    
-    func testPerformanceRenderingWhenUsingTypealiases() throws {
-        
-        let view = TestPage {
-            Html {
-                Body {
-                    Header {
-                        H1 {
-                            "Performance Test"
-                        }
-                    }
-                    Main {
-                        Article {
-                            H3 {
-                                "Test"
-                            }
-                        }
-                    }
-                }
+            
+            for _ in 0...1000 {
+                _ = try! renderer.render(raw: SampleView.self, with: context)
             }
-        }
-        
-        try renderer.add(view: view)
-        
-        measure {
-            _ = try! renderer.render(raw: TestPage.self)
-        }
-    }
-    
-    func testPerformanceWithAttributes() throws {
-        
-        let view = TestPage {
-            Html {
-                Body {
-                    Header {
-                        Heading1 {
-                            "Performance Test"
-                        }
-                        .id("test")
-                        .class("class")
-                        .role(.heading)
-                    }
-                    Main {
-                        Article {
-                            Heading3 {
-                                "Test"
-                            }
-                            .id("test")
-                            .class("class")
-                            .role(.heading)
-                        }
-                    }
-                    .id("test")
-                    .class("class")
-                    .role(.main)
-                }
-            }
-        }
-        
-        try renderer.add(view: view)
-        
-        measure {
-            _ = try! renderer.render(raw: TestPage.self)
-        }
-    }
-    
-    func testPerformanceWithoutAttributes() throws {
-        
-        let view = TestPage {
-            Html {
-                Body {
-                    Header {
-                        Heading1 {
-                            "Performance Test"
-                        }
-                    }
-                    Main {
-                        Article {
-                            Heading3 {
-                                "Test"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        
-        try renderer.add(view: view)
-        
-        measure {
-            _ = try! renderer.render(raw: TestPage.self)
         }
     }
 }
@@ -135,10 +23,7 @@ final class PerformanceTests: XCTestCase {
 extension PerformanceTests {
     
     static var allTests = [
-        ("testPerformanceRenderingWhenUsingDefault", testPerformanceRenderingWhenUsingDefault),
-        ("testPerformanceRenderingWhenUsingTypealiases", testPerformanceRenderingWhenUsingTypealiases),
-        ("testPerformanceWithAttributes", testPerformanceWithAttributes),
-        ("testPerformanceWithoutAttributes", testPerformanceWithoutAttributes)
+        ("testPerformance", testPerformance)
     ]
 }
 

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -246,6 +246,28 @@ final class RenderingTests: XCTestCase {
                        """
         )
     }
+    
+    func testRenderingCustomProperty() throws {
+        
+        let view = TestPage {
+            Division {
+                Paragraph {
+                    "text"
+                }
+            }
+            .custom(key: "key", value: "value")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <div key="value">\
+                       <p>text</p>\
+                       </div>
+                       """
+        )
+    }
 }
 
 extension RenderingTests {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -284,6 +284,7 @@ extension RenderingTests {
         ("testEscaping", testEscaping),
         ("testModified", testModified),
         ("testUnmodified", testUnmodified),
-        ("testModifiedAndUnwrapped", testModifiedAndUnwrapped)
+        ("testModifiedAndUnwrapped", testModifiedAndUnwrapped),
+        ("testRenderingCustomProperty", testRenderingCustomProperty)
     ]
 }

--- a/Tests/HTMLKitTests/TemplatingTests.swift
+++ b/Tests/HTMLKitTests/TemplatingTests.swift
@@ -6,7 +6,7 @@ final class TemplatingTests: XCTestCase {
     
     var renderer = Renderer()
     
-    func testEmbed() throws {
+    func testEmbeding() throws {
         
         struct TestPage: Page {
             
@@ -59,7 +59,7 @@ final class TemplatingTests: XCTestCase {
         )
     }
     
-    func testExtend() throws {
+    func testExtending() throws {
         
         struct TestPage: Page {
             
@@ -119,13 +119,79 @@ final class TemplatingTests: XCTestCase {
                        """
         )
     }
+    
+    func testExtendingWithSingles() throws {
+        
+        struct TestPage: Page {
+            
+            var content: [BodyElement]
+            
+            init(@ContentBuilder<BodyElement> content: () -> [BodyElement]) {
+                self.content = content()
+            }
+            
+            var body: AnyContent {
+                Document(type: .html5)
+                Html {
+                    Head {
+                        Title {
+                            "Test"
+                        }
+                    }
+                    Body {
+                        content
+                        Script {
+                        }
+                        Script {
+                        }
+                    }
+                }
+            }
+        }
+        
+        struct TestView: View {
+            
+            var context: TemplateValue<String>
+            
+            var body: AnyContent {
+                TestPage {
+                    Heading1 {
+                        context
+                    }
+                    Heading2 {
+                        context
+                    }
+                }
+            }
+        }
+        
+        let view = TestView(context: "Hello World!")
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestView.self, with: "Hello World!"),
+                       """
+                       <!DOCTYPE html>\
+                       <html>\
+                       <head>\
+                       <title>Test</title>\
+                       </head>\
+                       <body>\
+                       <h1>Hello World!</h1>\
+                       <h2>Hello World!</h2>\
+                       </body>\
+                       </html>
+                       """
+        )
+    }
 }
 
 extension TemplatingTests {
     
     static var allTests = [
-        ("testEmbed", testEmbed),
-        ("textExtend", testExtend)
+        ("testEmbeding", testEmbeding),
+        ("testExtending", testExtending),
+        ("testExtendingWithSingles", testExtendingWithSingles)
     ]
 }
 

--- a/Tests/HTMLKitTests/TemplatingTests.swift
+++ b/Tests/HTMLKitTests/TemplatingTests.swift
@@ -179,6 +179,8 @@ final class TemplatingTests: XCTestCase {
                        <body>\
                        <h1>Hello World!</h1>\
                        <h2>Hello World!</h2>\
+                       <script></script>\
+                       <script></script>\
                        </body>\
                        </html>
                        """

--- a/Tests/HTMLKitTests/TemplatingTests.swift
+++ b/Tests/HTMLKitTests/TemplatingTests.swift
@@ -59,7 +59,7 @@ final class TemplatingTests: XCTestCase {
         )
     }
     
-    func textExtend() throws {
+    func testExtend() throws {
         
         struct TestPage: Page {
             
@@ -125,7 +125,7 @@ extension TemplatingTests {
     
     static var allTests = [
         ("testEmbed", testEmbed),
-        ("textExtend", textExtend)
+        ("textExtend", testExtend)
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import HTMLKitTests
 
 XCTMain([
-    testCase(TemplatingTests.allTests),
     testCase(ComponentTests.allTests),
     testCase(ContextTests.allTests),
     testCase(ElementTests.allTests),
     testCase(LocalizationTests.allTests),
     testCase(PerformanceTests.allTests),
-    testCase(RenderingTests.allTests)
+    testCase(RenderingTests.allTests),
+    testCase(TemplatingTests.allTests)
 ])


### PR DESCRIPTION
This merge will add a missing attribute and scopes to the elements. A bit more of a change is the content builder. The content builder will accept a mixture of array and singles as content, now.

```swift

var content: [BodyElement]

var body: AnyContent {
   Body {
      content /// array
      Script {
      } /// single
      Script {
      } /// single
   }
}
```

Currently it hits an error, when you try it. The change shouldn't have an impact on your current code. The tests didn't run on an error too, so I think it is okay to add it.