### PR TITLE
Make localization error handling less strict

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,13 +24,15 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.65.2")
     ],
     targets: [
         .target(
             name: "HTMLKit",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections")
+                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "Logging", package: "swift-log"),
             ],
             exclude: ["Abstraction/README.md", "Framework/README.md"]
         ),

--- a/Sources/HTMLKit/Framework/Localization/Locale.swift
+++ b/Sources/HTMLKit/Framework/Localization/Locale.swift
@@ -4,7 +4,7 @@
 @_documentation(visibility: internal)
 public struct Locale: Hashable {
     
-    /// A enumeration of possible tags
+    /// A enumeration of potential language tags
     public enum Tag: String {
         
         case arabic = "ar"
@@ -47,12 +47,16 @@ public struct Locale: Hashable {
         case chinese = "zh"
     }
     
-    /// The language code
+    /// The language code of the language
+    ///
+    /// The language code represents the generic language.
     public var language: String? {
         return tag.components(separatedBy: "-").first
     }
     
-    /// The region code
+    /// The region code of the language
+    ///
+    /// The region code refers to the regional dialect of a language.
     public var region: String? {
         
         let components = tag.components(separatedBy: "-")
@@ -64,27 +68,27 @@ public struct Locale: Hashable {
         return nil
     }
     
-    /// The currency code
+    /// The currency code of the language
     public var currencyCode: String? {
         return currencyCodes[tag]
     }
     
-    /// The currency symbol
+    /// The currency symbol of the language
     public var currencySymbol: String? {
         return currencySymbols[tag]
     }
     
-    /// The decimal seperator
+    /// The decimal seperator of the language
     public var decimalSeparator: String? {
         return decimalSeparators[tag]
     }
     
-    /// The date format
+    /// The date format of the language
     public var dateFormat: String? {
         return dateFormats[tag]
     }
     
-    /// The time format
+    /// The time format of the language
     public var timeFormat: String? {
         return timeFormats[tag]
     }
@@ -92,14 +96,14 @@ public struct Locale: Hashable {
     /// The locale identifier
     public let tag: String
     
-    /// Initialize a locale
+    /// Initializes a locale
     ///
     /// - Parameter tag: A locale tag e.g. en-US
     public init(tag: String) {
         self.tag = tag
     }
     
-    /// Initialize a locale with a predefined tag
+    /// Initializes a locale with a predefined tag
     ///
     /// - Parameter tag: A locale tag e.g. en-US
     public init(tag: Tag) {

--- a/Sources/HTMLKit/Framework/Localization/Locale.swift
+++ b/Sources/HTMLKit/Framework/Localization/Locale.swift
@@ -1,4 +1,6 @@
 /// A type that represents a locale
+///
+/// A locale holds information about language, region and cultural preferences.
 @_documentation(visibility: internal)
 public struct Locale: Hashable {
     
@@ -90,12 +92,16 @@ public struct Locale: Hashable {
     /// The locale identifier
     public let tag: String
     
-    /// Initiates a locale
+    /// Initialize a locale
+    ///
+    /// - Parameter tag: A locale tag e.g. en-US
     public init(tag: String) {
         self.tag = tag
     }
     
-    /// Initiates a locale with a predefined tag
+    /// Initialize a locale with a predefined tag
+    ///
+    /// - Parameter tag: A locale tag e.g. en-US
     public init(tag: Tag) {
         self.tag = tag.rawValue
     }

--- a/Sources/HTMLKit/Framework/Localization/Localizable.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localizable.swift
@@ -1,11 +1,12 @@
-/*
- Abstract:
- The file contains the default definition of a localizable element. It defines which properties and methods a content should come with.
- */
-
-/// A protocol that defines a type capable of being localized.
+/// A protocol that defines a type capable of being localized
 @_documentation(visibility: internal)
 public protocol Localizable {
     
+    /// Initializes a phrasing element intended for localization
+    ///
+    /// - Parameters:
+    ///   - localizedKey: The string key to be translated
+    ///   - tableName: The name of the translation table
+    ///   - interpolation: A variadic list of values used to replace placeholders within the translation string
     init(_ localizedKey: String, tableName: String?, interpolation: Any...)
 }

--- a/Sources/HTMLKit/Framework/Localization/Localizable.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localizable.swift
@@ -3,7 +3,7 @@
  The file contains the default definition of a localizable element. It defines which properties and methods a content should come with.
  */
 
-/// The protocol defines
+/// A protocol that defines a type capable of being localized.
 @_documentation(visibility: internal)
 public protocol Localizable {
     

--- a/Sources/HTMLKit/Framework/Localization/Localization.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localization.swift
@@ -5,29 +5,29 @@ import Foundation
 public class Localization {
     
     /// A enumeration of various errors
-    public enum Errors: Error {
+    public enum Errors: Error, Equatable {
         
-        case missingKey
-        case missingTable
+        case missingKey(String)
+        case missingTable(String)
         case missingTables
-        case unkownTable
+        case unknownTable(String)
         case noFallback
         case loadingDataFailed
         
         public var description: String {
             
             switch self {
-            case .missingKey:
-                return "Unable to find a translation for the key."
+            case .missingKey(let key):
+                return "Unable to find translation key '\(key)'."
                 
-            case .missingTable:
-                return "Unable to find a translation table for the locale."
+            case .missingTable(let tag):
+                return "Unable to find a translation table for the locale '\(tag)'."
                 
             case .missingTables:
                 return "Unable to find any localization tables."
                 
-            case .unkownTable:
-                return "Unkown table name."
+            case .unknownTable(let table):
+                return "Unable to find translation table '\(table)'."
                 
             case .noFallback:
                 return "The fallback needs to be set up first."
@@ -170,10 +170,10 @@ public class Localization {
             }
             
         } else {
-            throw Errors.missingTable
+            throw Errors.missingTable(currentLocale.tag)
         }
         
-        throw Errors.missingKey
+        throw Errors.missingKey(key)
     }
     
     /// Retrieves a value for a specific key from a specific table
@@ -238,16 +238,16 @@ public class Localization {
                         return translation
                         
                     } else {
-                        throw Errors.missingKey
+                        throw Errors.missingKey(key)
                     }
                 }
             }
             
         } else {
-            throw Errors.missingTable
+            throw Errors.missingTable(currentLocale.tag)
         }
         
-        throw Errors.unkownTable
+        throw Errors.unknownTable(table)
     }
 }
 

--- a/Sources/HTMLKit/Framework/Localization/Localization.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localization.swift
@@ -10,7 +10,7 @@ public class Localization {
         /// Indicates a missing key
         ///
         /// A key is considered as missing if it cannot be found in the translation table.
-        case missingKey(String)
+        case missingKey(String, String)
         
         /// Indicates a missing table
         ///
@@ -23,7 +23,7 @@ public class Localization {
         /// Indicates a unknown table
         ///
         /// A table is considered as unknown if it cannot be found by the given table name.
-        case unknownTable(String)
+        case unknownTable(String, String)
         
         /// Indicates there is no fallback configuration set up.
         case noFallback
@@ -35,17 +35,17 @@ public class Localization {
         public var description: String {
             
             switch self {
-            case .missingKey(let key):
-                return "Unable to find translation key '\(key)'."
+            case .missingKey(let key, let tag):
+                return "Unable to find translation key '\(key)' for the locale '\(tag)'."
                 
             case .missingTable(let tag):
                 return "Unable to find a translation table for the locale '\(tag)'."
                 
             case .missingTables:
-                return "Unable to find any localization tables."
+                return "Unable to find any translation tables."
                 
-            case .unknownTable(let table):
-                return "Unable to find translation table '\(table)'."
+            case .unknownTable(let table, let tag):
+                return "Unable to find translation table '\(table)' for the locale '\(tag)'."
                 
             case .noFallback:
                 return "The fallback needs to be set up first."
@@ -207,11 +207,11 @@ public class Localization {
         if let table = key.table {
             
             guard let translationTable = translationTables.first(where: { $0.name == table }) else {
-                throw Errors.unknownTable(table)
+                throw Errors.unknownTable(table, currentLocale.tag)
             }
             
             guard var translation = translationTable.retrieve(for: key.key) else {
-                throw Errors.missingKey(key.key)
+                throw Errors.missingKey(key.key, currentLocale.tag)
             }
         
             if let interpolation = key.interpolation {
@@ -234,7 +234,7 @@ public class Localization {
             }
         }
         
-        throw Errors.missingKey(key.key)
+        throw Errors.missingKey(key.key, currentLocale.tag)
     }
 }
 

--- a/Sources/HTMLKit/Framework/Localization/Localization.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localization.swift
@@ -4,16 +4,34 @@ import Foundation
 @_documentation(visibility: internal)
 public class Localization {
     
-    /// A enumeration of various errors
+    /// A enumeration of errors regarding the localization rendering
     public enum Errors: Error, Equatable {
         
+        /// Indicates a missing key
+        ///
+        /// A key is considered as missing if it cannot be found in the translation table.
         case missingKey(String)
+        
+        /// Indicates a missing table
+        ///
+        /// A table is considered as missing if there is no translation table for the given locale.
         case missingTable(String)
+        
+        /// Indicates missing tables
         case missingTables
+        
+        /// Indicates a unknown table
+        ///
+        /// A table is considered as unknown if it cannot be found by the given table name.
         case unknownTable(String)
+        
+        /// Indicates there is no fallback configuration set up.
         case noFallback
+        
+        /// Indicates a loading failure
         case loadingDataFailed
         
+        /// Returns a description about the failure reason
         public var description: String {
             
             switch self {
@@ -38,34 +56,48 @@ public class Localization {
         }
     }
     
-    /// The localization tables
+    /// The translations tables
     internal var tables: [Locale: [TranslationTable]]?
     
     /// The default locale
+    ///
+    /// This locale will be used as the primary locale for translations and as the fallback locale when a translation is unavailable in other locales.
     internal var locale: Locale?
     
-    /// Initiates a localization
+    /// Initialize a localization
     public init() {
     }
     
-    /// Initiates a localization
+    /// Initialize a localization
+    ///
+    /// - Parameters:
+    ///   - source: The directory where the translations should be loaded from.
+    ///   - locale: The default locale
     public init(source: URL, locale: Locale) {
         
         self.locale = locale
         self.tables = load(source: source)
     }
     
-    /// Sets the root path
+    /// Sets the source directory
+    ///
+    /// - Parameter source: The directory where the translations should be loaded from.
     public func set(source: URL) {
         self.tables = load(source: source)
     }
     
-    /// Sets the default locale indentifier
+    /// Sets the default locale
+    ///
+    /// - Parameter locale: A locale tag e.g. en-US
     public func set(locale: String) {
         self.locale = Locale(tag: locale)
     }
     
-    /// Loads the tables from a specific path
+    /// Loads the translation tables from a given directory
+    ///
+    /// - Parameter source: The directory where the translation tables are located.
+    ///
+    /// - Returns: The translation tables mapped to their locale
     internal func load(source: URL) -> [Locale: [TranslationTable]] {
         
         var localizationTables = [Locale: [TranslationTable]]()
@@ -105,7 +137,14 @@ public class Localization {
         return localizationTables
     }
     
-    /// Retrieves a value for a specific key from the tables
+    /// Retrieves the translation for a specified key
+    ///
+    /// - Parameters:
+    ///   - key: The string key to be translated
+    ///   - locale: The locale to use when retrieving the translation
+    ///   - interpolation: An array of values used to replace placeholders within the translation string
+    ///
+    /// - Returns: The translation
     public func localize(key: String, locale: Locale? = nil, interpolation: [Any]? = nil) throws -> String {
         
         guard let fallback = self.locale else {
@@ -176,7 +215,15 @@ public class Localization {
         throw Errors.missingKey(key)
     }
     
-    /// Retrieves a value for a specific key from a specific table
+    /// Retrieves the translation for a specified key from a given translation table
+    ///
+    /// - Parameters:
+    ///   - key: The string key to be translated
+    ///   - table: The name of the translation table
+    ///   - locale: The locale to use when retrieving the translation
+    ///   - interpolation: An array of values used to replace placeholders within the translation string
+    ///
+    /// - Returns: The translation
     public func localize(key: String, table: String, locale: Locale? = nil, interpolation: [Any]? = nil) throws -> String {
         
         guard let fallback = self.locale else {

--- a/Sources/HTMLKit/Framework/Localization/Localization.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localization.swift
@@ -61,23 +61,12 @@ public class Localization {
     
     /// The default locale
     ///
-    /// This locale will be used as the primary locale for translations and as the fallback locale when a translation is unavailable in other locales.
+    /// This locale will be used as the primary locale for translations and as the fallback locale when a translation
+    /// is unavailable in other locales.
     internal var locale: Locale?
     
-    /// Initialize a localization
-    public init() {
-    }
-    
-    /// Initialize a localization
-    ///
-    /// - Parameters:
-    ///   - source: The directory where the translations should be loaded from.
-    ///   - locale: The default locale
-    public init(source: URL, locale: Locale) {
-        
-        self.locale = locale
-        self.tables = load(source: source)
-    }
+    /// Initializes a localization
+    public init() {}
     
     /// Sets the source directory
     ///
@@ -93,12 +82,23 @@ public class Localization {
         self.locale = Locale(tag: locale)
     }
     
+    /// Initializes a localization
+    ///
+    /// - Parameters:
+    ///   - source: The directory where the translations should be loaded from.
+    ///   - locale: The default locale
+    public init(source: URL, locale: Locale) {
+        
+        self.locale = locale
+        self.tables = load(source: source)
+    }
+    
     /// Loads the translation tables from a given directory
     ///
     /// - Parameter source: The directory where the translation tables are located.
     ///
     /// - Returns: The translation tables mapped to their locale
-    internal func load(source: URL) -> [Locale: [TranslationTable]] {
+    private func load(source: URL) -> [Locale: [TranslationTable]] {
         
         var localizationTables = [Locale: [TranslationTable]]()
         
@@ -143,7 +143,7 @@ public class Localization {
     ///   - arguments: An array of values used to replace placeholders within the translation string
     ///   - translation: The translation string
     ///   - locale: The locale
-    internal func interpolate(arguments: [Any], to translation: inout String, for locale: Locale) {
+    private func interpolate(arguments: [Any], to translation: inout String, for locale: Locale) {
         
         for argument in arguments {
 

--- a/Sources/HTMLKit/Framework/Localization/LocalizedStringKey.swift
+++ b/Sources/HTMLKit/Framework/Localization/LocalizedStringKey.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-/// The struct thats contains the information for the localization
+/// A type thats holds the information for the localization
 @_documentation(visibility: internal)
 public struct LocalizedStringKey: Content {
 
@@ -18,7 +18,12 @@ public struct LocalizedStringKey: Content {
     /// The interpolation for the translation string
     public var interpolation: [Any]?
     
-    /// Initiates a localized string key with a context
+    /// Initialize a localized string key with a context
+    ///
+    /// - Parameters:
+    ///   - key: The string key to be translated
+    ///   - table: The table where the string key should be looked up. Default is nil.
+    ///   - interpolation: An array of values that will replace placeholders within the translation string.
     public init(key: String, table: String? = nil, interpolation: [Any]? = nil) {
         
         self.key = key

--- a/Sources/HTMLKit/Framework/Localization/LocalizedStringKey.swift
+++ b/Sources/HTMLKit/Framework/Localization/LocalizedStringKey.swift
@@ -1,8 +1,3 @@
-/*
- Abstract:
- The file contains the localized.
- */
-
 import Foundation
 
 /// A type thats holds the information for the localization
@@ -10,15 +5,15 @@ import Foundation
 public struct LocalizedStringKey: Content {
 
     /// The key of the translation value
-    public let key: String
+    internal let key: String
     
     /// The name of the translation table
-    public let table: String?
+    internal let table: String?
     
     /// The interpolation for the translation string
-    public var interpolation: [Any]?
+    internal var interpolation: [Any]?
     
-    /// Initialize a localized string key with a context
+    /// Initializes a localized string key with a context
     ///
     /// - Parameters:
     ///   - key: The string key to be translated

--- a/Sources/HTMLKit/Framework/Localization/TranslationTable.swift
+++ b/Sources/HTMLKit/Framework/Localization/TranslationTable.swift
@@ -1,23 +1,20 @@
-import Foundation
-
 /// A type that represents a translation table
 ///
 /// A translation table stores multiple localized strings, mapping unique string keys to their corresponding translations
-@_documentation(visibility: internal)
-public class TranslationTable {
+internal struct TranslationTable {
     
     /// The name of the table
-    public let name: String
+    internal let name: String
     
     /// The translations in the table
-    private var translations: [String: String]
+    private let translations: [String: String]
     
-    /// Initialize a translation table
+    /// Initializes a translation table
     ///
     /// - Parameters:
     ///   - name: The name of the translation table
     ///   - translations: The translations
-    public init(name: String, translations: [String: String]) {
+    internal init(name: String, translations: [String: String]) {
         
         self.name = name
         self.translations = translations
@@ -26,23 +23,9 @@ public class TranslationTable {
     /// Retrieves the translation for the specified key
     ///
     /// - Parameter key: The string key
-    ///
+    /// 
     /// - Returns: The translation
-    public func retrieve(for key: String) -> String? {
-        
-        if let translation = self.translations[key] {
-            return translation
-        }
-        
-        return nil
-    }
-    
-    /// Adds or updates a translation to the translation table
-    ///
-    /// - Parameters:
-    ///   - translation: The translation
-    ///   - key: The string key to which the translation should be associated
-    public func upsert(_ translation: String, for key: String) {
-        self.translations[key] = translation
+    internal func retrieve(for key: String) -> String? {
+        return translations[key]
     }
 }

--- a/Sources/HTMLKit/Framework/Localization/TranslationTable.swift
+++ b/Sources/HTMLKit/Framework/Localization/TranslationTable.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 /// A type that represents a translation table
+///
+/// A translation table stores multiple localized strings, mapping unique string keys to their corresponding translations
 @_documentation(visibility: internal)
 public class TranslationTable {
     
@@ -10,14 +12,22 @@ public class TranslationTable {
     /// The translations in the table
     private var translations: [String: String]
     
-    /// Initiates a translation table
+    /// Initialize a translation table
+    ///
+    /// - Parameters:
+    ///   - name: The name of the translation table
+    ///   - translations: The translations
     public init(name: String, translations: [String: String]) {
         
         self.name = name
         self.translations = translations
     }
     
-    /// Retrieves a translation
+    /// Retrieves the translation for the specified key
+    ///
+    /// - Parameter key: The string key
+    ///
+    /// - Returns: The translation
     public func retrieve(for key: String) -> String? {
         
         if let translation = self.translations[key] {
@@ -27,7 +37,11 @@ public class TranslationTable {
         return nil
     }
     
-    /// Adds und updates a translation
+    /// Adds or updates a translation to the translation table
+    ///
+    /// - Parameters:
+    ///   - translation: The translation
+    ///   - key: The string key to which the translation should be associated
     public func upsert(_ translation: String, for key: String) {
         self.translations[key] = translation
     }

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -357,7 +357,22 @@ public final class Renderer {
             throw Errors.missingLocalization
         }
         
-        return try localization.localize(key: stringkey, for: environment.locale)
+        do {
+            return try localization.localize(key: stringkey, for: environment.locale)
+            
+        } catch Localization.Errors.missingKey(let key, let locale) {
+            
+            // Check if the fallback was already in charge
+            if environment.locale != nil {
+                
+                // Seems not, let's try to recover by using the fallback
+                return try localization.localize(key: stringkey)
+                
+            } else {
+                // Recovery didn't work out. Let's face the truth
+                throw Localization.Errors.missingKey(key, locale)
+            }
+        }
     }
     
     /// Renders a environment modifier.

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import OrderedCollections
+import Logging
 
 @_documentation(visibility: internal)
 public final class Renderer {
@@ -63,18 +64,23 @@ public final class Renderer {
     
     /// The feature flag used to manage the visibility of new and untested features.
     private var features: Features
+    
+    /// The logger used to log all operations
+    private var logger: Logger
 
     /// Initiates the renderer.
     public init(localization: Localization? = nil, 
                 environment: Environment = Environment(),
                 security: Security = Security(),
-                features: Features = []) {
+                features: Features = [],
+                logger: Logger = Logger(label: "HTMLKit")) {
         
         self.localization = localization
         self.environment = environment
         self.security = security
         self.markdown = Markdown()
         self.features = features
+        self.logger = logger
     }
     
     /// Renders a view and transforms it into a string representation.
@@ -364,6 +370,8 @@ public final class Renderer {
             
             // Check if the fallback was already in charge
             if environment.locale != nil {
+                
+                logger.warning("Unable to find translation key '\(key)' for the locale '\(locale)'.")
                 
                 // Seems not, let's try to recover by using the fallback
                 return try localization.localize(key: stringkey)

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -357,11 +357,7 @@ public final class Renderer {
             throw Errors.missingLocalization
         }
         
-        if let table = stringkey.table {
-            return try localization.localize(key: stringkey.key, table: table, locale: environment.locale, interpolation: stringkey.interpolation)
-        }
-        
-        return try localization.localize(key: stringkey.key, locale: environment.locale, interpolation: stringkey.interpolation)
+        return try localization.localize(key: stringkey, for: environment.locale)
     }
     
     /// Renders a environment modifier.

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -82,7 +82,7 @@ extension Application {
         /// The view renderer
         internal var renderer: ViewRenderer {
             
-            return .init(eventLoop: application.eventLoopGroup.next(), configuration: configuration)
+            return .init(eventLoop: application.eventLoopGroup.next(), configuration: configuration, logger: application.logger)
         }
         
         /// The application dependency
@@ -115,6 +115,6 @@ extension Request {
             self.application.htmlkit.localization.set(locale: acceptLanguage)
         }
         
-        return .init(eventLoop: self.eventLoop, configuration: self.application.htmlkit.configuration)
+        return .init(eventLoop: self.eventLoop, configuration: self.application.htmlkit.configuration, logger: self.logger)
     }
 }

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -118,3 +118,31 @@ extension Request {
         return .init(eventLoop: self.eventLoop, configuration: self.application.htmlkit.configuration, logger: self.logger)
     }
 }
+
+extension HTMLKit.Renderer.Errors: @retroactive AbortError {
+ 
+    @_implements(AbortError, reason)
+    public var abortReason: String { self.description }
+    
+    public var status: HTTPResponseStatus { .internalServerError }
+}
+
+extension HTMLKit.Renderer.Errors: @retroactive DebuggableError {
+
+    @_implements(DebuggableError, reason)
+    public var debuggableReason: String {  self.description }
+}
+
+extension HTMLKit.Localization.Errors: @retroactive AbortError {
+ 
+    @_implements(AbortError, reason)
+    public var abortReason: String { self.description }
+    
+    public var status: HTTPResponseStatus { .internalServerError }
+}
+
+extension HTMLKit.Localization.Errors: @retroactive DebuggableError {
+    
+    @_implements(DebuggableError, reason)
+    public var debuggableReason: String { self.description }
+}

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -119,7 +119,7 @@ extension Request {
     }
 }
 
-extension HTMLKit.Renderer.Errors: @retroactive AbortError {
+extension HTMLKit.Renderer.Errors: AbortError {
  
     @_implements(AbortError, reason)
     public var abortReason: String { self.description }
@@ -127,13 +127,13 @@ extension HTMLKit.Renderer.Errors: @retroactive AbortError {
     public var status: HTTPResponseStatus { .internalServerError }
 }
 
-extension HTMLKit.Renderer.Errors: @retroactive DebuggableError {
+extension HTMLKit.Renderer.Errors: DebuggableError {
 
     @_implements(DebuggableError, reason)
     public var debuggableReason: String {  self.description }
 }
 
-extension HTMLKit.Localization.Errors: @retroactive AbortError {
+extension HTMLKit.Localization.Errors: AbortError {
  
     @_implements(AbortError, reason)
     public var abortReason: String { self.description }
@@ -141,7 +141,7 @@ extension HTMLKit.Localization.Errors: @retroactive AbortError {
     public var status: HTTPResponseStatus { .internalServerError }
 }
 
-extension HTMLKit.Localization.Errors: @retroactive DebuggableError {
+extension HTMLKit.Localization.Errors: DebuggableError {
     
     @_implements(DebuggableError, reason)
     public var debuggableReason: String { self.description }

--- a/Sources/HTMLKitVapor/ViewRenderer.swift
+++ b/Sources/HTMLKitVapor/ViewRenderer.swift
@@ -50,17 +50,3 @@ public class ViewRenderer {
         return try await render(view).get()
     }
 }
-
-extension HTMLKit.Renderer.Errors: AbortError {
- 
-    @_implements(AbortError, reason)
-    public var abortReason: String { self.description }
-    
-    public var status: HTTPResponseStatus { .internalServerError }
-}
-
-extension HTMLKit.Renderer.Errors: DebuggableError {
-
-    @_implements(DebuggableError, reason)
-    public var debuggableReason: String {  self.description }
-}

--- a/Sources/HTMLKitVapor/ViewRenderer.swift
+++ b/Sources/HTMLKitVapor/ViewRenderer.swift
@@ -15,14 +15,19 @@ public class ViewRenderer {
     /// The renderer for the view renderer
     internal var renderer: Renderer
     
+    /// The logger used to log all operations
+    private var logger: Logger
+    
     /// Creates the view renderer
-    public init(eventLoop: EventLoop, configuration: Configuration) {
+    public init(eventLoop: EventLoop, configuration: Configuration, logger: Logger) {
         
         self.eventLoop = eventLoop
         self.renderer = Renderer(localization: configuration.localization,
                                  environment: configuration.environment,
                                  security: configuration.security,
-                                 features: configuration.features)
+                                 features: configuration.features,
+                                 logger: logger)
+        self.logger = logger
     }
     
     /// Renders a view and transforms it into a view response.

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -132,7 +132,13 @@ final class LocalizationTests: XCTestCase {
         }
         
         XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
-            XCTAssertEqual(error as! Localization.Errors, .missingKey)
+            
+            guard let localizationError = error as? Localization.Errors else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+        
+            XCTAssertEqual(localizationError, .missingKey("unknown.key"))
+            XCTAssertEqual(localizationError.description, "Unable to find translation key 'unknown.key'.")
         }
     }
     
@@ -154,7 +160,13 @@ final class LocalizationTests: XCTestCase {
         }
         
         XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
-            XCTAssertEqual(error as! Localization.Errors, .missingTable)
+            
+            guard let localizationError = error as? Localization.Errors else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            
+            XCTAssertEqual(localizationError, .missingTable("unknown.tag"))
+            XCTAssertEqual(localizationError.description, "Unable to find a translation table for the locale 'unknown.tag'.")
         }
     }
     
@@ -172,7 +184,13 @@ final class LocalizationTests: XCTestCase {
         }
         
         XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
-            XCTAssertEqual(error as! Localization.Errors, .unkownTable)
+            
+            guard let localizationError = error as? Localization.Errors else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            
+            XCTAssertEqual(localizationError, .unknownTable("unknown.table"))
+            XCTAssertEqual(localizationError.description, "Unable to find translation table 'unknown.table'.")
         }
     }
 }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -16,6 +16,9 @@ final class LocalizationTests: XCTestCase {
         try! setupLocalization()
     }
     
+    /// Tests the localization of a specified translation key
+    ///
+    /// The test expects the key to exist in the default translation table and to be rendered correctly.
     func testLocalization() throws {
         
         struct MainView: View {
@@ -32,6 +35,10 @@ final class LocalizationTests: XCTestCase {
         )
     }
     
+    /// Tests the localization of string interpolation
+    ///
+    /// The test expects the key to exist in the default translation table and to be correctly formatted
+    /// and rendered accurately.
     func testLocalizationWithStringInterpolation() throws {
         
         struct TestView: View {
@@ -48,6 +55,10 @@ final class LocalizationTests: XCTestCase {
         )
     }
     
+    /// Tests the localization of string interpolation with multiple arguments
+    ///
+    /// The test expects the key to exist in the default translation table, to be correctly formatted
+    /// with the arguments in the proper order, and to be rendered accurately.
     func testStringInterpolationWithMultipleArguments() throws {
         
         struct TestView: View {
@@ -64,23 +75,29 @@ final class LocalizationTests: XCTestCase {
         )
     }
     
+    /// Tests the localization of a translation key in a specified translation table
+    ///
+    /// The test expects the key to exist in the specified translation tabl and to be rendered accurately.
     func testLocaliationWithTable() throws {
         
         struct TestView: View {
             
             var body: Content {
-                Paragraph("personal.intro", tableName: "web", interpolation: "John Doe", 31, "Mozart", 5, 21.5)
+                Paragraph("greeting.world", tableName: "web")
             }
         }
         
         XCTAssertEqual(try renderer!.render(view: TestView()),
                        """
-                       <p>Hello, I am John Doe, and I am 31 years old. I have a dog named Mozart. He is 5 and 21.5 inches tall.</p>
+                       <p>Hello World</p>
                        """
         )
     }
     
-    
+    /// Tests the change of the locale by the environment modifier
+    ///
+    /// The test expects that the localization environment modifier correctly applies the locale
+    /// down to nested views
     func testEnvironmentLocalization() throws {
         
         struct MainView: View {
@@ -199,12 +216,10 @@ extension LocalizationTests {
     
     func setupLocalization() throws {
         
-        let currentFile = URL(fileURLWithPath: #file).deletingLastPathComponent()
+        guard let sourcePath = Bundle.module.url(forResource: "Localization", withExtension: nil) else {
+            return
+        }
         
-        let currentDirectory = currentFile.appendingPathComponent("Localization")
-        
-        let localization = Localization(source: currentDirectory, locale: Locale(tag: "en-GB"))
-        
-        self.renderer = Renderer(localization: localization)
+        self.renderer = Renderer(localization: .init(source: sourcePath, locale: .init(tag: "en-GB")))
     }
 }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -154,8 +154,8 @@ final class LocalizationTests: XCTestCase {
                 return XCTFail("Unexpected error type: \(error)")
             }
         
-            XCTAssertEqual(localizationError, .missingKey("unknown.key"))
-            XCTAssertEqual(localizationError.description, "Unable to find translation key 'unknown.key'.")
+            XCTAssertEqual(localizationError, .missingKey("unknown.key", "en-GB"))
+            XCTAssertEqual(localizationError.description, "Unable to find translation key 'unknown.key' for the locale 'en-GB'.")
         }
     }
     
@@ -206,8 +206,8 @@ final class LocalizationTests: XCTestCase {
                 return XCTFail("Unexpected error type: \(error)")
             }
             
-            XCTAssertEqual(localizationError, .unknownTable("unknown.table"))
-            XCTAssertEqual(localizationError.description, "Unable to find translation table 'unknown.table'.")
+            XCTAssertEqual(localizationError, .unknownTable("unknown.table", "en-GB"))
+            XCTAssertEqual(localizationError.description, "Unable to find translation table 'unknown.table' for the locale 'en-GB'.")
         }
     }
 }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -210,6 +210,46 @@ final class LocalizationTests: XCTestCase {
             XCTAssertEqual(localizationError.description, "Unable to find translation table 'unknown.table' for the locale 'en-GB'.")
         }
     }
+    
+    /// Tests the recovery from a missing key
+    ///
+    /// The renderer should attempt a secondary lookup in the translation tables of the default locale.
+    func testRecoveryFromMissingKey() throws {
+        
+        struct MainView: View {
+            
+            var content: [Content]
+            
+            init(@ContentBuilder<Content> content: () -> [Content]) {
+                self.content = content()
+            }
+            
+            var body: Content {
+                Division {
+                    content
+                }
+                .environment(key: \.locale, value: Locale(tag: .french))
+            }
+        }
+        
+        struct ChildView: View {
+            
+            var body: Content {
+                MainView {
+                    Heading1("greeting.person", interpolation: "John Doe")
+                        .environment(key: \.locale)
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: ChildView()),
+                       """
+                       <div>\
+                       <h1>Hello John Doe</h1>\
+                       </div>
+                       """
+        )
+    }
 }
 
 extension LocalizationTests {

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -117,6 +117,64 @@ final class LocalizationTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests the behavior when a localization key is missing
+    ///
+    /// A key is considered as missing if it cannot be found in the translation table. In this case,
+    /// the renderer is expected to throw an error.
+    func testMissingKey() throws {
+         
+        struct MainView: View {
+            
+            var body: Content {
+                Heading1("unknown.key")
+            }
+        }
+        
+        XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
+            XCTAssertEqual(error as! Localization.Errors, .missingKey)
+        }
+    }
+    
+    /// Tests the behavior when a translation table is missing
+    ///
+    /// A table is considered as missing if there is no translation table for the given locale. In this case,
+    /// the renderer is expected to throw an error.
+    func testMissingTable() throws {
+        
+        struct MainView: View {
+            
+            var body: Content {
+                Division {
+                    Heading1("greeting.world")
+                        .environment(key: \.locale)
+                }
+                .environment(key: \.locale, value: Locale(tag: "unknown.tag"))
+            }
+        }
+        
+        XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
+            XCTAssertEqual(error as! Localization.Errors, .missingTable)
+        }
+    }
+    
+    /// Tests the behavior when a translation table is unknown
+    ///
+    /// A table is considered as unknown if it cannot be found by the given table name. In this case,
+    /// the renderer is expected to throw an error.
+    func testUnknownTable() throws {
+        
+        struct MainView: View {
+            
+            var body: Content {
+                Heading1("greeting.world", tableName: "unknown.table")
+            }
+        }
+        
+        XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
+            XCTAssertEqual(error as! Localization.Errors, .unkownTable)
+        }
+    }
 }
 
 extension LocalizationTests {

--- a/Tests/HTMLKitTests/PerformanceTests.swift
+++ b/Tests/HTMLKitTests/PerformanceTests.swift
@@ -58,4 +58,30 @@ final class PerformanceTests: XCTestCase {
             }
         }
     }
+    
+    /// Measures the performance of the localization rendering
+    ///
+    /// The test runs up to 1000 iterations and utilizes string interpolation and table lookup
+    func testPerformanceWithLocalization() throws {
+        
+        guard let sourcePath = Bundle.module.url(forResource: "Localization", withExtension: nil) else {
+            return
+        }
+        
+        let renderer = Renderer(localization: .init(source: sourcePath, locale: .init(tag: "en-GB")))
+        
+        struct TestView: View {
+            
+            var body: Content {
+                Paragraph("personal.intro", interpolation: "John Doe", 31, "Mozart", 5, 21.5)
+            }
+        }
+        
+        measure {
+            
+            for _ in 0...1000 {
+                _ = try! renderer.render(view: TestView())
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pull request is the first of two addressing the issue #148. While the public API remains unchanged, it adds more precise error messages for better understanding during development and introduces a recovery mechanism for cases where a key is missing in one of the non-default translation tables.