### PR TITLE
Make the converter available to use

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,10 @@ let package = Package(
         .library(
             name: "HTMLKit",
             targets: ["HTMLKit"]
+        ),
+        .plugin(
+            name: "ConverterPlugin",
+            targets: ["ConverterPlugin"]
         )
     ],
     dependencies: [


### PR DESCRIPTION
I forgot to make the converter available. The merge adds the plugin as a product of the package and makes it available to use.