### PR TITLE
Add support for rel=“external”

### DIFF
--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -323,6 +323,7 @@ public enum Relation: String {
     
     case alternate
     case author
+    case external
     case help
     case icon
     case licence


### PR DESCRIPTION
This PR proposes to introduce the `rel="external"` attribute value, which indicates that the referenced document is not part of the same site as the current document.