### PR TITLE
Harden the HTML output

### DIFF
--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -39,26 +39,34 @@ public class Renderer {
         }
     }
     
-    private var safemode: Bool
-    
     private var environment: Environment
     
     private var localization: Localization?
+    
+    private var security: Security
 
     /// Initiates the renderer.
-    public init(localization: Localization? = nil, mode: Bool = true) {
+    public init(localization: Localization? = nil) {
         
-        self.environment = Environment()
         self.localization = localization
-        self.safemode = mode
+        self.environment = Environment()
+        self.security = Security()
     }
     
     /// Initiates the renderer.
-    public init(localization: Localization? = nil, environment: Environment, mode: Bool = true) {
+    public init(localization: Localization? = nil, security: Security) {
         
-        self.environment = environment
         self.localization = localization
-        self.safemode = mode
+        self.environment = Environment()
+        self.security = security
+    }
+    
+    /// Initiates the renderer.
+    public init(localization: Localization? = nil, environment: Environment, security: Security) {
+        
+        self.localization = localization
+        self.environment = environment
+        self.security = security
     }
     
     /// Renders a view
@@ -415,8 +423,7 @@ public class Renderer {
     /// Converts specific charaters into encoded values.
     internal func escape(attribute value: String) -> String {
         
-        if safemode {
-            
+        if security.autoEscaping {
             return value.replacingOccurrences(of: "&", with: "&amp;")
                 .replacingOccurrences(of: "\"", with: "&quot;")
                 .replacingOccurrences(of: "'", with: "&apos;")
@@ -428,7 +435,7 @@ public class Renderer {
     /// Converts specific charaters into encoded values.
     internal func escape(content value: String) -> String {
         
-        if safemode {
+        if security.autoEscaping {
             return value.replacingOccurrences(of: "<", with: "&lt;")
                 .replacingOccurrences(of: ">", with: "&gt;")
         }

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -116,7 +116,7 @@ public class Renderer {
             }
             
             if let element = content as? String {
-                result += element
+                result += escape(element)
             }
         }
         
@@ -181,7 +181,7 @@ public class Renderer {
                 }
                 
                 if let element = content as? String {
-                    result += element
+                    result += escape(element)
                 }
             }
         }
@@ -267,7 +267,7 @@ public class Renderer {
                 }
                 
                 if let element = content as? String {
-                    result += element
+                    result += escape(element)
                 }
             }
         }
@@ -348,7 +348,7 @@ public class Renderer {
             return String(doubleValue)
             
         case let stringValue as String:
-            return String(stringValue)
+            return escape(stringValue)
             
         case let dateValue as Date:
             
@@ -382,5 +382,15 @@ public class Renderer {
         }
         
         return result
+    }
+    
+    /// Converts specific charaters into encoded values.
+    internal func escape(_ value: String) -> String {
+        
+        return value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
     }
 }

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -374,11 +374,13 @@ public class Renderer {
             result += " \(attribute.key)=\""
             
             if let value = attribute.value as? EnvironmentValue {
-                result += "\(try render(value: value))\""
+                result += try render(value: value)
                 
             } else {
-                result += "\(attribute.value)\""
+                result += escape("\(attribute.value)")
             }
+            
+            result += "\""
         }
         
         return result

--- a/Sources/HTMLKit/Framework/Security/Security.swift
+++ b/Sources/HTMLKit/Framework/Security/Security.swift
@@ -1,0 +1,9 @@
+public class Security {
+    
+    public var autoEscaping: Bool
+    
+    public init() {
+        
+        self.autoEscaping = true
+    }
+}

--- a/Sources/HTMLKitComponents/Actions/SubmitAction.swift
+++ b/Sources/HTMLKitComponents/Actions/SubmitAction.swift
@@ -13,10 +13,10 @@ extension SubmitAction {
         if let data = try? JSONEncoder().encode(validators) {
             
             if let result = String(data: data, encoding: .utf8) {
-                return "$('#\(target)').validate('\(result)');"
+                return "$('#\(target.escape())').validate('\(result)');"
             }
         }
         
-        return "$('#\(target)').validate('[]');"
+        return "$('#\(target.escape())').validate('[]');"
     }
 }

--- a/Sources/HTMLKitComponents/Actions/ViewAction.swift
+++ b/Sources/HTMLKitComponents/Actions/ViewAction.swift
@@ -21,22 +21,22 @@ public protocol ViewAction {
 extension ViewAction {
     
     public func show(_ target: String) -> String {
-        return "$('#\(target)').show();"
+        return "$('#\(target.escape())').show();"
     }
     
     public func hide(_ target: String) -> String {
-        return "$('#\(target)').hide();"
+        return "$('#\(target.escape())').hide();"
     }
     
     public func animate(_ target: String) -> String {
-        return "$('#\(target)').animate();"
+        return "$('#\(target.escape())').animate();"
     }
     
     public func open(_ target: String) -> String {
-        return "$('#\(target)').open();"
+        return "$('#\(target.escape())').open();"
     }
     
     public func close(_ target: String) -> String {
-        return "$('#\(target)').close();"
+        return "$('#\(target.escape())').close();"
     }
 }

--- a/Sources/HTMLKitComponents/Extensions/Components+String.swift
+++ b/Sources/HTMLKitComponents/Extensions/Components+String.swift
@@ -1,0 +1,11 @@
+extension String {
+    
+    internal func escape() -> String {
+        
+        return self.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+}

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -26,6 +26,24 @@ extension Application {
             public typealias Value = HTMLKit.Environment
         }
         
+        internal struct SecurityStorageKey: StorageKey {
+            
+            public typealias Value = HTMLKit.Security
+        }
+        
+        public var security: HTMLKit.Security {
+            
+            if let configuration = self.application.storage[SecurityStorageKey.self] {
+                return configuration
+            }
+            
+            let configuration = Security()
+            
+            self.application.storage[SecurityStorageKey.self] = configuration
+            
+            return configuration
+        }
+        
         /// The view localization
         public var localization: HTMLKit.Localization {
             
@@ -59,7 +77,8 @@ extension Application {
             
             return .init(eventLoop: application.eventLoopGroup.next(),
                          localization: localization,
-                         environment: environment)
+                         environment: environment,
+                         security: security)
         }
         
         /// The application dependency
@@ -94,6 +113,7 @@ extension Request {
         
         return .init(eventLoop: self.eventLoop,
                      localization: self.application.htmlkit.localization,
-                     environment: self.application.htmlkit.environment)
+                     environment: self.application.htmlkit.environment,
+                     security: self.application.htmlkit.security)
     }
 }

--- a/Sources/HTMLKitVapor/ViewRenderer.swift
+++ b/Sources/HTMLKitVapor/ViewRenderer.swift
@@ -16,10 +16,10 @@ public class ViewRenderer {
     internal var renderer: Renderer
     
     /// Creates the view renderer
-    public init(eventLoop: EventLoop, localization: HTMLKit.Localization, environment: HTMLKit.Environment) {
+    public init(eventLoop: EventLoop, localization: Localization, environment: HTMLKit.Environment, security: Security) {
         
         self.eventLoop = eventLoop
-        self.renderer = Renderer(localization: localization, environment: environment)
+        self.renderer = Renderer(localization: localization, environment: environment, security: security)
     }
     
     /// Renders a layout and its context

--- a/Tests/HTMLKitComponentsTests/SecurityTests.swift
+++ b/Tests/HTMLKitComponentsTests/SecurityTests.swift
@@ -1,0 +1,77 @@
+import HTMLKit
+import HTMLKitComponents
+import XCTest
+
+final class SecurityTests: XCTestCase {
+    
+    struct TestView: View {
+        
+        @ContentBuilder<Content> var body: Content
+    }
+    
+    var renderer = Renderer()
+    
+    func testEncodingAttributeContext() throws {
+        
+        let attack = "\" onclick=\"alert(1);\""
+        
+        let view = TestView {
+            Button(role: .button) {
+                "Show"
+            }
+            .tag(attack)
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <button type="button" class="button" id="&quot; onclick=&quot;alert(1);&quot;">Show</button>
+                       """
+        )
+    }
+    
+    func testEncodingActionContext() throws {
+        
+        let attack = "test').appendTo(''); $('#test"
+        
+        let view = TestView {
+            Button(role: .button) {
+                "Show"
+            }
+            .tag("sender")
+            .onClick { button in
+                button.show(attack)
+            }
+            
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <button type="button" class="button" id="sender">Show</button>\
+                       <script>\
+                       $('#sender').onClick(function(){\
+                       $('#test&apos;).appendTo(&apos;&apos;); $(&apos;#test').show();\
+                       });\
+                       </script>
+                       """
+        )
+    }
+    
+    func testEncodingCssContext() throws {
+        
+        let attack = "test\" style=\"property: unsafe\""
+        
+        let view = TestView {
+            Text {
+                "Text"
+            }
+            .backgroundColor(.custom(attack))
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <p class="text background:test&quot; style=&quot;property: unsafe&quot;">Text</p>
+                       """
+        )
+    }
+}
+

--- a/Tests/HTMLKitTests/PerformanceTests.swift
+++ b/Tests/HTMLKitTests/PerformanceTests.swift
@@ -7,12 +7,26 @@ import HTMLKit
 import XCTest
 
 final class PerformanceTests: XCTestCase {
-
-    var renderer = Renderer()
     
-    func testPerformance() throws {
+    func testPerformanceWithoutSafeMode() throws {
         
         let context = SampleContext(id: 0, title: "TestPage", excerpt: "Testpage", modified: Date(), posted: Date())
+        
+        let renderer = Renderer(mode: false)
+        
+        measure {
+            
+            for _ in 0...1000 {
+                _ = try! renderer.render(view: SampleView(context: context))
+            }
+        }
+    }
+    
+    func testPerformanceWithSafeMode() throws {
+        
+        let context = SampleContext(id: 0, title: "TestPage", excerpt: "Testpage", modified: Date(), posted: Date())
+        
+        let renderer = Renderer(mode: true)
         
         measure {
             

--- a/Tests/HTMLKitTests/PerformanceTests.swift
+++ b/Tests/HTMLKitTests/PerformanceTests.swift
@@ -8,11 +8,14 @@ import XCTest
 
 final class PerformanceTests: XCTestCase {
     
-    func testPerformanceWithoutSafeMode() throws {
+    func testPerformanceWithoutAutoEscaping() throws {
         
         let context = SampleContext(id: 0, title: "TestPage", excerpt: "Testpage", modified: Date(), posted: Date())
         
-        let renderer = Renderer(mode: false)
+        let security = Security()
+        security.autoEscaping = false
+        
+        let renderer = Renderer(security: security)
         
         measure {
             
@@ -22,11 +25,14 @@ final class PerformanceTests: XCTestCase {
         }
     }
     
-    func testPerformanceWithSafeMode() throws {
+    func testPerformanceWithAutoEscaping() throws {
         
         let context = SampleContext(id: 0, title: "TestPage", excerpt: "Testpage", modified: Date(), posted: Date())
         
-        let renderer = Renderer(mode: true)
+        let security = Security()
+        security.autoEscaping = true
+        
+        let renderer = Renderer(security: security)
         
         measure {
             

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -154,22 +154,6 @@ final class RenderingTests: XCTestCase {
         )
     }
     
-    func testEscaping() throws {
-        
-        let view = TestView {
-            Paragraph {
-                "text"
-            }
-            .class("cl'ass")
-        }
-        
-        XCTAssertEqual(try renderer.render(view: view),
-                       """
-                       <p class="cl'ass">text</p>
-                       """
-        )
-    }
-    
     func testModified() throws {
         
         let isModified: Bool = true

--- a/Tests/HTMLKitTests/SecurityTests.swift
+++ b/Tests/HTMLKitTests/SecurityTests.swift
@@ -15,6 +15,23 @@ final class SecurityTests: XCTestCase {
     
     var renderer = Renderer()
     
+    func testEncodingAttributeContext() throws {
+        
+        let variable = "\" onclick=\"alert(1);\""
+        
+        let view = TestView {
+            Paragraph {
+            }
+            .class(variable)
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <p class="&quot; onclick=&quot;alert(1);&quot;"></p>
+                       """
+        )
+    }
+    
     func testEncodingHtmlContext() throws {
         
         let variable = "<script></script>"

--- a/Tests/HTMLKitTests/SecurityTests.swift
+++ b/Tests/HTMLKitTests/SecurityTests.swift
@@ -1,0 +1,60 @@
+/*
+ Abstract:
+ The file tests the rendering of the elements.
+ */
+
+import HTMLKit
+import XCTest
+
+final class SecurityTests: XCTestCase {
+    
+    struct TestView: View {
+        
+        @ContentBuilder<Content> var body: Content
+    }
+    
+    var renderer = Renderer()
+    
+    func testEncodingHtmlContext() throws {
+        
+        let variable = "<script></script>"
+        
+        let view = TestView {
+            Paragraph {
+                variable
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <p>&lt;script&gt;&lt;/script&gt;</p>
+                       """
+        )
+    }
+    
+    func testEncodingEnvironmentValue() throws {
+        
+        struct Variable {
+            let value = "<script></script>"
+        }
+        
+        @EnvironmentObject(Variable.self)
+        var variable
+        
+        let view = TestView {
+            Article {
+                Paragraph {
+                    variable.value
+                }
+            }
+            .environment(object: Variable())
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <article><p>&lt;script&gt;&lt;/script&gt;</p></article>
+                       """
+        )
+    }
+}
+


### PR DESCRIPTION
At the moment HTMLKit is vulnerable to arbitrary code insertions. This PR introduces auto escaping of string variables to mitigate (stored) cross site scripting. That said, this behavior will be on by default in the future.

But if you don't want to use the auto escape for any reasons, you can disabled it with the option:

```swift
app.htmlkit.security.autoEscaping = false
```