### PR TITLE
Result builder fixes

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -711,7 +711,7 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
 /// ```html
 /// <link>
 /// ```
-public struct Link: EmptyNode, HeadElement {
+public struct Link: EmptyNode, HeadElement, BodyElement {
 
     internal var name: String { "link" }
 

--- a/Sources/HTMLKit/Framework/Builders/ContentBuilder.swift
+++ b/Sources/HTMLKit/Framework/Builders/ContentBuilder.swift
@@ -3,56 +3,46 @@
 
 /// The builder builds up a result value from a sequence of elements.
 @resultBuilder public enum ContentBuilder<T> {
+    
     public typealias Component = [T]
+    
     public typealias Expression = T
 
+    /// Builds an empty block
+    ///
+    /// ```swift
+    /// Tag {
+    /// }
+    /// ```
     public static func buildBlock() -> Component {
         return []
     }
-
-    public static func buildExpression( _ statement: Void) -> Component {
-        return []
-    }
-
-    public static func buildExpression(_ element: Expression?) -> Component {
-        guard let element else {
-            return []
-        }
-        return [element]
-    }
-
-    public static func buildExpression( _ statement: Component) -> Component {
-        return statement
-    }
-
-    public static func buildOptional(_ component: Component?) -> Component {
-        component ?? []
-    }
-
-    public static func buildEither(first component: Component) -> Component {
-        return component
-    }
-
-    public static func buildEither(second component: Component) -> Component {
-        return component
-    }
-
-    public static func buildArray(_ components: [Component]) -> Component {
-        return components.flatMap { $0 }
-    }
-
+    
+    /// Builds a block with more than one element.
+    ///
+    /// ```swift
+    /// Tag {
+    ///    Tag {
+    ///    }
+    ///    Tag {
+    ///    }
+    /// }
+    /// ```
     public static func buildBlock(_ components: Component...) -> Component {
         return components.flatMap { $0 }
     }
-
+    
+    /// Builds a block
     public static func buildPartialBlock(first: Component) -> Component {
         return first
     }
 
+    /// Builds a block
     public static func buildPartialBlock(first: [Component]) -> Component {
         return first.flatMap { $0 }
     }
 
+    /// Builds a block
     public static func buildPartialBlock(accumulated: Component, next: Expression?) -> Component {
         guard let next else {
             return accumulated
@@ -60,11 +50,93 @@
         return accumulated + [next]
     }
 
+    /// Builds a block
     public static func buildPartialBlock(accumulated: Component, next: Component) -> Component {
         return accumulated + next
     }
 
+    /// Builds a block
     public static func buildPartialBlock(accumulated: Component, next: [Component]) -> Component {
         return accumulated + next.flatMap { $0 }
+    }
+
+    /// Builds a block
+    public static func buildExpression(_ element: Expression?) -> Component {
+        guard let element else {
+            return []
+        }
+        return [element]
+    }
+    
+    /// Builds a block
+    public static func buildExpression(_ statement: Void) -> Component {
+        return []
+    }
+
+    /// Builds a block
+    public static func buildExpression(_ statement: Component) -> Component {
+        return statement
+    }
+
+    /// Builds a block with one element.
+    ///
+    /// ```swift
+    /// Tag {
+    ///    if let unwrapped = optional {
+    ///       Tag {
+    ///          unwrapped
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    public static func buildOptional(_ component: Component?) -> Component {
+        component ?? []
+    }
+
+    /// Builds a block, if the condition is true.
+    ///
+    /// ```swift
+    /// Tag {
+    ///    if(true) {
+    ///       Tag {
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    public static func buildEither(first component: Component) -> Component {
+        return component
+    }
+
+    /// Builds a block, if the condition is false.
+    ///
+    /// ```swift
+    /// Tag {
+    ///    if(false) {
+    ///       Tag {
+    ///       }
+    ///    }
+    ///    else {
+    ///       Tag {
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    public static func buildEither(second component: Component) -> Component {
+        return component
+    }
+
+    /// Builds blocks by running through a sequence of elements.
+    ///
+    /// ```swift
+    /// Tag {
+    ///    for element in sequence {
+    ///       Tag {
+    ///          element
+    ///       }
+    ///    }
+    /// }
+    /// ```
+    public static func buildArray(_ components: [Component]) -> Component {
+        return components.flatMap { $0 }
     }
 }

--- a/Sources/HTMLKit/Framework/Builders/ContentBuilder.swift
+++ b/Sources/HTMLKit/Framework/Builders/ContentBuilder.swift
@@ -18,6 +18,18 @@
         return []
     }
     
+    /// Builds a block with one element.
+    ///
+    /// ```swift
+    /// Tag {
+    ///    Tag {
+    ///    }
+    /// }
+    /// ```
+    public static func buildPartialBlock(first: Component) -> Component {
+        return first
+    }
+
     /// Builds a block with more than one element.
     ///
     /// ```swift
@@ -28,40 +40,21 @@
     ///    }
     /// }
     /// ```
-    public static func buildBlock(_ components: Component...) -> Component {
-        return components.flatMap { $0 }
-    }
-    
-    /// Builds a block
-    public static func buildPartialBlock(first: Component) -> Component {
-        return first
-    }
-
-    /// Builds a block
-    public static func buildPartialBlock(first: [Component]) -> Component {
-        return first.flatMap { $0 }
-    }
-
-    /// Builds a block
-    public static func buildPartialBlock(accumulated: Component, next: Expression?) -> Component {
-        guard let next else {
-            return accumulated
-        }
-        return accumulated + [next]
-    }
-
-    /// Builds a block
     public static func buildPartialBlock(accumulated: Component, next: Component) -> Component {
         return accumulated + next
     }
 
     /// Builds a block
-    public static func buildPartialBlock(accumulated: Component, next: [Component]) -> Component {
-        return accumulated + next.flatMap { $0 }
-    }
-
-    /// Builds a block
+    ///
+    /// ```swift
+    /// let content = "Content"
+    ///
+    /// Tag {
+    ///    content
+    /// }
+    /// ```
     public static func buildExpression(_ element: Expression?) -> Component {
+        
         guard let element else {
             return []
         }
@@ -69,13 +62,16 @@
     }
     
     /// Builds a block
-    public static func buildExpression(_ statement: Void) -> Component {
-        return []
-    }
-
-    /// Builds a block
-    public static func buildExpression(_ statement: Component) -> Component {
-        return statement
+    ///
+    /// ```swift
+    /// let content: [Type]
+    ///
+    /// Tag {
+    ///    content
+    /// }
+    /// ```
+    public static func buildExpression(_ element: Component) -> Component {
+        return element
     }
 
     /// Builds a block with one element.
@@ -90,7 +86,11 @@
     /// }
     /// ```
     public static func buildOptional(_ component: Component?) -> Component {
-        component ?? []
+
+        guard let component else {
+            return []
+        }
+        return component
     }
 
     /// Builds a block, if the condition is true.
@@ -103,8 +103,8 @@
     ///    }
     /// }
     /// ```
-    public static func buildEither(first component: Component) -> Component {
-        return component
+    public static func buildEither(first: Component) -> Component {
+        return first
     }
 
     /// Builds a block, if the condition is false.
@@ -121,8 +121,8 @@
     ///    }
     /// }
     /// ```
-    public static func buildEither(second component: Component) -> Component {
-        return component
+    public static func buildEither(second: Component) -> Component {
+        return second
     }
 
     /// Builds blocks by running through a sequence of elements.

--- a/Sources/HTMLKit/Framework/Builders/ContentBuilder.swift
+++ b/Sources/HTMLKit/Framework/Builders/ContentBuilder.swift
@@ -1,124 +1,70 @@
-/*
- Abstract:
- The file contains the builder to build up the result from a sequence of elements.
- */
+// Abstract:
+// The file contains the builder to build up the result from a sequence of elements.
 
 /// The builder builds up a result value from a sequence of elements.
-@resultBuilder public class ContentBuilder<T> {
-    
-    /// Builds an empty block
-    ///
-    /// ```swift
-    /// Tag {
-    /// }
-    /// ```
-    public static func buildBlock() -> [T] {
+@resultBuilder public enum ContentBuilder<T> {
+    public typealias Component = [T]
+    public typealias Expression = T
+
+    public static func buildBlock() -> Component {
         return []
     }
-    
-    /// Builds a block with one element.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    Tag {
-    ///    }
-    /// }
-    /// ```
-    public static func buildBlock(_ component: T) -> [T] {
-        return [component]
+
+    public static func buildExpression( _ statement: Void) -> Component {
+        return []
     }
 
-    /// Builds a block with more than one element.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    Tag {
-    ///    }
-    ///    Tag {
-    ///    }
-    /// }
-    /// ```
-    public static func buildBlock(_ components: T...) -> [T] {
-        return components.compactMap { $0 }
-    }
-    
-    /// Builds a block with one element.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    if let unwrapped = optional {
-    ///       Tag {
-    ///          unwrapped
-    ///       }
-    ///    }
-    /// }
-    /// ```
-    public static func buildOptional(_ component: T?) -> [T] {
-        
-        if let component = component {
-            return [component]
+    public static func buildExpression(_ element: Expression?) -> Component {
+        guard let element else {
+            return []
         }
-        
-        return []
+        return [element]
     }
 
-    /// Builds a block, if the condition is true.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    if(true) {
-    ///       Tag {
-    ///       }
-    ///    }
-    /// }
-    /// ```
-    public static func buildEither(first component: T) -> [T] {
-        return [component]
+    public static func buildExpression( _ statement: Component) -> Component {
+        return statement
     }
 
-    /// Builds a block, if the condition is false.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    if(false) {
-    ///       Tag {
-    ///       }
-    ///    }
-    ///    else {
-    ///       Tag {
-    ///       }
-    ///    }
-    /// }
-    /// ```
-    public static func buildEither(second component: T) -> [T] {
-        return [component]
+    public static func buildOptional(_ component: Component?) -> Component {
+        component ?? []
     }
-    
-    /// Builds blocks by running through a sequence of elements.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    for element in sequence {
-    ///       Tag {
-    ///          element
-    ///       }
-    ///    }
-    /// }
-    /// ```
-    public static func buildArray(_ components: [[T]]) -> [T] {
+
+    public static func buildEither(first component: Component) -> Component {
+        return component
+    }
+
+    public static func buildEither(second component: Component) -> Component {
+        return component
+    }
+
+    public static func buildArray(_ components: [Component]) -> Component {
         return components.flatMap { $0 }
     }
-    
-    /// Builds a block with embeded content.
-    ///
-    /// ```swift
-    /// Tag {
-    ///    content
-    ///    Tag {
-    ///    }
-    /// }
-    /// ```
-    public static func buildBlock(_ content: [T], _ components: T...) -> [T] {
-        return content + components.compactMap { $0 }
+
+    public static func buildBlock(_ components: Component...) -> Component {
+        return components.flatMap { $0 }
+    }
+
+    public static func buildPartialBlock(first: Component) -> Component {
+        return first
+    }
+
+    public static func buildPartialBlock(first: [Component]) -> Component {
+        return first.flatMap { $0 }
+    }
+
+    public static func buildPartialBlock(accumulated: Component, next: Expression?) -> Component {
+        guard let next else {
+            return accumulated
+        }
+        return accumulated + [next]
+    }
+
+    public static func buildPartialBlock(accumulated: Component, next: Component) -> Component {
+        return accumulated + next
+    }
+
+    public static func buildPartialBlock(accumulated: Component, next: [Component]) -> Component {
+        return accumulated + next.flatMap { $0 }
     }
 }

--- a/Tests/HTMLKitTests/StatementTests.swift
+++ b/Tests/HTMLKitTests/StatementTests.swift
@@ -96,4 +96,71 @@ final class StatementTests: XCTestCase {
                        """
         )
     }
+    
+    func testOptionalBeforeElement() throws {
+        
+        let name: String? = "Tony"
+        
+        let view = TestView {
+            if let name = name {
+                Paragraph {
+                    name
+                }
+            }
+            Division {
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <p>Tony</p>\
+                       <div></div>
+                       """
+        )
+    }
+    
+    func testOptionalAfterElement() throws {
+        
+        let name: String? = "Tony"
+        
+        let view = TestView {
+            Division {
+            }
+            if let name = name {
+                Paragraph {
+                    name
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <div></div>\
+                       <p>Tony</p>
+                       """
+        )
+    }
+    
+    func testOptionalWithExpectedResult() throws {
+        
+        let name: String? = "Tony"
+        
+        let view = TestView {
+            Body {
+                if let name = name {
+                    Paragraph {
+                        name
+                    }
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <body>\
+                       <p>Tony</p>\
+                       </body>
+                       """
+        )
+    }
 }


### PR DESCRIPTION
This PR proposes to update the ContentBuilder to support partial blocks. This seems to resolve the issues that I was seeing with #132, and potentially other unexpectedly invalid content combinations.

Sorry for the lack of comment documentation on these revised methods. 

I've also included conformance of the `Link` type to `BodyElement` as it's valid HTML.