### PR TITLE
Add support for the aria attributes

### DIFF
--- a/Sources/HTMLKit/External/Attributes/AriaAttributes.swift
+++ b/Sources/HTMLKit/External/Attributes/AriaAttributes.swift
@@ -1,0 +1,1390 @@
+/*
+ Abstract:
+ The file contains the protocols for the aria html-attributes.
+ 
+ Note:
+ If you about to add something to the file, stick to the official documentation to keep the code consistent.
+ */
+
+public typealias GlobalAriaAttributes = AriaAtomicAttribute & AriaBusyAttribute & AriaControlsAttribute & AriaCurrentAttribute & AriaDescribedAttribute & AriaDetailsAttribute & AriaDisabledAttribute & AriaErrorMessageAttribute & AriaFlowToAttribute & AriaPopupAttribute & AriaHiddenAttribute & AriaInvalidAttribute & AriaShortcutsAttribute & AriaLabelAttribute & AriaLabeledAttribute & AriaLiveAttribute & AriaOwnsAttribute & AriaRelevantAttribute & AriaRoleDescriptionAttribute
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaActiveDescendantAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-activedescendant'.
+    ///
+    /// ```html
+    /// <tag aria-activedescendant="" />
+    /// ```
+    func aria(activeDescendant value: String) -> Self
+}
+
+extension AriaActiveDescendantAttribute {
+    
+    internal var key: String { "aria-activedescendant" }
+}
+
+extension AriaActiveDescendantAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaactivedescendant value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaActiveDescendantAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaactivedescendant value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaAtomicAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-atomic'.
+    ///
+    /// ```html
+    /// <tag aria-atomic="" />
+    /// ```
+    func aria(atomic value: Bool) -> Self
+}
+
+extension AriaAtomicAttribute {
+    
+    internal var key: String { "aria-atomic" }
+}
+
+extension AriaAtomicAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaatomic value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaAtomicAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaatomic value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaAutoCompleteAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-autocomplete'.
+    ///
+    /// ```html
+    /// <tag aria-autocomplete="" />
+    /// ```
+    func aria(autoComplete value: Accessibility.Complete) -> Self
+}
+
+extension AriaAutoCompleteAttribute {
+    
+    internal var key: String { "aria-autocomplete" }
+}
+
+extension AriaAutoCompleteAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaautocomplete value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaAutoCompleteAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaautocomplete value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaBusyAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-busy'.
+    ///
+    /// ```html
+    /// <tag aria-busy="" />
+    /// ```
+    func aria(busy value: Bool) -> Self
+}
+
+extension AriaBusyAttribute {
+    
+    internal var key: String { "aria-busy" }
+}
+
+extension AriaBusyAttribute where Self: ContentNode {
+    
+    internal func mutate(ariabusy value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaBusyAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariabusy value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaCheckedAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-checked'.
+    ///
+    /// ```html
+    /// <tag aria-checked="" />
+    /// ```
+    func aria(checked value: Accessibility.Check) -> Self
+}
+
+extension AriaCheckedAttribute {
+    
+    internal var key: String { "aria-checked" }
+}
+
+extension AriaCheckedAttribute where Self: ContentNode {
+    
+    internal func mutate(ariachecked value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaCheckedAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariachecked value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaColumnCountAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-colcount'.
+    ///
+    /// ```html
+    /// <tag aria-colcount="" />
+    /// ```
+    func aria(columnCount value: Int) -> Self
+}
+
+extension AriaColumnCountAttribute {
+    
+    internal var key: String { "aria-colcount" }
+}
+
+extension AriaColumnCountAttribute where Self: ContentNode {
+    
+    internal func mutate(ariacolcount value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaColumnCountAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariacolcount value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaColumnIndexAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-colindex'.
+    ///
+    /// ```html
+    /// <tag aria-colindex="" />
+    /// ```
+    func aria(columnIndex value: Int) -> Self
+}
+
+extension AriaColumnIndexAttribute {
+    
+    internal var key: String { "aria-colindex" }
+}
+
+extension AriaColumnIndexAttribute where Self: ContentNode {
+    
+    internal func mutate(ariacolindex value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaColumnIndexAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariacolindex value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaColumnSpanAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-colspan'.
+    ///
+    /// ```html
+    /// <tag aria-colspan="" />
+    /// ```
+    func aria(columnSpan value: Int) -> Self
+}
+
+extension AriaColumnSpanAttribute {
+    
+    internal var key: String { "aria-colspan" }
+}
+
+extension AriaColumnSpanAttribute where Self: ContentNode {
+    
+    internal func mutate(ariacolspan value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaColumnSpanAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariacolspan value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaControlsAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-controls'.
+    ///
+    /// ```html
+    /// <tag aria-controls="" />
+    /// ```
+    func aria(controls value: String) -> Self
+}
+
+extension AriaControlsAttribute {
+    
+    internal var key: String { "aria-controls" }
+}
+
+extension AriaControlsAttribute where Self: ContentNode {
+    
+    internal func mutate(ariacontrols value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaControlsAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariacontrols value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaCurrentAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-current'.
+    ///
+    /// ```html
+    /// <tag aria-current="" />
+    /// ```
+    func aria(current value: Accessibility.Current) -> Self
+}
+
+extension AriaCurrentAttribute {
+    
+    internal var key: String { "aria-current" }
+}
+
+extension AriaCurrentAttribute where Self: ContentNode {
+    
+    internal func mutate(ariacurrent value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaCurrentAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariacurrent value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaDescribedAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-describedby'.
+    ///
+    /// ```html
+    /// <tag aria-describedby="" />
+    /// ```
+    func aria(describedBy value: String) -> Self
+}
+
+extension AriaDescribedAttribute {
+    
+    internal var key: String { "aria-describedby" }
+}
+
+extension AriaDescribedAttribute where Self: ContentNode {
+    
+    internal func mutate(ariadescribedby value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaDescribedAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariadescribedby value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaDetailsAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-details'.
+    ///
+    /// ```html
+    /// <tag aria-details="" />
+    /// ```
+    func aria(details value: String) -> Self
+}
+
+extension AriaDetailsAttribute {
+    
+    internal var key: String { "aria-details" }
+}
+
+extension AriaDetailsAttribute where Self: ContentNode {
+    
+    internal func mutate(ariadetails value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaDetailsAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariadetails value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaDisabledAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-disabled'.
+    ///
+    /// ```html
+    /// <tag aria-disabled="" />
+    /// ```
+    func aria(disabled value: Bool) -> Self
+}
+
+extension AriaDisabledAttribute {
+    
+    internal var key: String { "aria-disabled" }
+}
+
+extension AriaDisabledAttribute where Self: ContentNode {
+    
+    internal func mutate(ariadisabled value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaDisabledAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariadisabled value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaErrorMessageAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-errormessage'.
+    ///
+    /// ```html
+    /// <tag aria-errormessage="" />
+    /// ```
+    func aria(errorMessage value: String) -> Self
+}
+
+extension AriaErrorMessageAttribute {
+    
+    internal var key: String { "aria-errormessage" }
+}
+
+extension AriaErrorMessageAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaerrormessage value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaErrorMessageAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaerrormessage value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaExpandedAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-expanded'.
+    ///
+    /// ```html
+    /// <tag aria-expanded="" />
+    /// ```
+    func aria(expanded value: Bool) -> Self
+}
+
+extension AriaExpandedAttribute {
+    
+    internal var key: String { "aria-expanded" }
+}
+
+extension AriaExpandedAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaexpanded value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaExpandedAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaexpanded value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaFlowToAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-flowto'.
+    ///
+    /// ```html
+    /// <tag aria-flowto="" />
+    /// ```
+    func aria(flowTo value: String) -> Self
+}
+
+extension AriaFlowToAttribute {
+    
+    internal var key: String { "aria-flowto" }
+}
+
+extension AriaFlowToAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaflowto value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaFlowToAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaflowto value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaPopupAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-haspopup'.
+    ///
+    /// ```html
+    /// <tag aria-haspopup="" />
+    /// ```
+    func aria(hasPopup value: Accessibility.Popup) -> Self
+}
+
+extension AriaPopupAttribute {
+    
+    internal var key: String { "aria-haspopup" }
+}
+
+extension AriaPopupAttribute where Self: ContentNode {
+    
+    internal func mutate(ariahaspopup value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaPopupAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariahaspopup value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaHiddenAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-hidden'.
+    ///
+    /// ```html
+    /// <tag aria-hidden="" />
+    /// ```
+    func aria(hidden value: Bool) -> Self
+}
+
+extension AriaHiddenAttribute {
+    
+    internal var key: String { "aria-hidden" }
+}
+
+extension AriaHiddenAttribute where Self: ContentNode {
+    
+    internal func mutate(ariahidden value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaHiddenAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariahidden value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaInvalidAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-invalid'.
+    ///
+    /// ```html
+    /// <tag aria-invalid="" />
+    /// ```
+    func aria(invalid value: Accessibility.Invalid) -> Self
+}
+
+extension AriaInvalidAttribute {
+    
+    internal var key: String { "aria-invalid" }
+}
+
+extension AriaInvalidAttribute where Self: ContentNode {
+    
+    internal func mutate(ariainvalid value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaInvalidAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariainvalid value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaShortcutsAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-keyshortcuts'.
+    ///
+    /// ```html
+    /// <tag aria-keyshortcuts="" />
+    /// ```
+    func aria(keyShortcuts value: String) -> Self
+}
+
+extension AriaShortcutsAttribute {
+    
+    internal var key: String { "aria-keyshortcuts" }
+}
+
+extension AriaShortcutsAttribute where Self: ContentNode {
+    
+    internal func mutate(ariakeyshortcuts value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaShortcutsAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariakeyshortcuts value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaLabelAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-label'.
+    ///
+    /// ```html
+    /// <tag aria-label="" />
+    /// ```
+    func aria(label value: String) -> Self
+}
+
+extension AriaLabelAttribute {
+    
+    internal var key: String { "aria-label" }
+}
+
+extension AriaLabelAttribute where Self: ContentNode {
+    
+    internal func mutate(arialabel value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaLabelAttribute where Self: EmptyNode {
+    
+    internal func mutate(arialabel value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaLabeledAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-labeledby'.
+    ///
+    /// ```html
+    /// <tag aria-labeledby="" />
+    /// ```
+    func aria(labeledBy value: String) -> Self
+}
+
+extension AriaLabeledAttribute {
+    
+    internal var key: String { "aria-labeledby" }
+}
+
+extension AriaLabeledAttribute where Self: ContentNode {
+    
+    internal func mutate(arialabeledby value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaLabeledAttribute where Self: EmptyNode {
+    
+    internal func mutate(arialabeledby value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaLevelAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-level'.
+    ///
+    /// ```html
+    /// <tag aria-level="" />
+    /// ```
+    func aria(level value: Int) -> Self
+}
+
+extension AriaLevelAttribute {
+    
+    internal var key: String { "aria-level" }
+}
+
+extension AriaLevelAttribute where Self: ContentNode {
+    
+    internal func mutate(arialevel value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaLevelAttribute where Self: EmptyNode {
+    
+    internal func mutate(arialevel value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaLiveAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-live'.
+    ///
+    /// ```html
+    /// <tag aria-live="" />
+    /// ```
+    func aria(live value: Accessibility.Live) -> Self
+}
+
+extension AriaLiveAttribute {
+    
+    internal var key: String { "aria-live" }
+}
+
+extension AriaLiveAttribute where Self: ContentNode {
+    
+    internal func mutate(arialive value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaLiveAttribute where Self: EmptyNode {
+    
+    internal func mutate(arialive value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaModalAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-modal'.
+    ///
+    /// ```html
+    /// <tag aria-modal="" />
+    /// ```
+    func aria(modal value: Bool) -> Self
+}
+
+extension AriaModalAttribute {
+    
+    internal var key: String { "aria-modal" }
+}
+
+extension AriaModalAttribute where Self: ContentNode {
+    
+    internal func mutate(ariamodal value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaModalAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariamodal value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaMultilineAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-multiline'.
+    ///
+    /// ```html
+    /// <tag aria-multiline="" />
+    /// ```
+    func aria(multiline value: Bool) -> Self
+}
+
+extension AriaMultilineAttribute {
+    
+    internal var key: String { "aria-multiline" }
+}
+
+extension AriaMultilineAttribute where Self: ContentNode {
+    
+    internal func mutate(ariamultiline value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaMultilineAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariamultiline value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaMultiselectAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-multiselectable'.
+    ///
+    /// ```html
+    /// <tag aria-multiselectable="" />
+    /// ```
+    func aria(multiselectable value: Bool) -> Self
+}
+
+extension AriaMultiselectAttribute {
+    
+    internal var key: String { "aria-multiselectable" }
+}
+
+extension AriaMultiselectAttribute where Self: ContentNode {
+    
+    internal func mutate(ariamultiselectable value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaMultiselectAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariamultiselectable value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaOrientationAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-orientation'.
+    ///
+    /// ```html
+    /// <tag aria-orientation="" />
+    /// ```
+    func aria(orientation value: Accessibility.Orientation) -> Self
+}
+
+extension AriaOrientationAttribute {
+    
+    internal var key: String { "aria-orientation" }
+}
+
+extension AriaOrientationAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaorientation value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaOrientationAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaorientation value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaOwnsAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-owns'.
+    ///
+    /// ```html
+    /// <tag aria-owns="" />
+    /// ```
+    func aria(owns value: String) -> Self
+}
+
+extension AriaOwnsAttribute {
+    
+    internal var key: String { "aria-owns" }
+}
+
+extension AriaOwnsAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaowns value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaOwnsAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaowns value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaPlaceholderAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-placeholder'.
+    ///
+    /// ```html
+    /// <tag aria-placeholder="" />
+    /// ```
+    func aria(placeholder value: String) -> Self
+}
+
+extension AriaPlaceholderAttribute {
+    
+    internal var key: String { "aria-placeholder" }
+}
+
+extension AriaPlaceholderAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaplaceholder value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaPlaceholderAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaplaceholder value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaPositionInsetAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-posinset'.
+    ///
+    /// ```html
+    /// <tag aria-posinset="" />
+    /// ```
+    func aria(positionInset_ value: Int) -> Self
+}
+
+extension AriaPositionInsetAttribute {
+    
+    internal var key: String { "aria-posinset" }
+}
+
+extension AriaPositionInsetAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaposinset value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaPositionInsetAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaposinset value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaPressedAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-pressed'.
+    ///
+    /// ```html
+    /// <tag aria-pressed="" />
+    /// ```
+    func aria(presssed value: Accessibility.Pressed) -> Self
+}
+
+extension AriaPressedAttribute {
+    
+    internal var key: String { "aria-pressed" }
+}
+
+extension AriaPressedAttribute where Self: ContentNode {
+    
+    internal func mutate(ariapressed value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaPressedAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariapressed value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaReadonlyAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-readonly'.
+    ///
+    /// ```html
+    /// <tag aria-readonly="" />
+    /// ```
+    func aria(readonly value: Bool) -> Self
+}
+
+extension AriaReadonlyAttribute {
+    
+    internal var key: String { "aria-readonly" }
+}
+
+extension AriaReadonlyAttribute where Self: ContentNode {
+    
+    internal func mutate(ariareadonly value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaReadonlyAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariareadonly value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaRelevantAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-relevant'.
+    ///
+    /// ```html
+    /// <tag aria-relevant="" />
+    /// ```
+    func aria(relevant value: Accessibility.Relevant) -> Self
+}
+
+extension AriaRelevantAttribute {
+    
+    internal var key: String { "aria-relevant" }
+}
+
+extension AriaRelevantAttribute where Self: ContentNode {
+    
+    internal func mutate(ariarelevant value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaRelevantAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariarelevant value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaRequiredAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-required'.
+    ///
+    /// ```html
+    /// <tag aria-required="" />
+    /// ```
+    func aria(required value: Bool) -> Self
+}
+
+extension AriaRequiredAttribute {
+    
+    internal var key: String { "aria-required" }
+}
+
+extension AriaRequiredAttribute where Self: ContentNode {
+    
+    internal func mutate(ariarequired value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaRequiredAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariarequired value: Bool) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaRoleDescriptionAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-roledescription'.
+    ///
+    /// ```html
+    /// <tag aria-roledescription="" />
+    /// ```
+    func aria(roleDescription value: String) -> Self
+}
+
+extension AriaRoleDescriptionAttribute {
+    
+    internal var key: String { "aria-roledescription" }
+}
+
+extension AriaRoleDescriptionAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaroledescription value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaRoleDescriptionAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaroledescription value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaRowCountAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-rowcount'.
+    ///
+    /// ```html
+    /// <tag aria-rowcount="" />
+    /// ```
+    func aria(rowCount value: Int) -> Self
+}
+
+extension AriaRowCountAttribute {
+    
+    internal var key: String { "aria-rowcount" }
+}
+
+extension AriaRowCountAttribute where Self: ContentNode {
+    
+    internal func mutate(ariarowcount value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaRowCountAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariarowcount value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaRowIndexAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-rowindex'.
+    ///
+    /// ```html
+    /// <tag aria-rowindex="" />
+    /// ```
+    func aria(rowIndex value: Int) -> Self
+}
+
+extension AriaRowIndexAttribute {
+    
+    internal var key: String { "aria-rowindex" }
+}
+
+extension AriaRowIndexAttribute where Self: ContentNode {
+    
+    internal func mutate(ariarowindex value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaRowIndexAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariarowindex value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaRowSpanAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-rowspan'.
+    ///
+    /// ```html
+    /// <tag aria-rowspan="" />
+    /// ```
+    func aria(rowSpan value: Int) -> Self
+}
+
+extension AriaRowSpanAttribute {
+    
+    internal var key: String { "aria-rowspan" }
+}
+
+extension AriaRowSpanAttribute where Self: ContentNode {
+    
+    internal func mutate(ariarowspan value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaRowSpanAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariarowspan value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaSelectedAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-selected'.
+    ///
+    /// ```html
+    /// <tag aria-selected="" />
+    /// ```
+    func aria(selected value: Accessibility.Selected) -> Self
+}
+
+extension AriaSelectedAttribute {
+    
+    internal var key: String { "aria-selected" }
+}
+
+extension AriaSelectedAttribute where Self: ContentNode {
+    
+    internal func mutate(ariaselected value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaSelectedAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariaselected value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaSetSizeAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-setsize'.
+    ///
+    /// ```html
+    /// <tag aria-setsize="" />
+    /// ```
+    func aria(setSize value: Int) -> Self
+}
+
+extension AriaSetSizeAttribute {
+    
+    internal var key: String { "aria-setsize" }
+}
+
+extension AriaSetSizeAttribute where Self: ContentNode {
+    
+    internal func mutate(ariasetsize value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaSetSizeAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariasetsize value: Int) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaSortAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-sort'.
+    ///
+    /// ```html
+    /// <tag aria-sort="" />
+    /// ```
+    func aria(sort value: Accessibility.Sort) -> Self
+}
+
+extension AriaSortAttribute {
+    
+    internal var key: String { "aria-sort" }
+}
+
+extension AriaSortAttribute where Self: ContentNode {
+    
+    internal func mutate(ariasort value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaSortAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariasort value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaValueMaximumAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-valuemax'.
+    ///
+    /// ```html
+    /// <tag aria-valuemax="" />
+    /// ```
+    func aria(valueMaximum value: Float) -> Self
+}
+
+extension AriaValueMaximumAttribute {
+    
+    internal var key: String { "aria-valuemax" }
+}
+
+extension AriaValueMaximumAttribute where Self: ContentNode {
+    
+    internal func mutate(ariavaluemax value: Float) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaValueMaximumAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariavaluemax value: Float) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaValueMininumAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-valuemin'.
+    ///
+    /// ```html
+    /// <tag aria-valuemin="" />
+    /// ```
+    func aria(valueMinimum value: Float) -> Self
+}
+
+extension AriaValueMininumAttribute {
+    
+    internal var key: String { "aria-valuemin" }
+}
+
+extension AriaValueMininumAttribute where Self: ContentNode {
+    
+    internal func mutate(ariavaluemin value: Float) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaValueMininumAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariavaluemin value: Float) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaValueNowAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-valuenow"'.
+    ///
+    /// ```html
+    /// <tag aria-valuenow="" />
+    /// ```
+    func aria(valueNow value: Float) -> Self
+}
+
+extension AriaValueNowAttribute {
+    
+    internal var key: String { "aria-valuenow" }
+}
+
+extension AriaValueNowAttribute where Self: ContentNode {
+    
+    internal func mutate(ariavaluenow value: Float) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaValueNowAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariavaluenow value: Float) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+/// The protocol provides the element with accessibility handler.
+public protocol AriaValueTextAttribute: AnyAttribute {
+    
+    /// The function represents the html-attribute 'aria-valuetext'.
+    ///
+    /// ```html
+    /// <tag aria-valuetext="" />
+    /// ```
+    func aria(valueText value: String) -> Self
+}
+
+extension AriaValueTextAttribute {
+    
+    internal var key: String { "aria-valuetext" }
+}
+
+extension AriaValueTextAttribute where Self: ContentNode {
+    
+    internal func mutate(ariavaluetext value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}
+
+extension AriaValueTextAttribute where Self: EmptyNode {
+    
+    internal func mutate(ariavaluetext value: String) -> Self {
+        return self.mutate(key: key, value: value)
+    }
+}

--- a/Sources/HTMLKit/External/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/External/Elements/BodyElements.swift
@@ -370,7 +370,7 @@ public struct Article: ContentNode, HtmlElement, BodyElement, FormElement, Figur
     }
 }
 
-extension Article: GlobalAttributes, GlobalEventAttributes {
+extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Article {
         return mutate(accesskey: value)
@@ -509,6 +509,82 @@ extension Article: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Article {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Article {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Article {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Article {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Article {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Article {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Article {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Article {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Article {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Article {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Article {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Article {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Article {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Article {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Article {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Article {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Article {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Article {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Article {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Article {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Article: AnyContent {
@@ -581,7 +657,7 @@ public struct Section: ContentNode, HtmlElement, BodyElement, FigureElement, For
     }
 }
 
-extension Section: GlobalAttributes, GlobalEventAttributes {
+extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Section {
         return mutate(accesskey: value)
@@ -720,6 +796,82 @@ extension Section: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Section {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Section {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Section {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Section {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Section {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Section {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Section {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Section {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Section {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Section {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Section {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Section {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Section {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Section {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Section {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Section {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Section {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Section {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Section {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Section {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Section: AnyContent {
@@ -792,7 +944,7 @@ public struct Navigation: ContentNode, HtmlElement, BodyElement, FormElement, Fi
     }
 }
 
-extension Navigation: GlobalAttributes, GlobalEventAttributes {
+extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Navigation {
         return mutate(accesskey: value)
@@ -931,6 +1083,82 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Navigation {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Navigation {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Navigation {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Navigation {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Navigation {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Navigation {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Navigation {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Navigation {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Navigation {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Navigation {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Navigation {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Navigation {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Navigation {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Navigation {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Navigation {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Navigation {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Navigation {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Navigation {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Navigation {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Navigation {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Navigation: AnyContent {
@@ -1003,7 +1231,7 @@ public struct Aside: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
     }
 }
 
-extension Aside: GlobalAttributes, GlobalEventAttributes {
+extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Aside {
         return mutate(accesskey: value)
@@ -1142,6 +1370,82 @@ extension Aside: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Aside {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Aside {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Aside {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Aside {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Aside {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Aside {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Aside {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Aside {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Aside {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Aside {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Aside {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Aside {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Aside {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Aside {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Aside {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Aside {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Aside {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Aside {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Aside {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Aside {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Aside: AnyContent {
@@ -1214,7 +1518,7 @@ public struct Heading1: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Heading1: GlobalAttributes, GlobalEventAttributes {
+extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Heading1 {
         return mutate(accesskey: value)
@@ -1353,6 +1657,82 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Heading1 {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Heading1 {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Heading1 {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Heading1 {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Heading1 {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Heading1 {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Heading1 {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Heading1 {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Heading1 {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Heading1 {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Heading1 {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Heading1 {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Heading1 {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Heading1 {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Heading1 {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Heading1 {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Heading1 {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Heading1 {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Heading1 {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Heading1 {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Heading1: AnyContent {
@@ -1436,7 +1816,7 @@ public struct Heading2: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Heading2: GlobalAttributes, GlobalEventAttributes {
+extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Heading2 {
         return mutate(accesskey: value)
@@ -1575,6 +1955,82 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Heading2 {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Heading2 {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Heading2 {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Heading2 {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Heading2 {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Heading2 {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Heading2 {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Heading2 {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Heading2 {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Heading2 {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Heading2 {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Heading2 {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Heading2 {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Heading2 {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Heading2 {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Heading2 {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Heading2 {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Heading2 {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Heading2 {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Heading2 {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Heading2: AnyContent {
@@ -1658,7 +2114,7 @@ public struct Heading3: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Heading3: GlobalAttributes, GlobalEventAttributes {
+extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Heading3 {
         return mutate(accesskey: value)
@@ -1797,6 +2253,82 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Heading3 {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Heading3 {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Heading3 {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Heading3 {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Heading3 {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Heading3 {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Heading3 {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Heading3 {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Heading3 {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Heading3 {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Heading3 {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Heading3 {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Heading3 {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Heading3 {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Heading3 {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Heading3 {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Heading3 {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Heading3 {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Heading3 {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Heading3 {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Heading3: AnyContent {
@@ -1880,7 +2412,7 @@ public struct Heading4: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Heading4: GlobalAttributes, GlobalEventAttributes {
+extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Heading4 {
         return mutate(accesskey: value)
@@ -2019,6 +2551,82 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Heading4 {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Heading4 {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Heading4 {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Heading4 {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Heading4 {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Heading4 {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Heading4 {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Heading4 {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Heading4 {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Heading4 {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Heading4 {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Heading4 {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Heading4 {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Heading4 {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Heading4 {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Heading4 {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Heading4 {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Heading4 {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Heading4 {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Heading4 {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Heading4: AnyContent {
@@ -2102,7 +2710,7 @@ public struct Heading5: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Heading5: GlobalAttributes, GlobalEventAttributes {
+extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Heading5 {
         return mutate(accesskey: value)
@@ -2241,6 +2849,82 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Heading5 {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Heading5 {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Heading5 {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Heading5 {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Heading5 {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Heading5 {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Heading5 {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Heading5 {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Heading5 {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Heading5 {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Heading5 {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Heading5 {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Heading5 {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Heading5 {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Heading5 {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Heading5 {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Heading5 {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Heading5 {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Heading5 {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Heading5 {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Heading5: AnyContent {
@@ -2324,7 +3008,7 @@ public struct Heading6: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Heading6: GlobalAttributes, GlobalEventAttributes {
+extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Heading6 {
         return mutate(accesskey: value)
@@ -2463,6 +3147,82 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Heading6 {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Heading6 {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Heading6 {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Heading6 {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Heading6 {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Heading6 {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Heading6 {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Heading6 {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Heading6 {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Heading6 {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Heading6 {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Heading6 {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Heading6 {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Heading6 {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Heading6 {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Heading6 {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Heading6 {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Heading6 {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Heading6 {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Heading6 {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Heading6: AnyContent {
@@ -2546,7 +3306,7 @@ public struct HeadingGroup: ContentNode, HtmlElement, BodyElement, FormElement, 
     }
 }
 
-extension HeadingGroup: GlobalAttributes, GlobalEventAttributes {
+extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> HeadingGroup {
         return mutate(accesskey: value)
@@ -2685,6 +3445,82 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> HeadingGroup {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> HeadingGroup {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> HeadingGroup {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> HeadingGroup {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> HeadingGroup {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> HeadingGroup {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> HeadingGroup {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> HeadingGroup {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> HeadingGroup {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> HeadingGroup {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> HeadingGroup {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> HeadingGroup {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> HeadingGroup {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> HeadingGroup {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> HeadingGroup {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> HeadingGroup {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> HeadingGroup {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> HeadingGroup {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> HeadingGroup {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> HeadingGroup {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension HeadingGroup: AnyContent {
@@ -2757,7 +3593,7 @@ public struct Header: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Header: GlobalAttributes, GlobalEventAttributes {
+extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Header {
         return mutate(accesskey: value)
@@ -2896,6 +3732,82 @@ extension Header: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Header {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Header {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Header {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Header {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Header {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Header {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Header {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Header {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Header {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Header {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Header {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Header {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Header {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Header {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Header {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Header {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Header {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Header {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Header {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Header {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Header: AnyContent {
@@ -2968,7 +3880,7 @@ public struct Footer: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Footer: GlobalAttributes, GlobalEventAttributes {
+extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Footer {
         return mutate(accesskey: value)
@@ -3107,6 +4019,82 @@ extension Footer: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Footer {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Footer {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Footer {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Footer {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Footer {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Footer {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Footer {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Footer {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Footer {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Footer {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Footer {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Footer {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Footer {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Footer {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Footer {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Footer {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Footer {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Footer {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Footer {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Footer {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Footer: AnyContent {
@@ -3179,7 +4167,7 @@ public struct Address: ContentNode, HtmlElement, BodyElement, FormElement, Figur
     }
 }
 
-extension Address: GlobalAttributes, GlobalEventAttributes {
+extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Address {
         return mutate(accesskey: value)
@@ -3318,6 +4306,82 @@ extension Address: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Address {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Address {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Address {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Address {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Address {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Address {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Address {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Address {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Address {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Address {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Address {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Address {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Address {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Address {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Address {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Address {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Address {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Address {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Address {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Address {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Address: AnyContent {
@@ -3390,7 +4454,7 @@ public struct Paragraph: ContentNode, HtmlElement, BodyElement, FormElement, Fig
     }
 }
 
-extension Paragraph: GlobalAttributes, GlobalEventAttributes {
+extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Paragraph {
         return mutate(accesskey: value)
@@ -3529,6 +4593,82 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Paragraph {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Paragraph {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Paragraph {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Paragraph {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Paragraph {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Paragraph {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Paragraph {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Paragraph {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Paragraph {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Paragraph {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Paragraph {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Paragraph {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Paragraph {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Paragraph {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Paragraph {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Paragraph {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Paragraph {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Paragraph {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Paragraph {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Paragraph {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Paragraph: AnyContent {
@@ -3607,7 +4747,7 @@ public struct HorizontalRule: EmptyNode, HtmlElement, BodyElement, FormElement, 
     }
 }
 
-extension HorizontalRule: GlobalAttributes, GlobalEventAttributes {
+extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> HorizontalRule {
         return mutate(accesskey: value)
@@ -3746,6 +4886,82 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> HorizontalRule {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> HorizontalRule {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> HorizontalRule {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> HorizontalRule {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> HorizontalRule {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> HorizontalRule {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> HorizontalRule {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> HorizontalRule {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> HorizontalRule {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> HorizontalRule {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> HorizontalRule {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> HorizontalRule {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> HorizontalRule {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> HorizontalRule {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> HorizontalRule {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> HorizontalRule {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> HorizontalRule {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> HorizontalRule {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> HorizontalRule {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> HorizontalRule {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension HorizontalRule: AnyContent {
@@ -3818,7 +5034,7 @@ public struct PreformattedText: ContentNode, HtmlElement, BodyElement, FormEleme
     }
 }
 
-extension PreformattedText: GlobalAttributes, GlobalEventAttributes {
+extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> PreformattedText {
         return mutate(accesskey: value)
@@ -3957,6 +5173,82 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> PreformattedText {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> PreformattedText {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> PreformattedText {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> PreformattedText {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> PreformattedText {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> PreformattedText {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> PreformattedText {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> PreformattedText {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> PreformattedText {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> PreformattedText {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> PreformattedText {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> PreformattedText {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> PreformattedText {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> PreformattedText {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> PreformattedText {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> PreformattedText {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> PreformattedText {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> PreformattedText {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> PreformattedText {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> PreformattedText {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension PreformattedText: AnyContent {
@@ -4029,7 +5321,7 @@ public struct Blockquote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
     }
 }
 
-extension Blockquote: GlobalAttributes, GlobalEventAttributes, CiteAttribute {
+extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, CiteAttribute {
     
     public func accessKey(_ value: Character) -> Blockquote {
         return mutate(accesskey: value)
@@ -4172,6 +5464,82 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, CiteAttribute {
     public func on(event: Events.Wheel, _ value: String) -> Blockquote {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Blockquote {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Blockquote {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Blockquote {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Blockquote {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Blockquote {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Blockquote {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Blockquote {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Blockquote {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Blockquote {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Blockquote {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Blockquote {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Blockquote {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Blockquote {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Blockquote {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Blockquote {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Blockquote {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Blockquote {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Blockquote {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Blockquote {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Blockquote: AnyContent {
@@ -4255,7 +5623,7 @@ public struct OrderedList: ContentNode, HtmlElement, BodyElement, FormElement, F
     }
 }
 
-extension OrderedList: GlobalAttributes, GlobalEventAttributes, ReversedAttribute, StartAttribute, TypeAttribute {
+extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ReversedAttribute, StartAttribute, TypeAttribute {
     
     public func accessKey(_ value: Character) -> OrderedList {
         return mutate(accesskey: value)
@@ -4406,6 +5774,82 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, ReversedAttribut
     public func on(event: Events.Wheel, _ value: String) -> OrderedList {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> OrderedList {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> OrderedList {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> OrderedList {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> OrderedList {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> OrderedList {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> OrderedList {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> OrderedList {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> OrderedList {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> OrderedList {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> OrderedList {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> OrderedList {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> OrderedList {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> OrderedList {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> OrderedList {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> OrderedList {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> OrderedList {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> OrderedList {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> OrderedList {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> OrderedList {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension OrderedList: AnyContent {
@@ -4478,7 +5922,7 @@ public struct UnorderedList: ContentNode, HtmlElement, BodyElement, FormElement,
     }
 }
 
-extension UnorderedList: GlobalAttributes, GlobalEventAttributes {
+extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> UnorderedList {
         return mutate(accesskey: value)
@@ -4617,6 +6061,82 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> UnorderedList {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> UnorderedList {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> UnorderedList {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> UnorderedList {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> UnorderedList {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> UnorderedList {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> UnorderedList {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> UnorderedList {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> UnorderedList {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> UnorderedList {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> UnorderedList {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> UnorderedList {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> UnorderedList {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> UnorderedList {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> UnorderedList {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> UnorderedList {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> UnorderedList {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> UnorderedList {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> UnorderedList {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> UnorderedList {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension UnorderedList: AnyContent {
@@ -4689,7 +6209,7 @@ public struct DescriptionList: ContentNode, HtmlElement, BodyElement, FormElemen
     }
 }
 
-extension DescriptionList: GlobalAttributes, GlobalEventAttributes {
+extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> DescriptionList {
         return mutate(accesskey: value)
@@ -4828,6 +6348,82 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> DescriptionList {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> DescriptionList {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> DescriptionList {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> DescriptionList {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> DescriptionList {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> DescriptionList {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> DescriptionList {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> DescriptionList {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> DescriptionList {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> DescriptionList {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> DescriptionList {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> DescriptionList {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> DescriptionList {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> DescriptionList {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> DescriptionList {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> DescriptionList {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> DescriptionList {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> DescriptionList {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> DescriptionList {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> DescriptionList {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension DescriptionList: AnyContent {
@@ -4900,7 +6496,7 @@ public struct Figure: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Figure: GlobalAttributes, GlobalEventAttributes {
+extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Figure {
         return mutate(accesskey: value)
@@ -5039,6 +6635,82 @@ extension Figure: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Figure {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Figure {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Figure {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Figure {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Figure {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Figure {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Figure {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Figure {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Figure {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Figure {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Figure {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Figure {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Figure {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Figure {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Figure {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Figure {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Figure {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Figure {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Figure {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Figure {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Figure: AnyContent {
@@ -5111,7 +6783,7 @@ public struct Anchor: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Anchor: GlobalAttributes, GlobalEventAttributes, DownloadAttribute, ReferenceAttribute, ReferenceLanguageAttribute, MediaAttribute, PingAttribute, ReferrerPolicyAttribute, RelationshipAttribute, TargetAttribute, TypeAttribute {
+extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DownloadAttribute, ReferenceAttribute, ReferenceLanguageAttribute, MediaAttribute, PingAttribute, ReferrerPolicyAttribute, RelationshipAttribute, TargetAttribute, TypeAttribute {
     
     public func accessKey(_ value: Character) -> Anchor {
         return mutate(accesskey: value)
@@ -5290,6 +6962,82 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, DownloadAttribute, Re
     public func on(event: Events.Wheel, _ value: String) -> Anchor {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Anchor {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Anchor {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Anchor {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Anchor {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Anchor {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Anchor {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Anchor {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Anchor {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Anchor {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Anchor {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Anchor {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Anchor {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Anchor {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Anchor {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Anchor {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Anchor {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Anchor {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Anchor {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Anchor {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Anchor: AnyContent {
@@ -5373,7 +7121,7 @@ public struct Emphasize: ContentNode, HtmlElement, BodyElement, FormElement, Fig
     }
 }
 
-extension Emphasize: GlobalAttributes, GlobalEventAttributes {
+extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Emphasize {
         return mutate(accesskey: value)
@@ -5512,6 +7260,82 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Emphasize {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Emphasize {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Emphasize {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Emphasize {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Emphasize {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Emphasize {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Emphasize {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Emphasize {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Emphasize {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Emphasize {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Emphasize {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Emphasize {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Emphasize {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Emphasize {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Emphasize {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Emphasize {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Emphasize {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Emphasize {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Emphasize {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Emphasize {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Emphasize: AnyContent {
@@ -5584,7 +7408,7 @@ public struct Strong: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Strong: GlobalAttributes, GlobalEventAttributes {
+extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Strong {
         return mutate(accesskey: value)
@@ -5723,6 +7547,82 @@ extension Strong: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Strong {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Strong {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Strong {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Strong {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Strong {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Strong {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Strong {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Strong {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Strong {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Strong {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Strong {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Strong {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Strong {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Strong {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Strong {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Strong {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Strong {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Strong {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Strong {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Strong {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Strong: AnyContent {
@@ -5795,7 +7695,7 @@ public struct Small: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
     }
 }
 
-extension Small: GlobalAttributes, GlobalEventAttributes {
+extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Small {
         return mutate(accesskey: value)
@@ -5933,6 +7833,82 @@ extension Small: GlobalAttributes, GlobalEventAttributes {
     
     public func on(event: Events.Wheel, _ value: String) -> Small {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Small {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Small {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Small {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Small {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Small {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Small {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Small {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Small {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Small {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Small {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Small {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Small {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Small {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Small {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Small {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Small {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Small {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Small {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Small {
+        return mutate(ariaroledescription: value)
     }
 }
 
@@ -6239,7 +8215,7 @@ public struct Main: ContentNode, HtmlElement, BodyElement, FormElement {
     }
 }
 
-extension Main: GlobalAttributes, GlobalEventAttributes {
+extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Main {
         return mutate(accesskey: value)
@@ -6378,6 +8354,82 @@ extension Main: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Main {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Main {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Main {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Main {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Main {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Main {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Main {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Main {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Main {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Main {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Main {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Main {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Main {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Main {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Main {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Main {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Main {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Main {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Main {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Main {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Main: AnyContent {
@@ -6450,7 +8502,7 @@ public struct Division: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Division: GlobalAttributes, GlobalEventAttributes {
+extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Division {
         return mutate(accesskey: value)
@@ -6589,6 +8641,82 @@ extension Division: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Division {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Division {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Division {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Division {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Division {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Division {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Division {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Division {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Division {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Division {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Division {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Division {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Division {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Division {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Division {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Division {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Division {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Division {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Division {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Division {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Division: AnyContent {
@@ -6661,7 +8789,7 @@ public struct Definition: ContentNode, HtmlElement, BodyElement, FormElement, Fi
     }
 }
 
-extension Definition: GlobalAttributes, GlobalEventAttributes {
+extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Definition {
         return mutate(accesskey: value)
@@ -6800,6 +8928,82 @@ extension Definition: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Definition {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Definition {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Definition {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Definition {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Definition {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Definition {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Definition {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Definition {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Definition {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Definition {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Definition {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Definition {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Definition {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Definition {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Definition {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Definition {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Definition {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Definition {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Definition {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Definition {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Definition: AnyContent {
@@ -6872,7 +9076,7 @@ public struct Cite: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Cite: GlobalAttributes, GlobalEventAttributes {
+extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Cite {
         return mutate(accesskey: value)
@@ -7011,6 +9215,82 @@ extension Cite: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Cite {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Cite {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Cite {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Cite {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Cite {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Cite {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Cite {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Cite {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Cite {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Cite {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Cite {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Cite {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Cite {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Cite {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Cite {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Cite {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Cite {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Cite {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Cite {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Cite {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Cite: AnyContent {
@@ -7083,7 +9363,7 @@ public struct ShortQuote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
     }
 }
 
-extension ShortQuote: GlobalAttributes, GlobalEventAttributes, CiteAttribute {
+extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, CiteAttribute {
     
     public func accessKey(_ value: Character) -> ShortQuote {
         return mutate(accesskey: value)
@@ -7226,6 +9506,82 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, CiteAttribute {
     public func on(event: Events.Wheel, _ value: String) -> ShortQuote {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> ShortQuote {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> ShortQuote {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> ShortQuote {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> ShortQuote {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> ShortQuote {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> ShortQuote {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> ShortQuote {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> ShortQuote {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> ShortQuote {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> ShortQuote {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> ShortQuote {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> ShortQuote {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> ShortQuote {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> ShortQuote {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> ShortQuote {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> ShortQuote {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> ShortQuote {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> ShortQuote {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> ShortQuote {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension ShortQuote: AnyContent {
@@ -7298,7 +9654,7 @@ public struct Abbreviation: ContentNode, HtmlElement, BodyElement, FormElement, 
     }
 }
 
-extension Abbreviation: GlobalAttributes, GlobalEventAttributes {
+extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Abbreviation {
         return mutate(accesskey: value)
@@ -7437,6 +9793,82 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Abbreviation {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Abbreviation {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Abbreviation {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Abbreviation {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Abbreviation {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Abbreviation {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Abbreviation {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Abbreviation {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Abbreviation {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Abbreviation {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Abbreviation {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Abbreviation {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Abbreviation {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Abbreviation {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Abbreviation {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Abbreviation {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Abbreviation {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Abbreviation {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Abbreviation {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Abbreviation {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Abbreviation: AnyContent {
@@ -7509,7 +9941,7 @@ public struct Ruby: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Ruby: GlobalAttributes, GlobalEventAttributes {
+extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Ruby {
         return mutate(accesskey: value)
@@ -7648,6 +10080,82 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Ruby {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Ruby {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Ruby {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Ruby {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Ruby {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Ruby {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Ruby {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Ruby {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Ruby {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Ruby {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Ruby {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Ruby {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Ruby {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Ruby {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Ruby {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Ruby {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Ruby {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Ruby {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Ruby {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Ruby {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Ruby: AnyContent {
@@ -7720,7 +10228,7 @@ public struct Data: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Data: GlobalAttributes, GlobalEventAttributes, ValueAttribute {
+extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ValueAttribute {
     
     public func accessKey(_ value: Character) -> Data {
         return mutate(accesskey: value)
@@ -7867,6 +10375,82 @@ extension Data: GlobalAttributes, GlobalEventAttributes, ValueAttribute {
     public func on(event: Events.Wheel, _ value: String) -> Data {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Data {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Data {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Data {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Data {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Data {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Data {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Data {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Data {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Data {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Data {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Data {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Data {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Data {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Data {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Data {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Data {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Data {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Data {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Data {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Data: AnyContent {
@@ -7939,7 +10523,7 @@ public struct Time: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Time: GlobalAttributes, GlobalEventAttributes, DateTimeAttribute {
+extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DateTimeAttribute {
 
     public func accessKey(_ value: Character) -> Time {
         return mutate(accesskey: value)
@@ -8082,6 +10666,82 @@ extension Time: GlobalAttributes, GlobalEventAttributes, DateTimeAttribute {
     public func on(event: Events.Wheel, _ value: String) -> Time {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Time {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Time {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Time {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Time {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Time {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Time {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Time {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Time {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Time {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Time {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Time {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Time {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Time {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Time {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Time {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Time {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Time {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Time {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Time {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Time: AnyContent {
@@ -8154,7 +10814,7 @@ public struct Code: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Code: GlobalAttributes, GlobalEventAttributes {
+extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Code {
         return mutate(accesskey: value)
@@ -8293,6 +10953,82 @@ extension Code: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Code {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Code {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Code {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Code {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Code {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Code {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Code {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Code {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Code {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Code {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Code {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Code {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Code {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Code {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Code {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Code {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Code {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Code {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Code {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Code {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Code: AnyContent {
@@ -8365,7 +11101,7 @@ public struct Variable: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Variable: GlobalAttributes, GlobalEventAttributes {
+extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Variable {
         return mutate(accesskey: value)
@@ -8504,6 +11240,82 @@ extension Variable: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Variable {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Variable {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Variable {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Variable {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Variable {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Variable {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Variable {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Variable {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Variable {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Variable {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Variable {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Variable {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Variable {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Variable {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Variable {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Variable {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Variable {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Variable {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Variable {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Variable {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Variable: AnyContent {
@@ -8576,7 +11388,7 @@ public struct SampleOutput: ContentNode, HtmlElement, BodyElement, FormElement, 
     }
 }
 
-extension SampleOutput: GlobalAttributes, GlobalEventAttributes {
+extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> SampleOutput {
         return mutate(accesskey: value)
@@ -8715,6 +11527,82 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> SampleOutput {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> SampleOutput {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> SampleOutput {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> SampleOutput {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> SampleOutput {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> SampleOutput {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> SampleOutput {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> SampleOutput {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> SampleOutput {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> SampleOutput {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> SampleOutput {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> SampleOutput {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> SampleOutput {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> SampleOutput {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> SampleOutput {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> SampleOutput {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> SampleOutput {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> SampleOutput {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> SampleOutput {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> SampleOutput {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension SampleOutput: AnyContent {
@@ -8787,7 +11675,7 @@ public struct KeyboardInput: ContentNode, HtmlElement, BodyElement, FormElement,
     }
 }
 
-extension KeyboardInput: GlobalAttributes, GlobalEventAttributes {
+extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> KeyboardInput {
         return mutate(accesskey: value)
@@ -8926,6 +11814,82 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> KeyboardInput {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> KeyboardInput {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> KeyboardInput {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> KeyboardInput {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> KeyboardInput {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> KeyboardInput {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> KeyboardInput {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> KeyboardInput {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> KeyboardInput {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> KeyboardInput {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> KeyboardInput {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> KeyboardInput {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> KeyboardInput {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> KeyboardInput {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> KeyboardInput {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> KeyboardInput {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> KeyboardInput {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> KeyboardInput {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> KeyboardInput {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> KeyboardInput {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension KeyboardInput: AnyContent {
@@ -8998,7 +11962,7 @@ public struct Subscript: ContentNode, HtmlElement, BodyElement, FormElement, Fig
     }
 }
 
-extension Subscript: GlobalAttributes, GlobalEventAttributes {
+extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Subscript {
         return mutate(accesskey: value)
@@ -9137,6 +12101,82 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Subscript {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Subscript {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Subscript {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Subscript {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Subscript {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Subscript {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Subscript {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Subscript {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Subscript {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Subscript {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Subscript {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Subscript {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Subscript {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Subscript {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Subscript {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Subscript {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Subscript {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Subscript {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Subscript {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Subscript {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Subscript: AnyContent {
@@ -9209,7 +12249,7 @@ public struct Superscript: ContentNode, HtmlElement, BodyElement, FormElement, F
     }
 }
 
-extension Superscript: GlobalAttributes, GlobalEventAttributes {
+extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Superscript {
         return mutate(accesskey: value)
@@ -9348,6 +12388,82 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Superscript {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Superscript {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Superscript {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Superscript {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Superscript {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Superscript {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Superscript {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Superscript {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Superscript {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Superscript {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Superscript {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Superscript {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Superscript {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Superscript {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Superscript {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Superscript {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Superscript {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Superscript {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Superscript {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Superscript {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Superscript: AnyContent {
@@ -9420,7 +12536,7 @@ public struct Italic: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Italic: GlobalAttributes, GlobalEventAttributes {
+extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Italic {
         return mutate(accesskey: value)
@@ -9559,6 +12675,82 @@ extension Italic: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Italic {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Italic {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Italic {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Italic {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Italic {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Italic {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Italic {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Italic {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Italic {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Italic {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Italic {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Italic {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Italic {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Italic {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Italic {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Italic {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Italic {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Italic {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Italic {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Italic {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Italic: Localizable {
@@ -9642,7 +12834,7 @@ public struct Bold: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Bold: GlobalAttributes, GlobalEventAttributes {
+extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Bold {
         return mutate(accesskey: value)
@@ -9781,6 +12973,82 @@ extension Bold: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Bold {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Bold {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Bold {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Bold {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Bold {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Bold {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Bold {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Bold {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Bold {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Bold {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Bold {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Bold {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Bold {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Bold {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Bold {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Bold {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Bold {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Bold {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Bold {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Bold {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Bold: Localizable {
@@ -9864,7 +13132,7 @@ public struct Underline: ContentNode, HtmlElement, BodyElement, FormElement, Fig
     }
 }
 
-extension Underline: GlobalAttributes, GlobalEventAttributes {
+extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Underline {
         return mutate(accesskey: value)
@@ -10003,6 +13271,82 @@ extension Underline: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Underline {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Underline {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Underline {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Underline {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Underline {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Underline {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Underline {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Underline {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Underline {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Underline {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Underline {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Underline {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Underline {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Underline {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Underline {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Underline {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Underline {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Underline {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Underline {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Underline {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Underline: Localizable {
@@ -10086,7 +13430,7 @@ public struct Mark: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Mark: GlobalAttributes, GlobalEventAttributes {
+extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Mark {
         return mutate(accesskey: value)
@@ -10225,6 +13569,82 @@ extension Mark: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Mark {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Mark {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Mark {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Mark {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Mark {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Mark {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Mark {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Mark {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Mark {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Mark {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Mark {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Mark {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Mark {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Mark {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Mark {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Mark {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Mark {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Mark {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Mark {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Mark {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Mark: AnyContent {
@@ -10297,7 +13717,7 @@ public struct Bdi: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
     }
 }
 
-extension Bdi: GlobalAttributes, GlobalEventAttributes {
+extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Bdi {
         return mutate(accesskey: value)
@@ -10436,6 +13856,82 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Bdi {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Bdi {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Bdi {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Bdi {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Bdi {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Bdi {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Bdi {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Bdi {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Bdi {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Bdi {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Bdi {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Bdi {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Bdi {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Bdi {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Bdi {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Bdi {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Bdi {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Bdi {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Bdi {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Bdi {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Bdi: AnyContent {
@@ -10503,7 +13999,7 @@ public struct Bdo: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEleme
     }
 }
 
-extension Bdo: GlobalAttributes, GlobalEventAttributes {
+extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Bdo {
         return mutate(accesskey: value)
@@ -10642,6 +14138,82 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Bdo {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Bdo {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Bdo {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Bdo {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Bdo {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Bdo {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Bdo {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Bdo {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Bdo {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Bdo {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Bdo {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Bdo {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Bdo {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Bdo {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Bdo {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Bdo {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Bdo {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Bdo {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Bdo {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Bdo {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Bdo: AnyContent {
@@ -10714,7 +14286,7 @@ public struct Span: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
     }
 }
 
-extension Span: GlobalAttributes, GlobalEventAttributes {
+extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Span {
         return mutate(accesskey: value)
@@ -10853,6 +14425,82 @@ extension Span: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> Span {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Span {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Span {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Span {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Span {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Span {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Span {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Span {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Span {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Span {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Span {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Span {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Span {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Span {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Span {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Span {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Span {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Span {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Span {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Span {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Span: AnyContent {
@@ -10920,7 +14568,7 @@ public struct LineBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
     }
 }
 
-extension LineBreak: GlobalAttributes, GlobalEventAttributes {
+extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> LineBreak {
         return mutate(accesskey: value)
@@ -11059,6 +14707,82 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> LineBreak {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> LineBreak {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> LineBreak {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> LineBreak {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> LineBreak {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> LineBreak {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> LineBreak {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> LineBreak {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> LineBreak {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> LineBreak {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> LineBreak {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> LineBreak {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> LineBreak {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> LineBreak {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> LineBreak {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> LineBreak {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> LineBreak {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> LineBreak {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> LineBreak {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> LineBreak {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension LineBreak: AnyContent {
@@ -11126,7 +14850,7 @@ public struct WordBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
     }
 }
 
-extension WordBreak: GlobalAttributes, GlobalEventAttributes {
+extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> WordBreak {
         return mutate(accesskey: value)
@@ -11265,6 +14989,82 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> WordBreak {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> WordBreak {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> WordBreak {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> WordBreak {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> WordBreak {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> WordBreak {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> WordBreak {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> WordBreak {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> WordBreak {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> WordBreak {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> WordBreak {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> WordBreak {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> WordBreak {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> WordBreak {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> WordBreak {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> WordBreak {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> WordBreak {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> WordBreak {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> WordBreak {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> WordBreak {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension WordBreak: AnyContent {
@@ -11337,7 +15137,7 @@ public struct InsertedText: ContentNode, HtmlElement, BodyElement, FormElement, 
     }
 }
 
-extension InsertedText: GlobalAttributes, GlobalEventAttributes, CiteAttribute, DateTimeAttribute {
+extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, CiteAttribute, DateTimeAttribute {
     
     public func accessKey(_ value: Character) -> InsertedText {
         return mutate(accesskey: value)
@@ -11484,6 +15284,82 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, CiteAttribute, 
     public func on(event: Events.Wheel, _ value: String) -> InsertedText {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> InsertedText {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> InsertedText {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> InsertedText {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> InsertedText {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> InsertedText {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> InsertedText {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> InsertedText {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> InsertedText {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> InsertedText {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> InsertedText {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> InsertedText {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> InsertedText {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> InsertedText {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> InsertedText {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> InsertedText {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> InsertedText {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> InsertedText {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> InsertedText {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> InsertedText {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension InsertedText: AnyContent {
@@ -11556,7 +15432,7 @@ public struct DeletedText: ContentNode, HtmlElement, BodyElement, FormElement, F
     }
 }
 
-extension DeletedText: GlobalAttributes, GlobalEventAttributes, CiteAttribute, DateTimeAttribute {
+extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, CiteAttribute, DateTimeAttribute {
     
     public func accessKey(_ value: Character) -> DeletedText {
         return mutate(accesskey: value)
@@ -11702,6 +15578,82 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, CiteAttribute, D
     
     public func on(event: Events.Wheel, _ value: String) -> DeletedText {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> DeletedText {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> DeletedText {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> DeletedText {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> DeletedText {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> DeletedText {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> DeletedText {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> DeletedText {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> DeletedText {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> DeletedText {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> DeletedText {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> DeletedText {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> DeletedText {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> DeletedText {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> DeletedText {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> DeletedText {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> DeletedText {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> DeletedText {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> DeletedText {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> DeletedText {
+        return mutate(ariaroledescription: value)
     }
 }
 
@@ -11981,7 +15933,7 @@ public struct Image: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
     }
 }
 
-extension Image: GlobalAttributes, GlobalEventAttributes, AlternateAttribute, SourceAttribute, SizesAttribute, WidthAttribute, HeightAttribute, ReferrerPolicyAttribute {
+extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, AlternateAttribute, SourceAttribute, SizesAttribute, WidthAttribute, HeightAttribute, ReferrerPolicyAttribute {
     
     public func accessKey(_ value: Character) -> Image {
         return mutate(accesskey: value)
@@ -12144,6 +16096,82 @@ extension Image: GlobalAttributes, GlobalEventAttributes, AlternateAttribute, So
     public func on(event: Events.Wheel, _ value: String) -> Image {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Image {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Image {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Image {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Image {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Image {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Image {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Image {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Image {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Image {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Image {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Image {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Image {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Image {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Image {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Image {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Image {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Image {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Image {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Image {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Image: AnyContent {
@@ -12216,7 +16244,7 @@ public struct InlineFrame: ContentNode, HtmlElement, BodyElement, FormElement, F
     }
 }
 
-extension InlineFrame: GlobalAttributes, GlobalEventAttributes, SourceAttribute, NameAttribute, WidthAttribute, HeightAttribute, ReferrerPolicyAttribute {
+extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, SourceAttribute, NameAttribute, WidthAttribute, HeightAttribute, ReferrerPolicyAttribute {
     
     public func accessKey(_ value: Character) -> InlineFrame {
         return mutate(accesskey: value)
@@ -12379,6 +16407,82 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, SourceAttribute,
     public func on(event: Events.Wheel, _ value: String) -> InlineFrame {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> InlineFrame {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> InlineFrame {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> InlineFrame {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> InlineFrame {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> InlineFrame {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> InlineFrame {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> InlineFrame {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> InlineFrame {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> InlineFrame {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> InlineFrame {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> InlineFrame {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> InlineFrame {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> InlineFrame {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> InlineFrame {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> InlineFrame {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> InlineFrame {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> InlineFrame {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> InlineFrame {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> InlineFrame {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension InlineFrame: AnyContent {
@@ -12446,7 +16550,7 @@ public struct Embed: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
     }
 }
 
-extension Embed: GlobalAttributes, GlobalEventAttributes, SourceAttribute, TypeAttribute, WidthAttribute, HeightAttribute {
+extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, SourceAttribute, TypeAttribute, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> Embed {
         return mutate(accesskey: value)
@@ -12601,6 +16705,82 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, SourceAttribute, TypeA
     public func on(event: Events.Wheel, _ value: String) -> Embed {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Embed {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Embed {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Embed {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Embed {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Embed {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Embed {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Embed {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Embed {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Embed {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Embed {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Embed {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Embed {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Embed {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Embed {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Embed {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Embed {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Embed {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Embed {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Embed {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Embed: AnyContent {
@@ -12673,7 +16853,7 @@ public struct Object: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Object: GlobalAttributes, GlobalEventAttributes, DataAttribute, TypeAttribute, NameAttribute, FormAttribute, WidthAttribute, HeightAttribute {
+extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DataAttribute, TypeAttribute, NameAttribute, FormAttribute, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> Object {
         return mutate(accesskey: value)
@@ -12840,6 +17020,82 @@ extension Object: GlobalAttributes, GlobalEventAttributes, DataAttribute, TypeAt
     public func on(event: Events.Wheel, _ value: String) -> Object {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Object {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Object {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Object {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Object {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Object {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Object {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Object {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Object {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Object {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Object {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Object {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Object {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Object {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Object {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Object {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Object {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Object {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Object {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Object {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Object: AnyContent {
@@ -12912,7 +17168,7 @@ public struct Video: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
     }
 }
 
-extension Video: GlobalAttributes, GlobalEventAttributes, SourceAttribute, AutoplayAttribute, LoopAttribute, MutedAttribute, ControlsAttribute, WidthAttribute, HeightAttribute, PreloadAttribute {
+extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, SourceAttribute, AutoplayAttribute, LoopAttribute, MutedAttribute, ControlsAttribute, WidthAttribute, HeightAttribute, PreloadAttribute {
     
     public func accessKey(_ value: Character) -> Video {
         return mutate(accesskey: value)
@@ -13083,6 +17339,82 @@ extension Video: GlobalAttributes, GlobalEventAttributes, SourceAttribute, Autop
     public func on(event: Events.Wheel, _ value: String) -> Video {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Video {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Video {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Video {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Video {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Video {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Video {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Video {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Video {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Video {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Video {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Video {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Video {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Video {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Video {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Video {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Video {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Video {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Video {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Video {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Video: AnyContent {
@@ -13155,7 +17487,7 @@ public struct Audio: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
     }
 }
 
-extension Audio: GlobalAttributes, GlobalEventAttributes, SourceAttribute, AutoplayAttribute, LoopAttribute, MutedAttribute, ControlsAttribute, PreloadAttribute {
+extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, SourceAttribute, AutoplayAttribute, LoopAttribute, MutedAttribute, ControlsAttribute, PreloadAttribute {
     
     public func accessKey(_ value: Character) -> Audio {
         return mutate(accesskey: value)
@@ -13317,6 +17649,82 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, SourceAttribute, Autop
     
     public func on(event: Events.Wheel, _ value: String) -> Audio {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Audio {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Audio {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Audio {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Audio {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Audio {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Audio {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Audio {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Audio {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Audio {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Audio {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Audio {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Audio {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Audio {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Audio {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Audio {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Audio {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Audio {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Audio {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Audio {
+        return mutate(ariaroledescription: value)
     }
 }
 
@@ -13609,7 +18017,7 @@ public struct Form: ContentNode, HtmlElement, BodyElement, FigureElement, Object
     }
 }
 
-extension Form: GlobalAttributes, GlobalEventAttributes, ActionAttribute, AutocompleteAttribute, EncodingAttribute, MethodAttribute, NameAttribute, TargetAttribute, RelationshipAttribute {
+extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ActionAttribute, AutocompleteAttribute, EncodingAttribute, MethodAttribute, NameAttribute, TargetAttribute, RelationshipAttribute {
     
     public func accessKey(_ value: Character) -> Form {
         return mutate(accesskey: value)
@@ -13780,6 +18188,82 @@ extension Form: GlobalAttributes, GlobalEventAttributes, ActionAttribute, Autoco
     public func on(event: Events.Wheel, _ value: String) -> Form {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Form {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Form {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Form {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Form {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Form {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Form {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Form {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Form {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Form {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Form {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Form {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Form {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Form {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Form {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Form {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Form {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Form {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Form {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Form {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Form: AnyContent {
@@ -13852,7 +18336,7 @@ public struct DataList: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension DataList: GlobalAttributes, GlobalEventAttributes {
+extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> DataList {
         return mutate(accesskey: value)
@@ -13991,6 +18475,82 @@ extension DataList: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> DataList {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> DataList {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> DataList {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> DataList {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> DataList {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> DataList {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> DataList {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> DataList {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> DataList {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> DataList {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> DataList {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> DataList {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> DataList {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> DataList {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> DataList {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> DataList {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> DataList {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> DataList {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> DataList {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> DataList {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension DataList: AnyContent {
@@ -14063,7 +18623,7 @@ public struct Output: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Output: GlobalAttributes, GlobalEventAttributes, ForAttribute, FormAttribute, NameAttribute {
+extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ForAttribute, FormAttribute, NameAttribute {
     
     public func accessKey(_ value: Character) -> Output {
         return mutate(accesskey: value)
@@ -14218,6 +18778,82 @@ extension Output: GlobalAttributes, GlobalEventAttributes, ForAttribute, FormAtt
     public func on(event: Events.Wheel, _ value: String) -> Output {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Output {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Output {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Output {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Output {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Output {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Output {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Output {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Output {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Output {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Output {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Output {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Output {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Output {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Output {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Output {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Output {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Output {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Output {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Output {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Output: AnyContent {
@@ -14290,7 +18926,7 @@ public struct Progress: ContentNode, HtmlElement, BodyElement, FormElement, Figu
     }
 }
 
-extension Progress: GlobalAttributes, GlobalEventAttributes, ValueAttribute, MaximumValueAttribute {
+extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ValueAttribute, MaximumValueAttribute {
     
     public func accessKey(_ value: Character) -> Progress {
         return mutate(accesskey: value)
@@ -14441,6 +19077,82 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, ValueAttribute, Max
     public func on(event: Events.Wheel, _ value: String) -> Progress {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Progress {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Progress {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Progress {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Progress {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Progress {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Progress {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Progress {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Progress {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Progress {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Progress {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Progress {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Progress {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Progress {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Progress {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Progress {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Progress {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Progress {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Progress {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Progress {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Progress: AnyContent {
@@ -14513,7 +19225,7 @@ public struct Meter: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
     }
 }
 
-extension Meter: GlobalAttributes, GlobalEventAttributes, ValueAttribute, MinimumValueAttribute, MaximumValueAttribute, LowAttribute, HighAttribute, OptimumAttribute {
+extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ValueAttribute, MinimumValueAttribute, MaximumValueAttribute, LowAttribute, HighAttribute, OptimumAttribute {
 
     public func accessKey(_ value: Character) -> Meter {
         return mutate(accesskey: value)
@@ -14680,6 +19392,82 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, ValueAttribute, Minimu
     public func on(event: Events.Wheel, _ value: String) -> Meter {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Meter {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Meter {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Meter {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Meter {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Meter {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Meter {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Meter {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Meter {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Meter {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Meter {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Meter {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Meter {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Meter {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Meter {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Meter {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Meter {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Meter {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Meter {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Meter {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Meter: AnyContent {
@@ -14752,7 +19540,7 @@ public struct Details: ContentNode, HtmlElement, BodyElement, FormElement, Figur
     }
 }
 
-extension Details: GlobalAttributes, GlobalEventAttributes, OpenAttribute, DetailEventAttribute {
+extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, OpenAttribute, DetailEventAttribute {
     
     public func accessKey(_ value: Character) -> Details {
         return mutate(accesskey: value)
@@ -14899,6 +19687,82 @@ extension Details: GlobalAttributes, GlobalEventAttributes, OpenAttribute, Detai
     public func on(event: Events.Detail, _ value: String) -> Details {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Details {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Details {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Details {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Details {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Details {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Details {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Details {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Details {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Details {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Details {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Details {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Details {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Details {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Details {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Details {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Details {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Details {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Details {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Details {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Details: AnyContent {
@@ -14967,7 +19831,7 @@ public struct Dialog: ContentNode, BodyElement {
     }
 }
 
-extension Dialog: GlobalAttributes, GlobalEventAttributes, OpenAttribute {
+extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, OpenAttribute {
     
     public func accessKey(_ value: Character) -> Dialog {
         return mutate(accesskey: value)
@@ -15109,6 +19973,82 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, OpenAttribute {
     
     public func on(event: Events.Wheel, _ value: String) -> Dialog {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Dialog {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Dialog {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Dialog {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Dialog {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Dialog {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Dialog {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Dialog {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Dialog {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Dialog {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Dialog {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Dialog {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Dialog {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Dialog {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Dialog {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Dialog {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Dialog {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Dialog {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Dialog {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Dialog {
+        return mutate(ariaroledescription: value)
     }
 }
 
@@ -15831,7 +20771,7 @@ public struct Canvas: ContentNode, HtmlElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Canvas: GlobalAttributes, GlobalEventAttributes, WidthAttribute, HeightAttribute {
+extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> Canvas {
         return mutate(accesskey: value)
@@ -15978,6 +20918,82 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, WidthAttribute, Heigh
     public func on(event: Events.Wheel, _ value: String) -> Canvas {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Canvas {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Canvas {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Canvas {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Canvas {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Canvas {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Canvas {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Canvas {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Canvas {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Canvas {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Canvas {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Canvas {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Canvas {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Canvas {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Canvas {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Canvas {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Canvas {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Canvas {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Canvas {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Canvas {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Canvas: AnyContent {
@@ -16050,7 +21066,7 @@ public struct Table: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
     }
 }
 
-extension Table: GlobalAttributes, GlobalEventAttributes, WidthAttribute, HeightAttribute {
+extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> Table {
         return mutate(accesskey: value)
@@ -16196,6 +21212,82 @@ extension Table: GlobalAttributes, GlobalEventAttributes, WidthAttribute, Height
     
     public func on(event: Events.Wheel, _ value: String) -> Table {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Table {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Table {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Table {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Table {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Table {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Table {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Table {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Table {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Table {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Table {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Table {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Table {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Table {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Table {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Table {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Table {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Table {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Table {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Table {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/External/Elements/DefinitionElements.swift
@@ -55,7 +55,7 @@ public struct TermName: ContentNode, DescriptionElement {
     }
 }
 
-extension TermName: GlobalAttributes, GlobalEventAttributes {
+extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> TermName {
         return mutate(accesskey: value)
@@ -194,6 +194,82 @@ extension TermName: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> TermName {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> TermName {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TermName {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TermName {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TermName {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TermName {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TermName {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TermName {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TermName {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TermName {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TermName {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TermName {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TermName {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TermName {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TermName {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TermName {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TermName {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TermName {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TermName {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TermName {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension TermName: AnyContent {
@@ -266,7 +342,7 @@ public struct TermDefinition: ContentNode, DescriptionElement {
     }
 }
 
-extension TermDefinition: GlobalAttributes, GlobalEventAttributes {
+extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> TermDefinition {
         return mutate(accesskey: value)
@@ -404,6 +480,82 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes {
 
     public func on(event: Events.Wheel, _ value: String) -> TermDefinition {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> TermDefinition {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TermDefinition {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TermDefinition {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TermDefinition {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TermDefinition {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TermDefinition {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TermDefinition {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TermDefinition {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TermDefinition {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TermDefinition {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TermDefinition {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TermDefinition {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TermDefinition {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TermDefinition {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TermDefinition {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TermDefinition {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TermDefinition {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TermDefinition {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TermDefinition {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/External/Elements/FigureElements.swift
@@ -46,7 +46,7 @@ public struct FigureCaption: ContentNode, FigureElement {
     }
 }
 
-extension FigureCaption: GlobalAttributes, GlobalEventAttributes {
+extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> FigureCaption {
         return mutate(accesskey: value)
@@ -184,6 +184,82 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes {
     
     public func on(event: Events.Wheel, _ value: String) -> FigureCaption {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> FigureCaption {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> FigureCaption {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> FigureCaption {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> FigureCaption {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> FigureCaption {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> FigureCaption {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> FigureCaption {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> FigureCaption {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> FigureCaption {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> FigureCaption {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> FigureCaption {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> FigureCaption {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> FigureCaption {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> FigureCaption {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> FigureCaption {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> FigureCaption {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> FigureCaption {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> FigureCaption {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> FigureCaption {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/FormElements.swift
+++ b/Sources/HTMLKit/External/Elements/FormElements.swift
@@ -355,7 +355,7 @@ public struct Label: ContentNode, FormElement {
     }
 }
 
-extension Label: GlobalAttributes, GlobalEventAttributes, ForAttribute {
+extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ForAttribute {
     
     public func accessKey(_ value: Character) -> Label {
         return mutate(accesskey: value)
@@ -497,6 +497,82 @@ extension Label: GlobalAttributes, GlobalEventAttributes, ForAttribute {
     
     public func on(event: Events.Wheel, _ value: String) -> Label {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Label {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Label {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Label {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Label {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Label {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Label {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Label {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Label {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Label {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Label {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Label {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Label {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Label {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Label {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Label {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Label {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Label {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Label {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Label {
+        return mutate(ariaroledescription: value)
     }
 }
 
@@ -824,7 +900,7 @@ public struct TextArea: ContentNode, FormElement {
     }
 }
 
-extension TextArea: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute, ColumnsAttribute, DisabledAttribute, FormAttribute, MaximumLengthAttribute, MinimumLengthAttribute, NameAttribute, PlaceholderAttribute, ReadyOnlyAttribute, RequiredAttribute, RowsAttribute, WrapAttribute {
+extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, AutocompleteAttribute, ColumnsAttribute, DisabledAttribute, FormAttribute, MaximumLengthAttribute, MinimumLengthAttribute, NameAttribute, PlaceholderAttribute, ReadyOnlyAttribute, RequiredAttribute, RowsAttribute, WrapAttribute {
     
     public func accessKey(_ value: Character) -> TextArea {
         return mutate(accesskey: value)
@@ -1019,6 +1095,82 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribu
     public func on(event: Events.Wheel, _ value: String) -> TextArea {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> TextArea {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TextArea {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TextArea {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TextArea {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TextArea {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TextArea {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TextArea {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TextArea {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TextArea {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TextArea {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TextArea {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TextArea {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TextArea {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TextArea {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TextArea {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TextArea {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TextArea {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TextArea {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TextArea {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension TextArea: AnyContent {
@@ -1091,7 +1243,7 @@ public struct Button: ContentNode, FormElement {
     }
 }
 
-extension Button: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, FormAttribute, FormActionAttribute, NameAttribute, TypeAttribute, ValueAttribute {
+extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DisabledAttribute, FormAttribute, FormActionAttribute, NameAttribute, TypeAttribute, ValueAttribute {
     
     public func accessKey(_ value: Character) -> Button {
         return mutate(accesskey: value)
@@ -1262,6 +1414,82 @@ extension Button: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, Fo
     public func on(event: Events.Wheel, _ value: String) -> Button {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Button {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Button {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Button {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Button {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Button {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Button {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Button {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Button {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Button {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Button {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Button {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Button {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Button {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Button {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Button {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Button {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Button {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Button {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Button {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Button: AnyContent {
@@ -1345,7 +1573,7 @@ public struct Fieldset: ContentNode, FormElement {
     }
 }
 
-extension Fieldset: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, FormAttribute, NameAttribute {
+extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DisabledAttribute, FormAttribute, NameAttribute {
     
     public func accessKey(_ value: Character) -> Fieldset {
         return mutate(accesskey: value)
@@ -1499,6 +1727,82 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, 
     
     public func on(event: Events.Wheel, _ value: String) -> Fieldset {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Fieldset {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Fieldset {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Fieldset {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Fieldset {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Fieldset {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Fieldset {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Fieldset {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Fieldset {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Fieldset {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Fieldset {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Fieldset {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Fieldset {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Fieldset {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Fieldset {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Fieldset {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Fieldset {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Fieldset {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Fieldset {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Fieldset {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/External/Elements/HtmlElements.swift
@@ -248,7 +248,7 @@ public struct Body: ContentNode, HtmlElement {
     }
 }
 
-extension Body: GlobalAttributes, GlobalEventAttributes, WindowEventAttribute {
+extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, WindowEventAttribute {
 
     public func accessKey(_ value: Character) -> Body {
         return mutate(accesskey: value)
@@ -390,6 +390,82 @@ extension Body: GlobalAttributes, GlobalEventAttributes, WindowEventAttribute {
 
     public func on(event: Events.Wheel, _ value: String) -> Body {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Body {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Body {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Body {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Body {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Body {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Body {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Body {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Body {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Body {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Body {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Body {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Body {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Body {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Body {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Body {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Body {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Body {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Body {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Body {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/InputElements.swift
+++ b/Sources/HTMLKit/External/Elements/InputElements.swift
@@ -46,7 +46,7 @@ public struct OptionGroup: ContentNode, InputElement {
     }
 }
 
-extension OptionGroup: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, LabelAttribute {
+extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DisabledAttribute, LabelAttribute {
 
     public func accessKey(_ value: Character) -> OptionGroup {
         return mutate(accesskey: value)
@@ -193,6 +193,82 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, DisabledAttribut
     public func on(event: Events.Mouse, _ value: String) -> OptionGroup {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> OptionGroup {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> OptionGroup {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> OptionGroup {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> OptionGroup {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> OptionGroup {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> OptionGroup {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> OptionGroup {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> OptionGroup {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> OptionGroup {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> OptionGroup {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> OptionGroup {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> OptionGroup {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> OptionGroup {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> OptionGroup {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> OptionGroup {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> OptionGroup {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> OptionGroup {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> OptionGroup {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> OptionGroup {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension OptionGroup: AnyContent {
@@ -265,7 +341,7 @@ public struct Option: ContentNode, InputElement {
     }
 }
 
-extension Option: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, LabelAttribute, ValueAttribute, SelectedAttribute {
+extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, DisabledAttribute, LabelAttribute, ValueAttribute, SelectedAttribute {
     
     public func accessKey(_ value: Character) -> Option {
         return mutate(accesskey: value)
@@ -424,6 +500,82 @@ extension Option: GlobalAttributes, GlobalEventAttributes, DisabledAttribute, La
     public func on(event: Events.Mouse, _ value: String) -> Option {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Option {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Option {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Option {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Option {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Option {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Option {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Option {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Option {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Option {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Option {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Option {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Option {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Option {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Option {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Option {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Option {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Option {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Option {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Option {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Option: AnyContent {
@@ -498,7 +650,7 @@ public struct Legend: ContentNode, InputElement {
     }
 }
 
-extension Legend: GlobalAttributes, GlobalEventAttributes {
+extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Legend {
         return mutate(accesskey: value)
@@ -637,6 +789,82 @@ extension Legend: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Mouse, _ value: String) -> Legend {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> Legend {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Legend {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Legend {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Legend {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Legend {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Legend {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Legend {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Legend {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Legend {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Legend {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Legend {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Legend {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Legend {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Legend {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Legend {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Legend {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Legend {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Legend {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Legend {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension Legend: AnyContent {
@@ -709,7 +937,7 @@ public struct Summary: ContentNode, InputElement {
     }
 }
 
-extension Summary: GlobalAttributes, GlobalEventAttributes {
+extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Summary {
         return mutate(accesskey: value)
@@ -847,6 +1075,82 @@ extension Summary: GlobalAttributes, GlobalEventAttributes {
     
     public func on(event: Events.Mouse, _ value: String) -> Summary {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Summary {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Summary {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Summary {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Summary {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Summary {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Summary {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Summary {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Summary {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Summary {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Summary {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Summary {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Summary {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Summary {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Summary {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Summary {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Summary {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Summary {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Summary {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Summary {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/ListElements.swift
+++ b/Sources/HTMLKit/External/Elements/ListElements.swift
@@ -46,7 +46,7 @@ public struct ListItem: ContentNode, ListElement {
     }
 }
 
-extension ListItem: GlobalAttributes, GlobalEventAttributes, ValueAttribute {
+extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ValueAttribute {
     
     public func accessKey(_ value: Character) -> ListItem {
         return mutate(accesskey: value)
@@ -192,6 +192,82 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, ValueAttribute {
     
     public func on(event: Events.Mouse, _ value: String) -> ListItem {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> ListItem {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> ListItem {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> ListItem {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> ListItem {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> ListItem {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> ListItem {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> ListItem {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> ListItem {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> ListItem {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> ListItem {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> ListItem {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> ListItem {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> ListItem {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> ListItem {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> ListItem {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> ListItem {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> ListItem {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> ListItem {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> ListItem {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/MapElements.swift
+++ b/Sources/HTMLKit/External/Elements/MapElements.swift
@@ -37,7 +37,7 @@ public struct Area: ContentNode, MapElement {
     }
 }
 
-extension Area: GlobalAttributes, GlobalEventAttributes, AlternateAttribute, CoordinatesAttribute, ShapeAttribute, ReferenceAttribute, TargetAttribute, DownloadAttribute, PingAttribute, RelationshipAttribute, ReferrerPolicyAttribute {
+extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, AlternateAttribute, CoordinatesAttribute, ShapeAttribute, ReferenceAttribute, TargetAttribute, DownloadAttribute, PingAttribute, RelationshipAttribute, ReferrerPolicyAttribute {
     
     public func accessKey(_ value: Character) -> Area {
         return mutate(accesskey: value)
@@ -215,6 +215,82 @@ extension Area: GlobalAttributes, GlobalEventAttributes, AlternateAttribute, Coo
     
     public func on(event: Events.Mouse, _ value: String) -> Area {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Area {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Area {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Area {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Area {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Area {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Area {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Area {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Area {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Area {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Area {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Area {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Area {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Area {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Area {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Area {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Area {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Area {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Area {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Area {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/External/Elements/RubyElements.swift
@@ -55,7 +55,7 @@ public struct RubyText: ContentNode, RubyElement {
     }
 }
 
-extension RubyText: GlobalAttributes, GlobalEventAttributes {
+extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> RubyText {
         return mutate(accesskey: value)
@@ -194,6 +194,82 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Mouse, _ value: String) -> RubyText {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> RubyText {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> RubyText {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> RubyText {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> RubyText {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> RubyText {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> RubyText {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> RubyText {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> RubyText {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> RubyText {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> RubyText {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> RubyText {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> RubyText {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> RubyText {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> RubyText {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> RubyText {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> RubyText {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> RubyText {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> RubyText {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> RubyText {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension RubyText: AnyContent {
@@ -266,7 +342,7 @@ public struct RubyPronunciation: ContentNode, RubyElement {
     }
 }
 
-extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes {
+extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> RubyPronunciation {
         return mutate(accesskey: value)
@@ -404,6 +480,82 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes {
     
     public func on(event: Events.Mouse, _ value: String) -> RubyPronunciation {
         return mutate(key: event.rawValue, value: value)
+    }
+
+    public func aria(atomic value: Bool) -> RubyPronunciation {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> RubyPronunciation {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> RubyPronunciation {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> RubyPronunciation {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> RubyPronunciation {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> RubyPronunciation {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> RubyPronunciation {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> RubyPronunciation {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> RubyPronunciation {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> RubyPronunciation {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> RubyPronunciation {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> RubyPronunciation {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> RubyPronunciation {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> RubyPronunciation {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> RubyPronunciation {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> RubyPronunciation {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> RubyPronunciation {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> RubyPronunciation {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> RubyPronunciation {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Elements/TableElements.swift
+++ b/Sources/HTMLKit/External/Elements/TableElements.swift
@@ -109,7 +109,7 @@ public struct Caption: ContentNode, TableElement {
     }
 }
 
-extension Caption: GlobalAttributes, GlobalEventAttributes {
+extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> Caption {
         return mutate(accesskey: value)
@@ -247,6 +247,82 @@ extension Caption: GlobalAttributes, GlobalEventAttributes {
     
     public func on(event: Events.Wheel, _ value: String) -> Caption {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> Caption {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> Caption {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> Caption {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> Caption {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> Caption {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> Caption {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> Caption {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> Caption {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> Caption {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> Caption {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> Caption {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> Caption {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> Caption {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> Caption {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> Caption {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> Caption {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> Caption {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> Caption {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> Caption {
+        return mutate(ariaroledescription: value)
     }
 }
 
@@ -750,7 +826,7 @@ public struct TableBody: ContentNode, TableElement {
     }
 }
 
-extension TableBody: GlobalAttributes, GlobalEventAttributes, WidthAttribute, HeightAttribute {
+extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> TableBody {
         return mutate(accesskey: value)
@@ -897,6 +973,82 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, WidthAttribute, He
     public func on(event: Events.Mouse, _ value: String) -> TableBody {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> TableBody {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TableBody {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TableBody {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TableBody {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TableBody {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TableBody {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TableBody {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TableBody {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TableBody {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TableBody {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TableBody {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TableBody {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TableBody {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TableBody {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TableBody {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TableBody {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TableBody {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TableBody {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TableBody {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension TableBody: AnyContent {
@@ -969,7 +1121,7 @@ public struct TableHead: ContentNode, TableElement {
     }
 }
 
-extension TableHead: GlobalAttributes, GlobalEventAttributes, WidthAttribute, HeightAttribute {
+extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> TableHead {
         return mutate(accesskey: value)
@@ -1116,6 +1268,82 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, WidthAttribute, He
     public func on(event: Events.Wheel, _ value: String) -> TableHead {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> TableHead {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TableHead {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TableHead {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TableHead {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TableHead {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TableHead {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TableHead {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TableHead {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TableHead {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TableHead {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TableHead {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TableHead {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TableHead {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TableHead {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TableHead {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TableHead {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TableHead {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TableHead {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TableHead {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension TableHead: AnyContent {
@@ -1188,7 +1416,7 @@ public struct TableFoot: ContentNode, TableElement {
     }
 }
 
-extension TableFoot: GlobalAttributes, GlobalEventAttributes {
+extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func accessKey(_ value: Character) -> TableFoot {
         return mutate(accesskey: value)
@@ -1327,6 +1555,82 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes {
     public func on(event: Events.Wheel, _ value: String) -> TableFoot {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> TableFoot {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TableFoot {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TableFoot {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TableFoot {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TableFoot {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TableFoot {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TableFoot {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TableFoot {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TableFoot {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TableFoot {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TableFoot {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TableFoot {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TableFoot {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TableFoot {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TableFoot {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TableFoot {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TableFoot {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TableFoot {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TableFoot {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension TableFoot: AnyContent {
@@ -1399,7 +1703,7 @@ public struct TableRow: ContentNode, TableElement {
     }
 }
 
-extension TableRow: GlobalAttributes, GlobalEventAttributes, WidthAttribute, HeightAttribute {
+extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, WidthAttribute, HeightAttribute {
     
     public func accessKey(_ value: Character) -> TableRow {
         return mutate(accesskey: value)
@@ -1546,6 +1850,82 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, WidthAttribute, Hei
     public func on(event: Events.Wheel, _ value: String) -> TableRow {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> TableRow {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> TableRow {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> TableRow {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> TableRow {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> TableRow {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> TableRow {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> TableRow {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> TableRow {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> TableRow {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> TableRow {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> TableRow {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> TableRow {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> TableRow {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> TableRow {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> TableRow {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> TableRow {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> TableRow {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> TableRow {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> TableRow {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension TableRow: AnyContent {
@@ -1618,7 +1998,7 @@ public struct DataCell: ContentNode, TableElement {
     }
 }
 
-extension DataCell: GlobalAttributes, GlobalEventAttributes, ColumnSpanAttribute, RowSpanAttribute, HeaderAttribute {
+extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ColumnSpanAttribute, RowSpanAttribute, HeaderAttribute {
 
     public func accessKey(_ value: Character) -> DataCell {
         return mutate(accesskey: value)
@@ -1769,6 +2149,82 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, ColumnSpanAttribute
     public func on(event: Events.Wheel, _ value: String) -> DataCell {
         return mutate(key: event.rawValue, value: value)
     }
+    
+    public func aria(atomic value: Bool) -> DataCell {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> DataCell {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> DataCell {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> DataCell {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> DataCell {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> DataCell {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> DataCell {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> DataCell {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> DataCell {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> DataCell {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> DataCell {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> DataCell {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> DataCell {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> DataCell {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> DataCell {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> DataCell {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> DataCell {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> DataCell {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> DataCell {
+        return mutate(ariaroledescription: value)
+    }
 }
 
 extension DataCell: AnyContent {
@@ -1841,7 +2297,7 @@ public struct HeaderCell: ContentNode, TableElement {
     }
 }
 
-extension HeaderCell: GlobalAttributes, GlobalEventAttributes, ColumnSpanAttribute, RowSpanAttribute, HeaderAttribute, ScopeAttribute {
+extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, ColumnSpanAttribute, RowSpanAttribute, HeaderAttribute, ScopeAttribute {
     
     public func accessKey(_ value: Character) -> HeaderCell {
         return mutate(accesskey: value)
@@ -1995,6 +2451,82 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, ColumnSpanAttribu
     
     public func on(event: Events.Wheel, _ value: String) -> HeaderCell {
         return mutate(key: event.rawValue, value: value)
+    }
+    
+    public func aria(atomic value: Bool) -> HeaderCell {
+        return mutate(ariaatomic: value)
+    }
+    
+    public func aria(busy value: Bool) -> HeaderCell {
+        return mutate(ariabusy: value)
+    }
+    
+    public func aria(controls value: String) -> HeaderCell {
+        return mutate(ariacontrols: value)
+    }
+    
+    public func aria(current value: Accessibility.Current) -> HeaderCell {
+        return mutate(ariacurrent: value.rawValue)
+    }
+    
+    public func aria(describedBy value: String) -> HeaderCell {
+        return mutate(ariadescribedby: value)
+    }
+    
+    public func aria(details value: String) -> HeaderCell {
+        return mutate(ariadetails: value)
+    }
+    
+    public func aria(disabled value: Bool) -> HeaderCell {
+        return mutate(ariadisabled: value)
+    }
+    
+    public func aria(errorMessage value: String) -> HeaderCell {
+        return mutate(ariaerrormessage: value)
+    }
+    
+    public func aria(flowTo value: String) -> HeaderCell {
+        return mutate(ariaflowto: value)
+    }
+    
+    public func aria(hasPopup value: Accessibility.Popup) -> HeaderCell {
+        return mutate(ariahaspopup: value.rawValue)
+    }
+    
+    public func aria(hidden value: Bool) -> HeaderCell {
+        return mutate(ariahidden: value)
+    }
+    
+    public func aria(invalid value: Accessibility.Invalid) -> HeaderCell {
+        return mutate(ariainvalid: value.rawValue)
+    }
+    
+    public func aria(keyShortcuts value: String) -> HeaderCell {
+        return mutate(ariakeyshortcuts: value)
+    }
+    
+    public func aria(label value: String) -> HeaderCell {
+        return mutate(arialabel: value)
+    }
+    
+    public func aria(labeledBy value: String) -> HeaderCell {
+        return mutate(arialabeledby: value)
+    }
+    
+    public func aria(live value: Accessibility.Live) -> HeaderCell {
+        return mutate(arialive: value.rawValue)
+    }
+    
+    public func aria(owns value: String) -> HeaderCell {
+        return mutate(ariaowns: value)
+    }
+    
+    public func aria(relevant value: Accessibility.Relevant) -> HeaderCell {
+        return mutate(ariarelevant: value.rawValue)
+    }
+    
+    public func aria(roleDescription value: String) -> HeaderCell {
+        return mutate(ariaroledescription: value)
     }
 }
 

--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -722,12 +722,25 @@ public enum Accessibility {
     /// ```
     public enum Current: String {
         
+        /// Does not represent the current item within a set.
         case `false`
+        
+        /// Represents the current item within a set.
         case `true`
+        
+        /// Represents the current page within a set of pages.
         case page
+        
+        /// Represents the current step within a process.
         case step
+        
+        /// Represents the current location within an context.
         case location
+        
+        /// Represents the current date within a collection of dates.
         case date
+        
+        /// Represents the current time within a set of times.
         case time
     }
 
@@ -740,10 +753,20 @@ public enum Accessibility {
         
         case `false`
         case `true`
+        
+        /// Indicates the popup is a menu.
         case menu
+        
+        /// Indicates the popup is a listbox.
         case listbox
+        
+        /// Indicates the popup is a tree.
         case tree
+        
+        /// Indicates the popup is a grid.
         case grid
+        
+        /// Indicates the popup is a dialog.
         case dialog
     }
 
@@ -754,10 +777,17 @@ public enum Accessibility {
     /// ```
     public enum Invalid: String {
         
+        /// Indicates that there are no detected errors.
         case `false`
-        case grammar
-        case spelling
+        
+        /// Indicates that errors were detected.
         case `true`
+        
+        /// Indicates that a grammatical error was deteced.
+        case grammar
+        
+        /// Indicates that a spelling error was deteced.
+        case spelling
     }
 
     /// The type is for
@@ -767,20 +797,30 @@ public enum Accessibility {
     /// ```
     public enum Live: String {
         
+        /// Indicates that updates to the region should be presented the user immediately.
         case assertive
+        
+        /// Indicates that updates to the region should not be presented to the user unless the used is currently focused on that region.
         case off
+        
+        /// Indicates that updates to the region should be presented at the next graceful opportunity.
         case polite
     }
 
-    /// The type is for
+    /// A indicator for the orientation of an element.
     ///
     /// ```html
     /// <tag aria-orientation="horizontal">
     /// ```
     public enum Orientation: String {
         
+        /// Indicates that the element's orientation is unkown.
         case undefined
+        
+        /// Indicates that the element is oriented horizontally.
         case horizontal
+        
+        /// Indicates that the element is oriented vertically.
         case vertical
     }
 
@@ -823,16 +863,23 @@ public enum Accessibility {
         case `true`
     }
 
-    /// The type is for
+    /// A indicator for the sort algorithm in a grid or table.
     ///
     /// ```html
     /// <tag aria-sort="ascending">
     /// ```
     public enum Sort: String {
         
-        case ascending
-        case descending
-        case other
+        /// Indicates that there is no sort algorithm defined.
         case none
+        
+        /// Indicates a different sort algorithm.
+        case other
+        
+        /// Indicates that the items are sorted in ascending order.
+        case ascending
+        
+        /// Indicates that the items are sorted in descending order.
+        case descending
     }
 }

--- a/Sources/HTMLKit/External/Types.swift
+++ b/Sources/HTMLKit/External/Types.swift
@@ -686,3 +686,153 @@ public enum Preload: String {
     case metadata
     case none
 }
+
+public enum Accessibility {
+    
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-autocomplete="none">
+    /// ```
+    public enum Complete: String {
+        
+        case none
+        case inline
+        case list
+        case both
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-checked="false">
+    /// ```
+    public enum Check: String {
+        
+        case `false`
+        case `mixed`
+        case `true`
+        case `undefined`
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-current="step">
+    /// ```
+    public enum Current: String {
+        
+        case `false`
+        case `true`
+        case page
+        case step
+        case location
+        case date
+        case time
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-haspopup="false">
+    /// ```
+    public enum Popup: String {
+        
+        case `false`
+        case `true`
+        case menu
+        case listbox
+        case tree
+        case grid
+        case dialog
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-invalid="grammar">
+    /// ```
+    public enum Invalid: String {
+        
+        case `false`
+        case grammar
+        case spelling
+        case `true`
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-live="assertive">
+    /// ```
+    public enum Live: String {
+        
+        case assertive
+        case off
+        case polite
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-orientation="horizontal">
+    /// ```
+    public enum Orientation: String {
+        
+        case undefined
+        case horizontal
+        case vertical
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-pressed="mixed">
+    /// ```
+    public enum Pressed: String {
+        
+        case undefined
+        case `false`
+        case mixed
+        case `true`
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-relevant="all">
+    /// ```
+    public enum Relevant: String {
+        
+        case additions
+        case additionsText
+        case all
+        case removals
+        case text
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-selected="false">
+    /// ```
+    public enum Selected: String {
+        
+        case undefined
+        case `false`
+        case `true`
+    }
+
+    /// The type is for
+    ///
+    /// ```html
+    /// <tag aria-sort="ascending">
+    /// ```
+    public enum Sort: String {
+        
+        case ascending
+        case descending
+        case other
+        case none
+    }
+}

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -9,7 +9,7 @@ final class AttributesTests: XCTestCase {
         @ContentBuilder<AnyContent> var body: AnyContent
     }
     
-    typealias AllAttributes = AccessKeyAttribute & AcceptAttribute & ActionAttribute & AlternateAttribute & AsynchronouslyAttribute & AutocapitalizeAttribute & AutocompleteAttribute & AutofocusAttribute & AutoplayAttribute & CharsetAttribute & CheckedAttribute & CiteAttribute & ClassAttribute & ColumnsAttribute & ColumnSpanAttribute & ContentAttribute & EditAttribute  & ControlsAttribute & CoordinatesAttribute & DataAttribute & DateTimeAttribute & DefaultAttribute & DeferAttribute & DirectionAttribute & DisabledAttribute & DownloadAttribute & DragAttribute & EncodingAttribute & EnterKeyHintAttribute & ForAttribute & FormAttribute & FormActionAttribute & EquivalentAttribute & HeaderAttribute & HeightAttribute & HiddenAttribute & HighAttribute & ReferenceAttribute & ReferenceLanguageAttribute & IdentifierAttribute & IsMapAttribute & InputModeAttribute & IsAttribute & ItemIdAttribute & ItemPropertyAttribute & ItemReferenceAttribute & ItemScopeAttribute & ItemTypeAttribute & KindAttribute & LabelAttribute & LanguageAttribute & ListAttribute & LoopAttribute & LowAttribute & MaximumValueAttribute & MaximumLengthAttribute & MediaAttribute & MethodAttribute & MinimumValueAttribute & MinimumLengthAttribute & MultipleAttribute & MutedAttribute & NameAttribute & NonceAttribute & NoValidateAttribute & OpenAttribute & OptimumAttribute & PatternAttribute & PartAttribute & PingAttribute & PlaceholderAttribute & PosterAttribute & PreloadAttribute & ReadyOnlyAttribute & ReferrerPolicyAttribute & RelationshipAttribute & RequiredAttribute & ReversedAttribute & RoleAttribute & RowsAttribute & RowSpanAttribute & SandboxAttribute & ScopeAttribute & ShapeAttribute & SizeAttribute & SizesAttribute & SlotAttribute & SpanAttribute & SpellCheckAttribute & SourceAttribute & StartAttribute & StepAttribute & StyleAttribute & TabulatorAttribute & TargetAttribute & TitleAttribute & TranslateAttribute & TypeAttribute & ValueAttribute & WidthAttribute & WrapAttribute & PropertyAttribute & SelectedAttribute & WindowEventAttribute & FocusEventAttribute & PointerEventAttribute & MouseEventAttribute & WheelEventAttribute & InputEventAttribute & KeyboardEventAttribute & DragEventAttribute & ClipboardEventAttribute & SelectionEventAttribute & MediaEventAttribute & FormEventAttribute & DetailEventAttribute
+    typealias AllAttributes = AccessKeyAttribute & AcceptAttribute & ActionAttribute & AlternateAttribute & AsynchronouslyAttribute & AutocapitalizeAttribute & AutocompleteAttribute & AutofocusAttribute & AutoplayAttribute & CharsetAttribute & CheckedAttribute & CiteAttribute & ClassAttribute & ColumnsAttribute & ColumnSpanAttribute & ContentAttribute & EditAttribute  & ControlsAttribute & CoordinatesAttribute & DataAttribute & DateTimeAttribute & DefaultAttribute & DeferAttribute & DirectionAttribute & DisabledAttribute & DownloadAttribute & DragAttribute & EncodingAttribute & EnterKeyHintAttribute & ForAttribute & FormAttribute & FormActionAttribute & EquivalentAttribute & HeaderAttribute & HeightAttribute & HiddenAttribute & HighAttribute & ReferenceAttribute & ReferenceLanguageAttribute & IdentifierAttribute & IsMapAttribute & InputModeAttribute & IsAttribute & ItemIdAttribute & ItemPropertyAttribute & ItemReferenceAttribute & ItemScopeAttribute & ItemTypeAttribute & KindAttribute & LabelAttribute & LanguageAttribute & ListAttribute & LoopAttribute & LowAttribute & MaximumValueAttribute & MaximumLengthAttribute & MediaAttribute & MethodAttribute & MinimumValueAttribute & MinimumLengthAttribute & MultipleAttribute & MutedAttribute & NameAttribute & NonceAttribute & NoValidateAttribute & OpenAttribute & OptimumAttribute & PatternAttribute & PartAttribute & PingAttribute & PlaceholderAttribute & PosterAttribute & PreloadAttribute & ReadyOnlyAttribute & ReferrerPolicyAttribute & RelationshipAttribute & RequiredAttribute & ReversedAttribute & RoleAttribute & RowsAttribute & RowSpanAttribute & SandboxAttribute & ScopeAttribute & ShapeAttribute & SizeAttribute & SizesAttribute & SlotAttribute & SpanAttribute & SpellCheckAttribute & SourceAttribute & StartAttribute & StepAttribute & StyleAttribute & TabulatorAttribute & TargetAttribute & TitleAttribute & TranslateAttribute & TypeAttribute & ValueAttribute & WidthAttribute & WrapAttribute & PropertyAttribute & SelectedAttribute & WindowEventAttribute & FocusEventAttribute & PointerEventAttribute & MouseEventAttribute & WheelEventAttribute & InputEventAttribute & KeyboardEventAttribute & DragEventAttribute & ClipboardEventAttribute & SelectionEventAttribute & MediaEventAttribute & FormEventAttribute & DetailEventAttribute & AriaAtomicAttribute & AriaBusyAttribute & AriaControlsAttribute & AriaCurrentAttribute & AriaDescribedAttribute & AriaDetailsAttribute & AriaDisabledAttribute & AriaErrorMessageAttribute & AriaFlowToAttribute & AriaPopupAttribute & AriaHiddenAttribute & AriaInvalidAttribute & AriaShortcutsAttribute & AriaLabelAttribute & AriaLabeledAttribute & AriaLiveAttribute & AriaOwnsAttribute & AriaRelevantAttribute & AriaRoleDescriptionAttribute
     
     struct Tag: ContentNode, GlobalElement, AllAttributes {
         
@@ -518,6 +518,82 @@ final class AttributesTests: XCTestCase {
         
         func on(event: Events.Detail, _ value: String) -> Tag {
             return self.mutate(key: event.rawValue, value: value)
+        }
+        
+        public func aria(atomic value: Bool) -> Tag {
+            return mutate(ariaatomic: value)
+        }
+        
+        public func aria(busy value: Bool) -> Tag {
+            return mutate(ariabusy: value)
+        }
+        
+        public func aria(controls value: String) -> Tag {
+            return mutate(ariacontrols: value)
+        }
+        
+        public func aria(current value: Accessibility.Current) -> Tag {
+            return mutate(ariacurrent: value.rawValue)
+        }
+        
+        public func aria(describedBy value: String) -> Tag {
+            return mutate(ariadescribedby: value)
+        }
+        
+        public func aria(details value: String) -> Tag {
+            return mutate(ariadetails: value)
+        }
+        
+        public func aria(disabled value: Bool) -> Tag {
+            return mutate(ariadisabled: value)
+        }
+        
+        public func aria(errorMessage value: String) -> Tag {
+            return mutate(ariaerrormessage: value)
+        }
+        
+        public func aria(flowTo value: String) -> Tag {
+            return mutate(ariaflowto: value)
+        }
+        
+        public func aria(hasPopup value: Accessibility.Popup) -> Tag {
+            return mutate(ariahaspopup: value.rawValue)
+        }
+        
+        public func aria(hidden value: Bool) -> Tag {
+            return mutate(ariahidden: value)
+        }
+        
+        public func aria(invalid value: Accessibility.Invalid) -> Tag {
+            return mutate(ariainvalid: value.rawValue)
+        }
+        
+        public func aria(keyShortcuts value: String) -> Tag {
+            return mutate(ariakeyshortcuts: value)
+        }
+        
+        public func aria(label value: String) -> Tag {
+            return mutate(arialabel: value)
+        }
+        
+        public func aria(labeledBy value: String) -> Tag {
+            return mutate(arialabeledby: value)
+        }
+        
+        public func aria(live value: Accessibility.Live) -> Tag {
+            return mutate(arialive: value.rawValue)
+        }
+        
+        public func aria(owns value: String) -> Tag {
+            return mutate(ariaowns: value)
+        }
+        
+        public func aria(relevant value: Accessibility.Relevant) -> Tag {
+            return mutate(ariarelevant: value.rawValue)
+        }
+        
+        public func aria(roleDescription value: String) -> Tag {
+            return mutate(ariaroledescription: value)
         }
         
         func prerender(_ formula: Renderer.Formula) throws {
@@ -2332,6 +2408,329 @@ final class AttributesTests: XCTestCase {
                        """
         )
     }
+    
+    func testAtomicAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(atomic: true)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-atomic="true"></tag>
+                       """
+        )
+    }
+    
+    func testBusyAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(busy: true)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-busy="true"></tag>
+                       """
+        )
+    }
+    
+    func testControlsAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(controls: "name")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-controls="name"></tag>
+                       """
+        )
+    }
+    
+    func testCurrentAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(current: .page)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-current="page"></tag>
+                       """
+        )
+    }
+    
+    func testDescribedByAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(describedBy: "description")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-describedby="description"></tag>
+                       """
+        )
+    }
+    
+    func testDetailsAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(details: "details")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-details="details"></tag>
+                       """
+        )
+    }
+    
+    func testDisabledAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(disabled: true)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-disabled="true"></tag>
+                       """
+        )
+    }
+    
+    func testErrorMessageAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(errorMessage: "error")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-errormessage="error"></tag>
+                       """
+        )
+    }
+    
+    func testFlowToAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(flowTo: "flow")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-flowto="flow"></tag>
+                       """
+        )
+    }
+    
+    func testHasPopupAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(hasPopup: .grid)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-haspopup="grid"></tag>
+                       """
+        )
+    }
+    
+    func testHiddenAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(hidden: true)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-hidden="true"></tag>
+                       """
+        )
+    }
+    
+    func testInvalidAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(invalid: .grammar)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-invalid="grammar"></tag>
+                       """
+        )
+    }
+    
+    func testKeyShortcutsAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(keyShortcuts: "shortcut")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-keyshortcuts="shortcut"></tag>
+                       """
+        )
+    }
+    
+    func testLabelAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(label: "label")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-label="label"></tag>
+                       """
+        )
+    }
+    
+    func testLabeledByAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(labeledBy: "label")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-labeledby="label"></tag>
+                       """
+        )
+    }
+    
+    func testLiveAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(live: .polite)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-live="polite"></tag>
+                       """
+        )
+    }
+    
+    func testOwnsAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(owns: "live")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-owns="live"></tag>
+                       """
+        )
+    }
+    
+    func testRelevantAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(relevant: .additions)
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-relevant="additions"></tag>
+                       """
+        )
+    }
+    
+    func testRoleDescriptionAriaAttribute() throws {
+        
+        let view = TestPage {
+            Tag {
+            }
+            .aria(roleDescription: "description")
+        }
+        
+        try renderer.add(view: view)
+        
+        XCTAssertEqual(try renderer.render(raw: TestPage.self),
+                       """
+                       <tag aria-roledescription="description"></tag>
+                       """
+        )
+    }
 }
 
 extension AttributesTests {
@@ -2442,6 +2841,24 @@ extension AttributesTests {
         ("testSelectionEventAttribute", testSelectionEventAttribute),
         ("testMediaEventAttribute", testMediaEventAttribute),
         ("testFormEventAttribute", testFormEventAttribute),
-        ("testDetailEventAttribute", testDetailEventAttribute)
+        ("testDetailEventAttribute", testDetailEventAttribute),
+        ("testRoleDescriptionAriaAttribute", testRoleDescriptionAriaAttribute),
+        ("testRelevantAriaAttribute", testRelevantAriaAttribute),
+        ("testOwnsAriaAttribute", testOwnsAriaAttribute),
+        ("testLiveAriaAttribute", testLiveAriaAttribute),
+        ("testLabeledByAriaAttribute", testLabeledByAriaAttribute),
+        ("testLabelAriaAttribute", testLabelAriaAttribute),
+        ("testKeyShortcutsAriaAttribute", testKeyShortcutsAriaAttribute),
+        ("testInvalidAriaAttribute", testInvalidAriaAttribute),
+        ("testHiddenAriaAttribute", testHiddenAriaAttribute),
+        ("testHasPopupAriaAttribute", testHasPopupAriaAttribute),
+        ("testFlowToAriaAttribute", testFlowToAriaAttribute),
+        ("testErrorMessageAriaAttribute", testErrorMessageAriaAttribute),
+        ("testDisabledAriaAttribute", testDetailsAriaAttribute),
+        ("testDescribedByAriaAttribute", testDescribedByAriaAttribute),
+        ("testCurrentAriaAttribute", testCurrentAriaAttribute),
+        ("testControlsAriaAttribute", testControlsAriaAttribute),
+        ("testBusyAriaAttribute", testBusyAriaAttribute),
+        ("testAtomicAriaAttribute", testAtomicAriaAttribute)
     ]
 }


### PR DESCRIPTION
This merge will fix the issue #90.

It adds support for aria attributes. 

Example:

```swift 
Body {
}
.aria(hasPopup: .grid)
```

Result:
```html 
<body aria-haspopup="grid"></body>
```