### PR TITLE
Upgrade the package

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -2290,6 +2290,8 @@ public protocol SourceAttribute: Attribute {
     /// <tag src="" />
     /// ```
     func source(_ value: String) -> Self
+    
+    func source(_ value: EnvironmentValue) -> Self
 }
 
 extension SourceAttribute where Self: ContentNode {
@@ -2297,11 +2299,19 @@ extension SourceAttribute where Self: ContentNode {
     internal func mutate(source value: String) -> Self {
         return self.mutate(key: "src", value: value)
     }
+    
+    internal func mutate(source value: EnvironmentValue) -> Self {
+        return self.mutate(key: "src", value: value)
+    }
 }
 
 extension SourceAttribute where Self: EmptyNode {
     
     internal func mutate(source value: String) -> Self {
+        return self.mutate(key: "src", value: value)
+    }
+    
+    internal func mutate(source value: EnvironmentValue) -> Self {
         return self.mutate(key: "src", value: value)
     }
 }

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -223,6 +223,8 @@ public protocol AutoplayAttribute: Attribute {
     /// <tag autoplay />
     /// ```
     func autoplay() -> Self
+    
+    func autoplay(_ condition: Bool) -> Self
 }
 
 extension AutoplayAttribute where Self: ContentNode {
@@ -273,6 +275,8 @@ public protocol CheckedAttribute: Attribute {
     /// <tag checked />
     /// ```
     func checked() -> Self
+    
+    func checked(_ condition: Bool) -> Self
 }
 
 extension CheckedAttribute where Self: ContentNode {
@@ -625,6 +629,8 @@ public protocol DisabledAttribute: Attribute {
     /// <tag disabled />
     /// ```
     func disabled() -> Self
+    
+    func disabled(_ condition: Bool) -> Self
 }
 
 extension DisabledAttribute where Self: ContentNode {
@@ -914,6 +920,8 @@ public protocol HiddenAttribute: Attribute {
     /// <tag hidden />
     /// ```
     func hidden() -> Self
+    
+    func hidden(_ condition: Bool) -> Self
 }
 
 extension HiddenAttribute where Self: ContentNode {
@@ -1878,6 +1886,8 @@ public protocol ReadyOnlyAttribute: Attribute {
     /// <tag readonly />
     /// ```
     func readonly() -> Self
+    
+    func readonly(_ condition: Bool) -> Self
 }
 
 extension ReadyOnlyAttribute where Self: ContentNode {
@@ -1953,6 +1963,8 @@ public protocol RequiredAttribute: Attribute {
     /// <tag required />
     /// ```
     func required() -> Self
+    
+    func required(_ condition: Bool) -> Self
 }
 
 extension RequiredAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -114,6 +114,15 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
     public func hidden() -> Html {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Html {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Html {
         return mutate(inputmode: value)

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -14163,6 +14163,10 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(source: value)
     }
     
+    public func source(_ value: EnvironmentValue) -> Image {
+        return mutate(source: value)
+    }
+    
     public func sizes(_ size: Int) -> Image {
         return mutate(sizes: size)
     }
@@ -14435,6 +14439,10 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     public func source(_ value: String) -> InlineFrame {
         return mutate(source: value)
     }
+
+    public func source(_ value: EnvironmentValue) -> InlineFrame {
+        return mutate(source: value)
+    }
     
     public func name(_ value: String) -> InlineFrame {
         return mutate(name: value)
@@ -14701,6 +14709,10 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     }
 
     public func source(_ value: String) -> Embed {
+        return mutate(source: value)
+    }
+    
+    public func source(_ value: EnvironmentValue) -> Embed {
         return mutate(source: value)
     }
     
@@ -15250,6 +15262,10 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(source: value)
     }
     
+    public func source(_ value: EnvironmentValue) -> Video {
+        return mutate(source: value)
+    }
+    
     public func autoplay() -> Video {
         return mutate(autoplay: "autoplay")
     }
@@ -15541,6 +15557,10 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     }
 
     public func source(_ value: String) -> Audio {
+        return mutate(source: value)
+    }
+    
+    public func source(_ value: EnvironmentValue) -> Audio {
         return mutate(source: value)
     }
     
@@ -17867,6 +17887,10 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
     }
     
     public func source(_ value: String) -> Script {
+        return mutate(source: value)
+    }
+    
+    public func source(_ value: EnvironmentValue) -> Script {
         return mutate(source: value)
     }
     

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -419,6 +419,15 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func hidden() -> Article {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Article {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Article {
         return mutate(inputmode: value)
@@ -662,6 +671,15 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
 
     public func hidden() -> Section {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Section {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Section {
@@ -907,6 +925,15 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     public func hidden() -> Navigation {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Navigation {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Navigation {
         return mutate(inputmode: value)
@@ -1151,6 +1178,15 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func hidden() -> Aside {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Aside {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Aside {
         return mutate(inputmode: value)
@@ -1394,6 +1430,15 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func hidden() -> Heading1 {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Heading1 {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
     
     public func inputMode(_ value: String) -> Heading1 {
@@ -1647,6 +1692,15 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(hidden: "hidden")
     }
     
+    public func hidden(_ condition: Bool) -> Heading2 {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
+    
     public func inputMode(_ value: String) -> Heading2 {
         return mutate(inputmode: value)
     }
@@ -1896,6 +1950,15 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func hidden() -> Heading3 {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Heading3 {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Heading3 {
@@ -2148,6 +2211,15 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> Heading4 {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Heading4 {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Heading4 {
         return mutate(inputmode: value)
@@ -2398,6 +2470,15 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func hidden() -> Heading5 {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Heading5 {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Heading5 {
@@ -2650,6 +2731,15 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> Heading6 {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Heading6 {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Heading6 {
         return mutate(inputmode: value)
@@ -2901,6 +2991,15 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
     public func hidden() -> HeadingGroup {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> HeadingGroup {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> HeadingGroup {
         return mutate(inputmode: value)
@@ -3144,6 +3243,15 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
 
     public func hidden() -> Header {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Header {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Header {
@@ -3389,6 +3497,15 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     public func hidden() -> Footer {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Footer {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Footer {
         return mutate(inputmode: value)
@@ -3633,6 +3750,15 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func hidden() -> Address {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Address {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Address {
         return mutate(inputmode: value)
@@ -3876,6 +4002,15 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func hidden() -> Paragraph {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Paragraph {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Paragraph {
@@ -4123,6 +4258,15 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
     public func hidden() -> HorizontalRule {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> HorizontalRule {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> HorizontalRule {
         return mutate(inputmode: value)
@@ -4367,6 +4511,15 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
     public func hidden() -> PreformattedText {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> PreformattedText {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> PreformattedText {
         return mutate(inputmode: value)
@@ -4610,6 +4763,15 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func hidden() -> Blockquote {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Blockquote {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Blockquote {
@@ -4865,6 +5027,15 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func hidden() -> OrderedList {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> OrderedList {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> OrderedList {
@@ -5122,6 +5293,15 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
     public func hidden() -> UnorderedList {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> UnorderedList {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> UnorderedList {
         return mutate(inputmode: value)
@@ -5365,6 +5545,15 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
 
     public func hidden() -> DescriptionList {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> DescriptionList {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> DescriptionList {
@@ -5610,6 +5799,15 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     public func hidden() -> Figure {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Figure {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Figure {
         return mutate(inputmode: value)
@@ -5853,6 +6051,15 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func hidden() -> Anchor {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Anchor {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Anchor {
@@ -6141,6 +6348,15 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func hidden() -> Emphasize {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Emphasize {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Emphasize {
         return mutate(inputmode: value)
@@ -6385,6 +6601,15 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     public func hidden() -> Strong {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Strong {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Strong {
         return mutate(inputmode: value)
@@ -6628,6 +6853,15 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func hidden() -> Small {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Small {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Small {
@@ -6880,6 +7114,15 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
     public func hidden() -> StrikeThrough {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> StrikeThrough {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> StrikeThrough {
         return mutate(inputmode: value)
@@ -7054,6 +7297,15 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func hidden() -> Main {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Main {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Main {
@@ -7299,6 +7551,15 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> Division {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Division {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Division {
         return mutate(inputmode: value)
@@ -7543,6 +7804,15 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     public func hidden() -> Definition {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Definition {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Definition {
         return mutate(inputmode: value)
@@ -7786,6 +8056,15 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func hidden() -> Cite {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Cite {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Cite {
@@ -8032,6 +8311,15 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(hidden: "hidden")
     }
 
+    public func hidden(_ condition: Bool) -> ShortQuote {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
+    
     public func inputMode(_ value: String) -> ShortQuote {
         return mutate(inputmode: value)
     }
@@ -8279,6 +8567,15 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
     public func hidden() -> Abbreviation {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Abbreviation {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Abbreviation {
         return mutate(inputmode: value)
@@ -8524,6 +8821,15 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(hidden: "hidden")
     }
     
+    public func hidden(_ condition: Bool) -> Ruby {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
+    
     public func inputMode(_ value: String) -> Ruby {
         return mutate(inputmode: value)
     }
@@ -8766,6 +9072,15 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
 
     public func hidden() -> Data {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Data {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Data {
@@ -9015,6 +9330,15 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
     public func hidden() -> Time {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Time {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Time {
         return mutate(inputmode: value)
@@ -9263,6 +9587,15 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func hidden() -> Code {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Code {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Code {
         return mutate(inputmode: value)
@@ -9506,6 +9839,15 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func hidden() -> Variable {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Variable {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Variable {
@@ -9751,6 +10093,15 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
     public func hidden() -> SampleOutput {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> SampleOutput {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> SampleOutput {
         return mutate(inputmode: value)
@@ -9994,6 +10345,15 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
 
     public func hidden() -> KeyboardInput {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> KeyboardInput {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> KeyboardInput {
@@ -10239,6 +10599,15 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func hidden() -> Subscript {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Subscript {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Subscript {
         return mutate(inputmode: value)
@@ -10481,6 +10850,15 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func hidden() -> Superscript {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Superscript {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Superscript {
@@ -10725,6 +11103,15 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
 
     public func hidden() -> Italic {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Italic {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Italic {
@@ -10977,6 +11364,15 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func hidden() -> Bold {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Bold {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Bold {
         return mutate(inputmode: value)
@@ -11227,6 +11623,15 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func hidden() -> Underline {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Underline {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Underline {
@@ -11479,6 +11884,15 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func hidden() -> Mark {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Mark {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Mark {
         return mutate(inputmode: value)
@@ -11723,6 +12137,15 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func hidden() -> Bdi {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Bdi {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Bdi {
         return mutate(inputmode: value)
@@ -11961,6 +12384,15 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func hidden() -> Bdo {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Bdo {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Bdo {
@@ -12206,6 +12638,15 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func hidden() -> Span {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Span {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Span {
         return mutate(inputmode: value)
@@ -12445,6 +12886,15 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func hidden() -> LineBreak {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> LineBreak {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> LineBreak {
         return mutate(inputmode: value)
@@ -12683,6 +13133,15 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func hidden() -> WordBreak {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> WordBreak {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> WordBreak {
@@ -12927,6 +13386,15 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
 
     public func hidden() -> InsertedText {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> InsertedText {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> InsertedText {
@@ -13180,6 +13648,15 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     public func hidden() -> DeletedText {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> DeletedText {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> DeletedText {
         return mutate(inputmode: value)
@@ -13432,6 +13909,15 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
     public func hidden() -> Picture {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Picture {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Picture {
         return mutate(inputmode: value)
@@ -13594,6 +14080,15 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func hidden() -> Image {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Image {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Image {
@@ -13863,6 +14358,15 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     public func hidden() -> InlineFrame {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> InlineFrame {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> InlineFrame {
         return mutate(inputmode: value)
@@ -14121,6 +14625,15 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func hidden() -> Embed {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Embed {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Embed {
@@ -14381,6 +14894,15 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func hidden() -> Object {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Object {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Object {
@@ -14650,6 +15172,15 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     public func hidden() -> Video {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Video {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Video {
         return mutate(inputmode: value)
@@ -14721,6 +15252,15 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func autoplay() -> Video {
         return mutate(autoplay: "autoplay")
+    }
+    
+    public func autoplay(_ condition: Bool) -> Video {
+        
+        if condition {
+            return mutate(autoplay: "autoplay")
+        }
+        
+        return self
     }
     
     public func loop() -> Video {
@@ -14926,6 +15466,15 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     public func hidden() -> Audio {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Audio {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Audio {
         return mutate(inputmode: value)
@@ -14997,6 +15546,15 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func autoplay() -> Audio {
         return mutate(autoplay: "autoplay")
+    }
+    
+    public func autoplay(_ condition: Bool) -> Audio {
+        
+        if condition {
+            return mutate(autoplay: "autoplay")
+        }
+        
+        return self
     }
     
     public func loop() -> Audio {
@@ -15194,6 +15752,15 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
     public func hidden() -> Map {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Map {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Map {
         return mutate(inputmode: value)
@@ -15365,6 +15932,15 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
 
     public func hidden() -> Form {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Form {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Form {
@@ -15638,6 +16214,15 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> DataList {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> DataList {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> DataList {
         return mutate(inputmode: value)
@@ -15881,6 +16466,15 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func hidden() -> Output {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Output {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Output {
@@ -16138,6 +16732,15 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> Progress {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Progress {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Progress {
         return mutate(inputmode: value)
@@ -16389,6 +16992,15 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func hidden() -> Meter {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Meter {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Meter {
@@ -16658,6 +17270,15 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func hidden() -> Details {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Details {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Details {
         return mutate(inputmode: value)
@@ -16905,6 +17526,15 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func hidden() -> Dialog {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Dialog {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Dialog {
@@ -17154,6 +17784,15 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
     public func hidden() -> Script {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Script {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Script {
         return mutate(inputmode: value)
@@ -17338,6 +17977,15 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
     public func hidden() -> NoScript {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> NoScript {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> NoScript {
         return mutate(inputmode: value)
@@ -17505,6 +18153,15 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
 
     public func hidden() -> Template {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Template {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Template {
@@ -17677,6 +18334,15 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func hidden() -> Canvas {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Canvas {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Canvas {
@@ -17929,6 +18595,15 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func hidden() -> Table {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Table {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Table {
@@ -18289,6 +18964,15 @@ extension Slot: GlobalAttributes, NameAttribute {
     
     public func hidden() -> Slot {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Slot {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
     
     public func inputMode(_ value: String) -> Slot {

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -104,6 +104,15 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> TermName {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> TermName{
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> TermName {
         return mutate(inputmode: value)
@@ -347,6 +356,15 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
 
     public func hidden() -> TermDefinition {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> TermDefinition {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> TermDefinition {

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -95,6 +95,15 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
     public func hidden() -> FigureCaption {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> FigureCaption {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> FigureCaption {
         return mutate(inputmode: value)

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -81,6 +81,15 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
     public func hidden() -> Input {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Input {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Input {
         return mutate(inputmode: value)
@@ -162,8 +171,26 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(checked: "checked")
     }
     
+    public func checked(_ condition: Bool) -> Input {
+        
+        if condition {
+            return mutate(checked: "checked")
+        }
+        
+        return self
+    }
+    
     public func disabled() -> Input {
         return mutate(disabled: "disabled")
+    }
+    
+    public func disabled(_ condition: Bool) -> Input {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
     }
     
     public func form(_ value: String) -> Input {
@@ -218,8 +245,26 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(readonly: "readonly")
     }
     
+    public func readonly(_ condition: Bool) -> Input {
+        
+        if condition {
+            return mutate(readonly: "readonly")
+        }
+        
+        return self
+    }
+    
     public func required() -> Input {
         return mutate(required: "required")
+    }
+    
+    public func required(_ condition: Bool) -> Input {
+        
+        if condition {
+            return mutate(required: "required")
+        }
+        
+        return self
     }
     
     public func size(_ size: Int) -> Input {
@@ -348,6 +393,15 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func hidden() -> Label {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Label {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Label {
@@ -604,6 +658,15 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
     public func hidden() -> Select {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Select {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Select {
         return mutate(inputmode: value)
@@ -677,6 +740,15 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return mutate(disabled: "disabled")
     }
     
+    public func disabled(_ condition: Bool) -> Select {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
+    }
+    
     public func form(_ value: String) -> Select {
         return mutate(form: value)
     }
@@ -691,6 +763,15 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
     
     public func required() -> Select {
         return mutate(required: "required")
+    }
+    
+    public func required(_ condition: Bool) -> Select {
+        
+        if condition {
+            return mutate(required: "required")
+        }
+        
+        return self
     }
     
     public func size(_ size: Int) -> Select {
@@ -800,6 +881,15 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> TextArea {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> TextArea {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> TextArea {
         return mutate(inputmode: value)
@@ -877,6 +967,15 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(disabled: "disabled")
     }
     
+    public func disabled(_ condition: Bool) -> TextArea {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
+    }
+    
     public func form(_ value: String) -> TextArea {
         return mutate(form: value)
     }
@@ -901,8 +1000,26 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(readonly: "readonly")
     }
     
+    public func readonly(_ condition: Bool) -> TextArea {
+        
+        if condition {
+            return mutate(readonly: "readonly")
+        }
+        
+        return self
+    }
+    
     public func required() -> TextArea {
         return mutate(required: "required")
+    }
+    
+    public func required(_ condition: Bool) -> TextArea {
+        
+        if condition {
+            return mutate(required: "required")
+        }
+        
+        return self
     }
     
     public func rows(_ size: Int) -> TextArea {
@@ -1092,6 +1209,15 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     public func hidden() -> Button {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Button {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Button {
         return mutate(inputmode: value)
@@ -1159,6 +1285,15 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func disabled() -> Button {
         return mutate(disabled: "disabled")
+    }
+    
+    public func disabled(_ condition: Bool) -> Button {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
     }
     
     public func form(_ value: String) -> Button {
@@ -1367,6 +1502,15 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> Fieldset {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Fieldset {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Fieldset {
         return mutate(inputmode: value)
@@ -1434,6 +1578,15 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func disabled() -> Fieldset {
         return mutate(disabled: "disabled")
+    }
+    
+    public func disabled(_ condition: Bool) -> Fieldset {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
     }
     
     public func form(_ value: String) -> Fieldset {

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -275,6 +275,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(source: value)
     }
     
+    public func source(_ value: EnvironmentValue) -> Input {
+        return mutate(source: value)
+    }
+    
     public func step(_ size: Int) -> Input {
         return mutate(step: size)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -87,6 +87,15 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return mutate(hidden: "hidden")
     }
     
+    public func hidden(_ condition: Bool) -> Title {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
+    
     public func inputMode(_ value: String) -> Title {
         return mutate(inputmode: value)
     }
@@ -248,6 +257,15 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
     
     public func hidden() -> Base {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Base {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
     
     public func inputMode(_ value: String) -> Base {
@@ -419,6 +437,15 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
 
     public func hidden() -> Meta {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Meta {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Meta {
@@ -608,6 +635,15 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
     public func hidden() -> Style {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Style {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Style {
         return mutate(inputmode: value)
@@ -778,6 +814,15 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
 
     public func hidden() -> Link {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Link {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Link {

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -87,6 +87,15 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return mutate(hidden: "hidden")
     }
     
+    public func hidden(_ condition: Bool) -> Head {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
+    
     public func inputMode(_ value: String) -> Head {
         return mutate(inputmode: value)
     }
@@ -253,6 +262,15 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
 
     public func hidden() -> Body {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Body {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Body {

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -95,6 +95,15 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     public func hidden() -> OptionGroup {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> OptionGroup {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> OptionGroup {
         return mutate(inputmode: value)
@@ -162,6 +171,15 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func disabled() -> OptionGroup {
         return mutate(disabled: "disabled")
+    }
+    
+    public func disabled(_ condition: Bool) -> OptionGroup {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
     }
     
     public func label(_ value: String) -> OptionGroup {
@@ -347,6 +365,15 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     public func hidden() -> Option {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Option {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Option {
         return mutate(inputmode: value)
@@ -414,6 +441,15 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func disabled() -> Option {
         return mutate(disabled: "disabled")
+    }
+    
+    public func disabled(_ condition: Bool) -> Option {
+        
+        if condition {
+            return mutate(disabled: "disabled")
+        }
+        
+        return self
     }
     
     public func label(_ value: String) -> Option {
@@ -608,6 +644,15 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
 
     public func hidden() -> Legend {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Legend {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Legend {
@@ -852,6 +897,15 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
 
     public func hidden() -> Summary {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Summary {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Summary {

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -95,6 +95,15 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> ListItem {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> ListItem {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> ListItem {
         return mutate(inputmode: value)

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -87,6 +87,15 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(hidden: "hidden")
     }
 
+    public func hidden(_ condition: Bool) -> Area {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
+    
     public func inputMode(_ value: String) -> Area {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -163,6 +163,10 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         return mutate(source: value)
     }
     
+    public func source(_ value: EnvironmentValue) -> Source {
+        return mutate(source: value)
+    }
+    
     public func sizes(_ size: Int) -> Source {
         return mutate(sizes: size)
     }
@@ -356,6 +360,10 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
     }
     
     public func source(_ value: String) -> Track {
+        return mutate(source: value)
+    }
+    
+    public func source(_ value: EnvironmentValue) -> Track {
         return mutate(source: value)
     }
     

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -81,6 +81,15 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
     public func hidden() -> Source {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Source {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Source {
         return mutate(inputmode: value)
@@ -267,6 +276,15 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
 
     public func hidden() -> Track {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> Track {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> Track {

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -81,6 +81,15 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
     public func hidden() -> Parameter {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Parameter {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Parameter {
         return mutate(inputmode: value)

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -104,6 +104,15 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func hidden() -> RubyText {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> RubyText {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> RubyText {
         return mutate(inputmode: value)
@@ -347,6 +356,15 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
 
     public func hidden() -> RubyPronunciation {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> RubyPronunciation {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> RubyPronunciation {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -158,6 +158,15 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func hidden() -> Caption {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Caption {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Caption {
         return mutate(inputmode: value)
@@ -402,6 +411,15 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
     public func hidden() -> ColumnGroup {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> ColumnGroup {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> ColumnGroup {
         return mutate(inputmode: value)
@@ -574,6 +592,15 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
     public func hidden() -> Column {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> Column {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> Column {
         return mutate(inputmode: value)
@@ -745,6 +772,15 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func hidden() -> TableBody {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> TableBody {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> TableBody {
@@ -998,6 +1034,15 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func hidden() -> TableHead {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> TableHead {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> TableHead {
         return mutate(inputmode: value)
@@ -1250,6 +1295,15 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func hidden() -> TableFoot {
         return mutate(hidden: "hidden")
     }
+    
+    public func hidden(_ condition: Bool) -> TableFoot {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
+    }
 
     public func inputMode(_ value: String) -> TableFoot {
         return mutate(inputmode: value)
@@ -1493,6 +1547,15 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func hidden() -> TableRow {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> TableRow {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> TableRow {
@@ -1745,6 +1808,15 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func hidden() -> DataCell {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> DataCell {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> DataCell {
@@ -2001,6 +2073,15 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func hidden() -> HeaderCell {
         return mutate(hidden: "hidden")
+    }
+    
+    public func hidden(_ condition: Bool) -> HeaderCell {
+        
+        if condition {
+            return mutate(hidden: "hidden")
+        }
+        
+        return self
     }
 
     public func inputMode(_ value: String) -> HeaderCell {

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
@@ -16,3 +16,10 @@ public struct EnvironmentValue: Content {
         self.valuePath = valuePath
     }
 }
+
+extension EnvironmentValue {
+    
+    static public func + (lhs: Content, rhs: Self) -> Content {
+        return [lhs, rhs]
+    }
+}

--- a/Sources/HTMLKit/Framework/Extensions/Datatypes+Content.swift
+++ b/Sources/HTMLKit/Framework/Extensions/Datatypes+Content.swift
@@ -17,7 +17,12 @@ extension Int: Content {}
 
 extension Optional: Content{}
 
-extension String: Content {}
+extension String: Content {
+    
+    static public func + (lhs: Content, rhs: Self) -> Content {
+        return [lhs, rhs]
+    }
+}
 
 extension UUID: Content {}
 

--- a/Sources/HTMLKit/Framework/Primitives/Nodes/Nodes.swift
+++ b/Sources/HTMLKit/Framework/Primitives/Nodes/Nodes.swift
@@ -29,19 +29,6 @@ internal protocol ContentNode: Node {
 
 extension ContentNode {
     
-    internal var startTag: String {
-        
-        guard let attributes = attributes else {
-            return "<\(name)>"
-        }
-        
-        return "<\(name) \(attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " "))>"
-    }
-    
-    internal var endTag: String {
-        return "</\(name)>"
-    }
-    
     internal func modify(_ element: Self) -> Self {
         
         guard var attributes = self.attributes else {
@@ -72,15 +59,6 @@ internal protocol EmptyNode: Node {
 
 extension EmptyNode {
     
-    internal var startTag: String {
-        
-        guard let attributes = attributes else {
-            return "<\(name)>"
-        }
-        
-        return "<\(name) \(attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " "))>"
-    }
-    
     internal func modify(_ element: Self) -> Self {
         
         guard var attributes = self.attributes else {
@@ -100,29 +78,11 @@ internal protocol CommentNode: Node {
     var content: String { get }
 }
 
-extension CommentNode {
-    
-    internal var startTag: String {
-        return "<!--"
-    }
-    
-    internal var endTag: String {
-        return "-->"
-    }
-}
-
 /// The protocol defines the document node.
 internal protocol DocumentNode: Node {
     
     /// The content of the node.
     var content: String { get }
-}
-
-extension DocumentNode {
-    
-    internal var startTag: String {
-        return "<!DOCTYPE \(content)>"
-    }
 }
 
 public protocol CustomNode: Node {
@@ -147,19 +107,6 @@ public protocol CustomNode: Node {
 }
 
 extension CustomNode {
-    
-    internal var startTag: String {
-        
-        guard let attributes = attributes else {
-            return "<\(name)>"
-        }
-        
-        return "<\(name) \(attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " "))>"
-    }
-    
-    internal var endTag: String {
-        return "</\(name)>"
-    }
     
     internal func modify(_ element: Self) -> Self {
         

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -4,6 +4,7 @@
  */
 
 import Foundation
+import OrderedCollections
 
 /// A struct containing the different formulas for the different views.
 public class Renderer {
@@ -87,7 +88,7 @@ public class Renderer {
             }
             
             if let element = content as? (any EmptyNode) {
-                result += render(element: element)
+                result += try render(element: element)
             }
             
             if let element = content as? (any DocumentNode) {
@@ -127,7 +128,13 @@ public class Renderer {
         
         var result = ""
         
-        result += element.startTag
+        result += "<\(element.name)"
+        
+        if let attributes = element.attributes {
+            result += try render(attributes: attributes)
+        }
+        
+        result += ">"
         
         if let contents = element.content as? [Content] {
             
@@ -146,7 +153,7 @@ public class Renderer {
                 }
                 
                 if let element = content as? (any EmptyNode) {
-                    result += render(element: element)
+                    result += try render(element: element)
                 }
                 
                 if let element = content as? (any DocumentNode) {
@@ -179,24 +186,35 @@ public class Renderer {
             }
         }
         
-        result += element.endTag
+        result += "</\(element.name)>"
         
         return result
     }
     
     /// Renders a empty element
-    internal func render(element: some EmptyNode) -> String {
-        return element.startTag
+    internal func render(element: some EmptyNode) throws -> String {
+        
+        var result = ""
+        
+        result += "<\(element.name)"
+        
+        if let attributes = element.attributes {
+            result += try render(attributes: attributes)
+        }
+        
+        result += ">"
+        
+        return result
     }
     
     /// Renders a document element
     internal func render(element: some DocumentNode) -> String {
-        return element.startTag
+        return "<!DOCTYPE \(element.content)>"
     }
     
     /// Renders a comment element
     internal func render(element: some CommentNode) -> String {
-        return element.startTag + element.content + element.endTag
+        return "<!--\(element.content)-->"
     }
     
     /// Renders a content element
@@ -204,7 +222,13 @@ public class Renderer {
         
         var result = ""
         
-        result += element.startTag
+        result += "<\(element.name)"
+        
+        if let attributes = element.attributes {
+            result += try render(attributes: attributes)
+        }
+        
+        result += ">"
         
         if let contents = element.content as? [Content] {
             
@@ -223,7 +247,7 @@ public class Renderer {
                 }
                 
                 if let element = content as? (any EmptyNode) {
-                    result += render(element: element)
+                    result += try render(element: element)
                 }
                 
                 if let element = content as? (any DocumentNode) {
@@ -248,7 +272,7 @@ public class Renderer {
             }
         }
         
-        result += element.endTag
+        result += "</\(element.name)>"
         
         return result
     }
@@ -338,5 +362,25 @@ public class Renderer {
         default:
             throw Errors.unableToCastEnvironmentValue
         }
+    }
+    
+    /// Renders the node attributes
+    internal func render(attributes: OrderedDictionary<String, Any>) throws -> String {
+        
+        var result = ""
+        
+        for attribute in attributes {
+            
+            result += " \(attribute.key)=\""
+            
+            if let value = attribute.value as? EnvironmentValue {
+                result += "\(try render(value: value))\""
+                
+            } else {
+                result += "\(attribute.value)\""
+            }
+        }
+        
+        return result
     }
 }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -69,6 +69,15 @@ final class AttributesTests: XCTestCase {
             return self.mutate(hidden: "hidden")
         }
         
+        public func hidden(_ condition: Bool) -> Tag {
+            
+            if condition {
+                return mutate(hidden: "hidden")
+            }
+            
+            return self
+        }
+        
         func id(_ value: String) -> Tag {
             return self.mutate(id: value)
         }
@@ -157,12 +166,30 @@ final class AttributesTests: XCTestCase {
             return self.mutate(autoplay: "autoplay")
         }
         
+        public func autoplay(_ condition: Bool) -> Tag {
+            
+            if condition {
+                return mutate(autoplay: "autoplay")
+            }
+            
+            return self
+        }
+        
         func charset(_ value: Values.Charset) -> Tag {
             return self.mutate(charset: value.rawValue)
         }
         
         func checked() -> Tag {
             return self.mutate(checked: "checked")
+        }
+        
+        public func checked(_ condition: Bool) -> Tag {
+            
+            if condition {
+                return mutate(checked: "checked")
+            }
+            
+            return self
         }
         
         func cite(_ value: String) -> Tag {
@@ -207,6 +234,15 @@ final class AttributesTests: XCTestCase {
         
         func disabled() -> Tag {
             return self.mutate(disabled: "disabled")
+        }
+        
+        public func disabled(_ condition: Bool) -> Tag {
+            
+            if condition {
+                return mutate(disabled: "disabled")
+            }
+            
+            return self
         }
         
         func download() -> Tag {
@@ -353,6 +389,15 @@ final class AttributesTests: XCTestCase {
             return self.mutate(readonly: "readonly")
         }
         
+        public func readonly(_ condition: Bool) -> Tag {
+            
+            if condition {
+                return mutate(readonly: "readonly")
+            }
+            
+            return self
+        }
+        
         func referrerPolicy(_ value: Values.Policy) -> Tag {
             return self.mutate(referrerpolicy: value.rawValue)
         }
@@ -363,6 +408,15 @@ final class AttributesTests: XCTestCase {
         
         func required() -> Tag {
             return self.mutate(required: "required")
+        }
+        
+        public func required(_ condition: Bool) -> Tag {
+            
+            if condition {
+                return mutate(required: "required")
+            }
+            
+            return self
         }
         
         func reversed() -> Tag {
@@ -647,9 +701,7 @@ final class AttributesTests: XCTestCase {
     func testAccesskeyAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .accessKey("s")
+            Tag {}.accessKey("s")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -662,9 +714,7 @@ final class AttributesTests: XCTestCase {
     func testAutocapitalizeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .autocapitalize(.words)
+            Tag {}.autocapitalize(.words)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -677,9 +727,7 @@ final class AttributesTests: XCTestCase {
     func testAutofocusAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .autofocus()
+            Tag {}.autofocus()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -692,9 +740,7 @@ final class AttributesTests: XCTestCase {
     func testClassAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .class("container")
+            Tag {}.class("container")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -707,9 +753,7 @@ final class AttributesTests: XCTestCase {
     func testDirectionAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .direction(.leftToRight)
+            Tag {}.direction(.leftToRight)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -722,9 +766,7 @@ final class AttributesTests: XCTestCase {
     func testDraggableAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .isDraggable(true)
+            Tag {}.isDraggable(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -737,9 +779,7 @@ final class AttributesTests: XCTestCase {
     func testEditableAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .isEditable(true)
+            Tag {}.isEditable(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -752,9 +792,7 @@ final class AttributesTests: XCTestCase {
     func testEnterkeyhintAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .enterKeyHint(.enter)
+            Tag {}.enterKeyHint(.enter)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -767,13 +805,18 @@ final class AttributesTests: XCTestCase {
     func testHiddenAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .hidden()
+            // unconditionally
+            Tag {}.hidden()
+            // with a false condition
+            Tag {}.hidden(false)
+            // with a true condition
+            Tag {}.hidden(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag hidden="hidden"></tag>\
+                       <tag></tag>\
                        <tag hidden="hidden"></tag>
                        """
         )
@@ -782,9 +825,7 @@ final class AttributesTests: XCTestCase {
     func testIdentifierAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .id("navigation")
+            Tag {}.id("navigation")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -797,9 +838,7 @@ final class AttributesTests: XCTestCase {
     func testLanguageAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .language(.german)
+            Tag {}.language(.german)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -812,9 +851,7 @@ final class AttributesTests: XCTestCase {
     func testNonceAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .nonce("84a97f593e589c45")
+            Tag {}.nonce("84a97f593e589c45")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -827,9 +864,7 @@ final class AttributesTests: XCTestCase {
     func testRoleAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .role(.range)
+            Tag {}.role(.range)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -842,9 +877,7 @@ final class AttributesTests: XCTestCase {
     func testHasSpellCheckAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .hasSpellCheck(true)
+            Tag {}.hasSpellCheck(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -857,9 +890,7 @@ final class AttributesTests: XCTestCase {
     func testStyleAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .style("background-color:powderblue;")
+            Tag {}.style("background-color:powderblue;")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -872,9 +903,7 @@ final class AttributesTests: XCTestCase {
     func testTabIndexAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .tabIndex(3)
+            Tag {}.tabIndex(3)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -887,9 +916,7 @@ final class AttributesTests: XCTestCase {
     func testTitleAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .title("homeview")
+            Tag {}.title("homeview")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -902,9 +929,7 @@ final class AttributesTests: XCTestCase {
     func testTranslateAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .translate(.yes)
+            Tag {}.translate(.yes)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -917,9 +942,7 @@ final class AttributesTests: XCTestCase {
     func testAcceptAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .accept("accept")
+            Tag {}.accept("accept")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -932,9 +955,7 @@ final class AttributesTests: XCTestCase {
     func testActionAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .action("action")
+            Tag {}.action("action")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -947,9 +968,7 @@ final class AttributesTests: XCTestCase {
     func testAlternateAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .alternate("a tag and a attribute")
+            Tag {}.alternate("a tag and a attribute")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -962,9 +981,7 @@ final class AttributesTests: XCTestCase {
     func testAsynchronouslyAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .asynchronously()
+            Tag {}.asynchronously()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -977,9 +994,7 @@ final class AttributesTests: XCTestCase {
     func testCompleteAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .hasCompletion(true)
+            Tag {}.hasCompletion(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -992,13 +1007,18 @@ final class AttributesTests: XCTestCase {
     func testAutoplayAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .autoplay()
+            // unconditionally
+            Tag {}.autoplay()
+            // with false condition
+            Tag {}.autoplay(false)
+            // with true condition
+            Tag {}.autoplay(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag autoplay="autoplay"></tag>\
+                       <tag></tag>\
                        <tag autoplay="autoplay"></tag>
                        """
         )
@@ -1007,9 +1027,7 @@ final class AttributesTests: XCTestCase {
     func testCharsetAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .charset(.utf8)
+            Tag {}.charset(.utf8)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1022,13 +1040,18 @@ final class AttributesTests: XCTestCase {
     func testCheckedAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .checked()
+            // unconditionally
+            Tag {}.checked()
+            // with false condition
+            Tag {}.checked(false)
+            // with true condition
+            Tag {}.checked(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag checked="checked"></tag>\
+                       <tag></tag>\
                        <tag checked="checked"></tag>
                        """
         )
@@ -1037,9 +1060,7 @@ final class AttributesTests: XCTestCase {
     func testCiteAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .cite("cite")
+            Tag {}.cite("cite")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1052,9 +1073,7 @@ final class AttributesTests: XCTestCase {
     func testColumnsAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .columns(2)
+            Tag {}.columns(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1067,9 +1086,7 @@ final class AttributesTests: XCTestCase {
     func testColumnSpanAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .columnSpan(2)
+            Tag {}.columnSpan(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1082,9 +1099,7 @@ final class AttributesTests: XCTestCase {
     func testContentAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .content("content")
+            Tag {}.content("content")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1097,9 +1112,7 @@ final class AttributesTests: XCTestCase {
     func testControlsAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .controls()
+            Tag {}.controls()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1112,9 +1125,7 @@ final class AttributesTests: XCTestCase {
     func testCoordinatesAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .coordinates("255,132,316,150")
+            Tag {}.coordinates("255,132,316,150")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1127,9 +1138,7 @@ final class AttributesTests: XCTestCase {
     func testDataAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .data("https://www.github.com")
+            Tag {}.data("https://www.github.com")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1142,9 +1151,7 @@ final class AttributesTests: XCTestCase {
     func testDateTimeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .dateTime("YYYY-MM-DDThh:mm:ssTZD")
+            Tag {}.dateTime("YYYY-MM-DDThh:mm:ssTZD")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1157,9 +1164,7 @@ final class AttributesTests: XCTestCase {
     func testDefaultAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .default()
+            Tag {}.default()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1172,9 +1177,7 @@ final class AttributesTests: XCTestCase {
     func testDeferAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .defer()
+            Tag {}.defer()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1187,13 +1190,18 @@ final class AttributesTests: XCTestCase {
     func testDisabledAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .disabled()
+            // unconditionally
+            Tag {}.disabled()
+            // with false condition
+            Tag {}.disabled(false)
+            // with true condition
+            Tag {}.disabled(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag disabled="disabled"></tag>\
+                       <tag></tag>\
                        <tag disabled="disabled"></tag>
                        """
         )
@@ -1202,9 +1210,7 @@ final class AttributesTests: XCTestCase {
     func testDownloadAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .download()
+            Tag {}.download()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1217,9 +1223,7 @@ final class AttributesTests: XCTestCase {
     func testEncodingAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .encoding(.plainText)
+            Tag {}.encoding(.plainText)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1232,9 +1236,7 @@ final class AttributesTests: XCTestCase {
     func testForAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .for("for")
+            Tag {}.for("for")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1247,9 +1249,7 @@ final class AttributesTests: XCTestCase {
     func testFormAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .form("/action.php")
+            Tag {}.form("/action.php")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1262,9 +1262,7 @@ final class AttributesTests: XCTestCase {
     func testFormActionAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .formAction("/action.php")
+            Tag {}.formAction("/action.php")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1277,9 +1275,7 @@ final class AttributesTests: XCTestCase {
     func testEquivalentAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .equivalent(.refresh)
+            Tag {}.equivalent(.refresh)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1292,9 +1288,7 @@ final class AttributesTests: XCTestCase {
     func testHeadersAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .headers("name")
+            Tag {}.headers("name")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1307,9 +1301,7 @@ final class AttributesTests: XCTestCase {
     func testHeightAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .height(2)
+            Tag {}.height(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1322,9 +1314,7 @@ final class AttributesTests: XCTestCase {
     func testHighAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .high(2.0)
+            Tag {}.high(2.0)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1337,9 +1327,7 @@ final class AttributesTests: XCTestCase {
     func testReferenceAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .reference("/index.html")
+            Tag {}.reference("/index.html")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1352,9 +1340,7 @@ final class AttributesTests: XCTestCase {
     func testReferenceLanguageAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .referenceLanguage(.german)
+            Tag {}.referenceLanguage(.german)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1367,9 +1353,7 @@ final class AttributesTests: XCTestCase {
     func testIsMapAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .isMap()
+            Tag {}.isMap()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1382,9 +1366,7 @@ final class AttributesTests: XCTestCase {
     func testKindAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .kind(.subtitles)
+            Tag {}.kind(.subtitles)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1397,9 +1379,7 @@ final class AttributesTests: XCTestCase {
     func testLabelAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .label("Soccer")
+            Tag {}.label("Soccer")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1412,9 +1392,7 @@ final class AttributesTests: XCTestCase {
     func testListAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .list("browsers")
+            Tag {}.list("browsers")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1427,9 +1405,7 @@ final class AttributesTests: XCTestCase {
     func testLoopAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .loop()
+            Tag {}.loop()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1442,9 +1418,7 @@ final class AttributesTests: XCTestCase {
     func testLowAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .low(2.0)
+            Tag {}.low(2.0)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1457,9 +1431,7 @@ final class AttributesTests: XCTestCase {
     func testMaximumAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .maximum("1948-01-01")
+            Tag {}.maximum("1948-01-01")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1472,9 +1444,7 @@ final class AttributesTests: XCTestCase {
     func testMaximumLengthAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .maximum(length: 2)
+            Tag {}.maximum(length: 2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1487,9 +1457,7 @@ final class AttributesTests: XCTestCase {
     func testMediaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .media("print and (resolution:300dpi)")
+            Tag {}.media("print and (resolution:300dpi)")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1502,9 +1470,7 @@ final class AttributesTests: XCTestCase {
     func testMethodAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .method(.get)
+            Tag {}.method(.get)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1517,9 +1483,7 @@ final class AttributesTests: XCTestCase {
     func testMinimumAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .minimum(2.0)
+            Tag {}.minimum(2.0)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1532,9 +1496,7 @@ final class AttributesTests: XCTestCase {
     func testMinimumLengthAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .minimum(length: 2)
+            Tag {}.minimum(length: 2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1547,9 +1509,7 @@ final class AttributesTests: XCTestCase {
     func testMultipleAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .multiple()
+            Tag {}.multiple()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1562,9 +1522,7 @@ final class AttributesTests: XCTestCase {
     func testMutedAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .muted()
+            Tag {}.muted()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1577,9 +1535,7 @@ final class AttributesTests: XCTestCase {
     func testNameAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .name("name")
+            Tag {}.name("name")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1592,9 +1548,7 @@ final class AttributesTests: XCTestCase {
     func testNoValidateAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .novalidate()
+            Tag {}.novalidate()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1607,9 +1561,7 @@ final class AttributesTests: XCTestCase {
     func testIsOpenAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .isOpen(true)
+            Tag {}.isOpen(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1622,9 +1574,7 @@ final class AttributesTests: XCTestCase {
     func testOptimumAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .optimum(2.0)
+            Tag {}.optimum(2.0)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1637,9 +1587,7 @@ final class AttributesTests: XCTestCase {
     func testPatternAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .pattern("[A-Za-z]{3}")
+            Tag {}.pattern("[A-Za-z]{3}")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1652,9 +1600,7 @@ final class AttributesTests: XCTestCase {
     func testPartAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .part("part")
+            Tag {}.part("part")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1667,9 +1613,7 @@ final class AttributesTests: XCTestCase {
     func testPingAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .ping("https://www.github.com")
+            Tag {}.ping("https://www.github.com")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1682,9 +1626,7 @@ final class AttributesTests: XCTestCase {
     func testPlaceholderAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .placeholder("123-45-678")
+            Tag {}.placeholder("123-45-678")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1697,9 +1639,7 @@ final class AttributesTests: XCTestCase {
     func testPosterAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .poster("https://www.github.com")
+            Tag {}.poster("https://www.github.com")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1712,9 +1652,7 @@ final class AttributesTests: XCTestCase {
     func testPreloadAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .preload(.metadata)
+            Tag {}.preload(.metadata)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1727,13 +1665,18 @@ final class AttributesTests: XCTestCase {
     func testReadonlyAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .readonly()
+            // unconditionally
+            Tag {}.readonly()
+            // with false condition
+            Tag {}.readonly(false)
+            // with true condition
+            Tag {}.readonly(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag readonly="readonly"></tag>\
+                       <tag></tag>\
                        <tag readonly="readonly"></tag>
                        """
         )
@@ -1742,9 +1685,7 @@ final class AttributesTests: XCTestCase {
     func testReferrerPolicyAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .referrerPolicy(.origin)
+            Tag {}.referrerPolicy(.origin)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1757,9 +1698,7 @@ final class AttributesTests: XCTestCase {
     func testRelationshipAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .relationship(.author)
+            Tag {}.relationship(.author)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1772,13 +1711,18 @@ final class AttributesTests: XCTestCase {
     func testRequiredAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .required()
+            // unconditionally
+            Tag {}.required()
+            // with false condition
+            Tag {}.required(false)
+            // with true condition
+            Tag {}.required(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag required="required"></tag>\
+                       <tag></tag>\
                        <tag required="required"></tag>
                        """
         )
@@ -1787,9 +1731,7 @@ final class AttributesTests: XCTestCase {
     func testReversedAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .reversed()
+            Tag {}.reversed()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1802,9 +1744,7 @@ final class AttributesTests: XCTestCase {
     func testRowsAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .rows(2)
+            Tag {}.rows(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1817,9 +1757,7 @@ final class AttributesTests: XCTestCase {
     func testRowSpanAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .rowSpan(2)
+            Tag {}.rowSpan(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1832,9 +1770,7 @@ final class AttributesTests: XCTestCase {
     func testSandboxAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .sandbox()
+            Tag {}.sandbox()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1847,9 +1783,7 @@ final class AttributesTests: XCTestCase {
     func testScopeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .scope("scope")
+            Tag {}.scope("scope")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1862,9 +1796,7 @@ final class AttributesTests: XCTestCase {
     func testShapeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .shape(.circle)
+            Tag {}.shape(.circle)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1877,9 +1809,7 @@ final class AttributesTests: XCTestCase {
     func testSizeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .size(2)
+            Tag {}.size(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1892,9 +1822,7 @@ final class AttributesTests: XCTestCase {
     func testSizesAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .sizes(2)
+            Tag {}.sizes(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1907,9 +1835,7 @@ final class AttributesTests: XCTestCase {
     func testSlotAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .slot("slot")
+            Tag {}.slot("slot")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1922,9 +1848,7 @@ final class AttributesTests: XCTestCase {
     func testSpanAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .span(2)
+            Tag {}.span(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1937,9 +1861,7 @@ final class AttributesTests: XCTestCase {
     func testSourceAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .source("source")
+            Tag {}.source("source")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1952,9 +1874,7 @@ final class AttributesTests: XCTestCase {
     func testStartAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .start(2)
+            Tag {}.start(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1967,9 +1887,7 @@ final class AttributesTests: XCTestCase {
     func testStepAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .step(2)
+            Tag {}.step(2)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1982,9 +1900,7 @@ final class AttributesTests: XCTestCase {
     func testTargetAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .target(.blank)
+            Tag {}.target(.blank)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1997,9 +1913,7 @@ final class AttributesTests: XCTestCase {
     func testTypeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .type("type")
+            Tag {}.type("type")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2012,9 +1926,7 @@ final class AttributesTests: XCTestCase {
     func testSelectedAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .selected()
+            Tag {}.selected()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2027,9 +1939,7 @@ final class AttributesTests: XCTestCase {
     func testCustomAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .custom(key: "data-animal-type", value: "bird")
+            Tag {}.custom(key: "data-animal-type", value: "bird")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2042,9 +1952,7 @@ final class AttributesTests: XCTestCase {
     func testWindowEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .afterprint, "script")
+            Tag {}.on(event: .afterprint, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2057,9 +1965,7 @@ final class AttributesTests: XCTestCase {
     func testFocusEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .focus, "script")
+            Tag {}.on(event: .focus, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2072,9 +1978,7 @@ final class AttributesTests: XCTestCase {
     func testPointerEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .pointerup, "script")
+            Tag {}.on(event: .pointerup, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2087,9 +1991,7 @@ final class AttributesTests: XCTestCase {
     func testMouseEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .mouseup, "script")
+            Tag {}.on(event: .mouseup, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2102,9 +2004,7 @@ final class AttributesTests: XCTestCase {
     func testWheelEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .wheel, "script")
+            Tag {}.on(event: .wheel, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2117,9 +2017,7 @@ final class AttributesTests: XCTestCase {
     func testInputEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .input, "script")
+            Tag {}.on(event: .input, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2132,9 +2030,7 @@ final class AttributesTests: XCTestCase {
     func testKeyboardEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .keyup, "script")
+            Tag {}.on(event: .keyup, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2147,9 +2043,7 @@ final class AttributesTests: XCTestCase {
     func testDragEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .drag, "script")
+            Tag {}.on(event: .drag, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2162,9 +2056,7 @@ final class AttributesTests: XCTestCase {
     func testClipboardEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .paste, "script")
+            Tag {}.on(event: .paste, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2177,9 +2069,7 @@ final class AttributesTests: XCTestCase {
     func testSelectionEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .selectstart, "script")
+            Tag {}.on(event: .selectstart, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2192,9 +2082,7 @@ final class AttributesTests: XCTestCase {
     func testMediaEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .play, "script")
+            Tag {}.on(event: .play, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2207,9 +2095,7 @@ final class AttributesTests: XCTestCase {
     func testFormEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .submit, "script")
+            Tag {}.on(event: .submit, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2222,9 +2108,7 @@ final class AttributesTests: XCTestCase {
     func testDetailEventAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .on(event: .toggle, "script")
+            Tag {}.on(event: .toggle, "script")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2237,9 +2121,7 @@ final class AttributesTests: XCTestCase {
     func testAtomicAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(atomic: true)
+            Tag {}.aria(atomic: true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2252,9 +2134,7 @@ final class AttributesTests: XCTestCase {
     func testBusyAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(busy: true)
+            Tag {}.aria(busy: true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2267,9 +2147,7 @@ final class AttributesTests: XCTestCase {
     func testControlsAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(controls: "name")
+            Tag {}.aria(controls: "name")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2282,9 +2160,7 @@ final class AttributesTests: XCTestCase {
     func testCurrentAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(current: .page)
+            Tag {}.aria(current: .page)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2297,9 +2173,7 @@ final class AttributesTests: XCTestCase {
     func testDescribedByAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(describedBy: "description")
+            Tag {}.aria(describedBy: "description")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2312,9 +2186,7 @@ final class AttributesTests: XCTestCase {
     func testDetailsAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(details: "details")
+            Tag {}.aria(details: "details")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2327,9 +2199,7 @@ final class AttributesTests: XCTestCase {
     func testDisabledAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(disabled: true)
+            Tag {}.aria(disabled: true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2342,9 +2212,7 @@ final class AttributesTests: XCTestCase {
     func testErrorMessageAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(errorMessage: "error")
+            Tag {}.aria(errorMessage: "error")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2357,9 +2225,7 @@ final class AttributesTests: XCTestCase {
     func testFlowToAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(flowTo: "flow")
+            Tag {}.aria(flowTo: "flow")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2372,9 +2238,7 @@ final class AttributesTests: XCTestCase {
     func testHasPopupAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(hasPopup: .grid)
+            Tag {}.aria(hasPopup: .grid)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2387,9 +2251,7 @@ final class AttributesTests: XCTestCase {
     func testHiddenAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(hidden: true)
+            Tag {}.aria(hidden: true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2402,9 +2264,7 @@ final class AttributesTests: XCTestCase {
     func testInvalidAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(invalid: .grammar)
+            Tag {}.aria(invalid: .grammar)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2417,9 +2277,7 @@ final class AttributesTests: XCTestCase {
     func testKeyShortcutsAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(keyShortcuts: "shortcut")
+            Tag {}.aria(keyShortcuts: "shortcut")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2432,9 +2290,7 @@ final class AttributesTests: XCTestCase {
     func testLabelAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(label: "label")
+            Tag {}.aria(label: "label")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2447,9 +2303,7 @@ final class AttributesTests: XCTestCase {
     func testLabeledByAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(labeledBy: "label")
+            Tag {}.aria(labeledBy: "label")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2462,9 +2316,7 @@ final class AttributesTests: XCTestCase {
     func testLiveAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(live: .polite)
+            Tag {}.aria(live: .polite)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2477,9 +2329,7 @@ final class AttributesTests: XCTestCase {
     func testOwnsAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(owns: "live")
+            Tag {}.aria(owns: "live")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2492,9 +2342,7 @@ final class AttributesTests: XCTestCase {
     func testRelevantAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(relevant: .additions)
+            Tag {}.aria(relevant: .additions)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2507,9 +2355,7 @@ final class AttributesTests: XCTestCase {
     func testRoleDescriptionAriaAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .aria(roleDescription: "description")
+            Tag {}.aria(roleDescription: "description")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2522,9 +2368,7 @@ final class AttributesTests: XCTestCase {
     func testDrawAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .draw("M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z")
+            Tag {}.draw("M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2537,9 +2381,7 @@ final class AttributesTests: XCTestCase {
     func testFillAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .fill("black")
+            Tag {}.fill("black")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2552,9 +2394,7 @@ final class AttributesTests: XCTestCase {
     func testFillOpacityAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .fillOpacity(0.5)
+            Tag {}.fillOpacity(0.5)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2567,9 +2407,7 @@ final class AttributesTests: XCTestCase {
     func testStrokeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .stroke("black")
+            Tag {}.stroke("black")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2582,9 +2420,7 @@ final class AttributesTests: XCTestCase {
     func testStrokeWidthAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .strokeWidth(5)
+            Tag {}.strokeWidth(5)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2597,9 +2433,7 @@ final class AttributesTests: XCTestCase {
     func testStrokeOpacityAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .strokeOpacity(1.0)
+            Tag {}.strokeOpacity(1.0)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2612,9 +2446,7 @@ final class AttributesTests: XCTestCase {
     func testStrokeLineCapAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .strokeLineCap(.round)
+            Tag {}.strokeLineCap(.round)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2627,9 +2459,7 @@ final class AttributesTests: XCTestCase {
     func testStrokeLineJoinAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .strokeLineJoin(.miter)
+            Tag {}.strokeLineJoin(.miter)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2642,9 +2472,7 @@ final class AttributesTests: XCTestCase {
     func testRadiusAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .radius(25)
+            Tag {}.radius(25)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2657,9 +2485,7 @@ final class AttributesTests: XCTestCase {
     func testPositionPointAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .positionPoint((10,10))
+            Tag {}.positionPoint((10,10))
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2672,9 +2498,7 @@ final class AttributesTests: XCTestCase {
     func testRadiusPointAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .radiusPoint((10,10))
+            Tag {}.radiusPoint((10,10))
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2687,9 +2511,7 @@ final class AttributesTests: XCTestCase {
     func testCenterPointAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .centerPoint((10,10))
+            Tag {}.centerPoint((10,10))
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2702,9 +2524,7 @@ final class AttributesTests: XCTestCase {
     func testViewBoxAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .viewBox("0 0 100 100")
+            Tag {}.viewBox("0 0 100 100")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2717,9 +2537,7 @@ final class AttributesTests: XCTestCase {
     func testNamespaceAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .namespace("http://www.w3.org/2000/svg")
+            Tag {}.namespace("http://www.w3.org/2000/svg")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2732,9 +2550,7 @@ final class AttributesTests: XCTestCase {
     func testPointsAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .points("50,0 21,90 98,35 2,35 79,90")
+            Tag {}.points("50,0 21,90 98,35 2,35 79,90")
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -2747,9 +2563,7 @@ final class AttributesTests: XCTestCase {
     func testShadowRootModeAttribute() throws {
         
         let view = TestView {
-            Tag {
-            }
-            .shadowRootMode(.open)
+            Tag {}.shadowRootMode(.open)
         }
         
         XCTAssertEqual(try renderer.render(view: view),

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -463,6 +463,10 @@ final class AttributesTests: XCTestCase {
             return self.mutate(source: value)
         }
         
+        public func source(_ value: EnvironmentValue) -> Tag {
+            return mutate(source: value)
+        }
+        
         func start(_ size: Int) -> Tag {
             return self.mutate(start: size)
         }

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -10,7 +10,8 @@ final class EnvironmentTests: XCTestCase {
     
     struct Object: Encodable {
         
-        var content: String = "GlobalObject"
+        var content: String = "Welcome to WWDC 2023!"
+        var image: String = "wwdc.jpeg"
     }
     
     struct ParentView: View {
@@ -31,11 +32,14 @@ final class EnvironmentTests: XCTestCase {
     
     struct ChildView: View {
         
-        @EnvironmentObject(Object.self) var object
+        @EnvironmentObject(Object.self)
+        var object
         
         var body: Content {
             ParentView {
                 Section{
+                    Image()
+                        .source(object.image)
                     Heading2 {
                         object.content
                     }
@@ -52,7 +56,8 @@ final class EnvironmentTests: XCTestCase {
                        """
                        <div>\
                        <section>\
-                       <h2>GlobalObject</h2>\
+                       <img src="wwdc.jpeg">\
+                       <h2>Welcome to WWDC 2023!</h2>\
                        </section>\
                        </div>
                        """

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -10,7 +10,8 @@ final class EnvironmentTests: XCTestCase {
     
     struct Object: Encodable {
         
-        var content: String = "Welcome to WWDC 2023!"
+        var title: String = "Welcome to WWDC"
+        var name: String = "Mattes!"
         var image: String = "wwdc.jpeg"
     }
     
@@ -41,7 +42,7 @@ final class EnvironmentTests: XCTestCase {
                     Image()
                         .source(object.image)
                     Heading2 {
-                        object.content
+                        object.title + " " + object.name
                     }
                 }
             }
@@ -57,7 +58,7 @@ final class EnvironmentTests: XCTestCase {
                        <div>\
                        <section>\
                        <img src="wwdc.jpeg">\
-                       <h2>Welcome to WWDC 2023!</h2>\
+                       <h2>Welcome to WWDC Mattes!</h2>\
                        </section>\
                        </div>
                        """


### PR DESCRIPTION
This merge tackles the latest ideas and issues (#134, #138).

### Conditional Attributes

In the past you had to use the modify method to alter an attribute for an element based on a condition.

```swift
Input()
    .modify(if: true) {
       $0.checked()
    }
```

Now you can use the condition on the attribute with the same result.

```swift
Input()
   .checked(true)
```

Keep in mind not every attribute has a conditional option for now. I have added it to attributes, where I think it makes  the most sense. If you find an attribute in the future, where you think it makes sense, let me know. 

The modify method still exists. I am thinking about to remove it as we can use an `if let` to unwrap an optional too, but thats a topic for a different time.

### Environment value

You can now pass an environment value to an attribute. Currently it is only available for the source attribute. The same applies here as for the conditional attributes, I am not sure for what attribute it makes sense or not.

```swift
@EnvironmentObject(Asset.self)
asset

Figure {
    Image()
        .source(asset.path) /// was not possible before
    FigureCaption {
       asset.caption /// was possible before
    }
}
```
