### PR TITLE
Add support for the SVG <path d=“…”> attribute

### DIFF
--- a/Sources/HTMLKit/External/Attributes/VectorAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/VectorAttributes.swift
@@ -17,6 +17,30 @@ import OrderedCollections
 /// The alias combines the global attributes of the vector attributes.
 public typealias GlobalVectorAttributes = IdentifierAttribute & TabulatorAttribute & ClassAttribute & StyleAttribute & FillAttribute & FillOpacityAttribute & StrokeAttribute & StrokeWidthAttribute & StrokeOpacityAttribute & StrokeLineCapAttribute & StrokeLineJoinAttribute
 
+/// The protocol provides the element with the draw handler.
+public protocol DrawAttribute: AnyAttribute {
+
+    /// The function represents the html-attribute 'd'.
+    ///
+    /// ```html
+    /// <tag d="" />
+    /// ```
+    func draw(_ value: String) -> Self
+}
+
+extension DrawAttribute {
+
+    internal var key: String { "d" }
+}
+
+extension DrawAttribute where Self: ContentNode {
+
+    internal func mutate(draw value: String) -> Self {
+        return self.mutate(key: self.key, value: value)
+    }
+}
+
+
 /// The protocol provides the element with the fill handler.
 public protocol FillAttribute: AnyAttribute {
     

--- a/Sources/HTMLKit/External/Elements/VectorElements.swift
+++ b/Sources/HTMLKit/External/Elements/VectorElements.swift
@@ -629,7 +629,7 @@ extension Path: GlobalVectorAttributes {
     public func style(_ value: String) -> Path {
         return self.mutate(style: value)
     }
-    
+
     public func fill(_ value: String) -> Path {
         return self.mutate(fill: value)
     }
@@ -661,6 +661,14 @@ extension Path: GlobalVectorAttributes {
     public func custom(key: String, value: Any) -> Path {
         return self.mutate(key: key, value: value)
     }
+}
+
+extension Path: DrawAttribute {
+
+    public func draw(_ value: String) -> Path {
+        return self.mutate(draw: value)
+    }
+
 }
 
 extension Path: AnyContent {

--- a/Sources/HTMLKit/External/Elements/VectorElements.swift
+++ b/Sources/HTMLKit/External/Elements/VectorElements.swift
@@ -685,6 +685,103 @@ extension Path: AnyContent {
 /// The element represents ...
 ///
 /// ```html
+/// <g></g>
+/// ```
+public struct Group: ContentNode, VectorElement {
+
+    internal var name: String { "g" }
+
+    internal var attributes: OrderedDictionary<String, Any>?
+
+    internal var content: [AnyContent]
+
+    public init(@ContentBuilder<AnyContent> content: () -> [AnyContent]) {
+        self.content = content()
+    }
+
+    internal init(attributes: OrderedDictionary<String, Any>?, content: [AnyContent]) {
+        self.attributes = attributes
+        self.content = content
+    }
+}
+
+extension Group: GlobalVectorAttributes {
+
+    public func id(_ value: String) -> Self {
+        return self.mutate(id: value)
+    }
+
+    public func id(_ value: TemplateValue<String>) -> Self {
+        return self.mutate(id: value.rawValue)
+    }
+
+    public func tabIndex(_ value: Int) -> Self {
+        return self.mutate(tabindex: value)
+    }
+
+    public func `class`(_ value: String) -> Self {
+        return self.mutate(class: value)
+    }
+
+    public func style(_ value: String) -> Self {
+        return self.mutate(style: value)
+    }
+
+    public func fill(_ value: String) -> Self {
+        return self.mutate(fill: value)
+    }
+
+    public func stroke(_ value: String) -> Self {
+        return self.mutate(stroke: value)
+    }
+
+    public func strokeWidth(_ size: Int) -> Self {
+        return self.mutate(strokewidth: size)
+    }
+
+    public func fillOpacity(_ value: Double) -> Self {
+        return self.mutate(fillopacity: value)
+    }
+
+    public func strokeOpacity(_ value: Double) -> Self {
+        return self.mutate(strokeopacity: value)
+    }
+
+    public func strokeLineCap(_ type: Linecap) -> Self {
+        return self.mutate(strokelinecap: type.rawValue)
+    }
+
+    public func strokeLineJoin(_ type: Linejoin) -> Self {
+        return self.mutate(strokelinejoin: type.rawValue)
+    }
+
+    public func custom(key: String, value: Any) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension Group: DrawAttribute {
+
+    public func draw(_ value: String) -> Self {
+        return self.mutate(draw: value)
+    }
+
+}
+
+extension Group: AnyContent {
+
+    public func prerender(_ formula: Renderer.Formula) throws {
+        try self.build(formula)
+    }
+
+    public func render<T>(with manager: Renderer.ContextManager<T>) throws -> String {
+        try self.build(with: manager)
+    }
+}
+
+/// The element represents ...
+///
+/// ```html
 /// <use></use>
 /// ```
 public struct Use: ContentNode, VectorElement {


### PR DESCRIPTION
This PR proposes support for the SVG `<path d="…">` attribute, as described here: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d