### PR TITLE
Extend the environment

### DIFF
--- a/Sources/HTMLKit/Framework/Environment/Condition.swift
+++ b/Sources/HTMLKit/Framework/Environment/Condition.swift
@@ -19,13 +19,13 @@ public struct Condition: Conditionable {
     }
     
     /// The left-hand side value
-    public let lhs: EnvironmentValue
+    internal let lhs: EnvironmentValue
     
     /// The right-hand side value to test against
-    public let rhs: any Comparable
+    internal let rhs: any Comparable
     
     /// The comparison to perfom
-    public let comparison: Comparison
+    internal let comparison: Comparison
     
     /// Initializes a condition
     ///

--- a/Sources/HTMLKit/Framework/Environment/Condition.swift
+++ b/Sources/HTMLKit/Framework/Environment/Condition.swift
@@ -1,6 +1,6 @@
-/// A type representing a condition that compares an environment value against another value
+/// A type representing a conditional that compares an environment value against another value
 @_documentation(visibility: internal)
-public struct Condition: Conditionable {
+public struct Condition {
     
     /// A enumeration of potential comparison
     public enum Comparison {

--- a/Sources/HTMLKit/Framework/Environment/Condition.swift
+++ b/Sources/HTMLKit/Framework/Environment/Condition.swift
@@ -1,0 +1,42 @@
+/// A type representing a condition that compares an environment value against another value
+@_documentation(visibility: internal)
+public struct Condition: Conditionable {
+    
+    /// A enumeration of potential comparison
+    public enum Comparison {
+        
+        /// Indicates an equal comparison
+        case equal
+        
+        /// Indicates a not-equal comparison
+        case unequal
+        
+        /// Indicates a greater-than comparison
+        case greater
+        
+        /// Indicates a less-than comparison
+        case less
+    }
+    
+    /// The left-hand side value
+    public let lhs: EnvironmentValue
+    
+    /// The right-hand side value to test against
+    public let rhs: any Comparable
+    
+    /// The comparison to perfom
+    public let comparison: Comparison
+    
+    /// Initializes a condition
+    ///
+    /// - Parameters:
+    ///   - lhs: The origin value
+    ///   - rhs: The value to atest against
+    ///   - operation: The comparison to perfom
+    public init(lhs: EnvironmentValue, rhs: any Comparable, comparison: Comparison) {
+        
+        self.lhs = lhs
+        self.rhs = rhs
+        self.comparison = comparison
+    }
+}

--- a/Sources/HTMLKit/Framework/Environment/Conditionable.swift
+++ b/Sources/HTMLKit/Framework/Environment/Conditionable.swift
@@ -1,0 +1,4 @@
+/// A type that defines a conditonal value which will be evualuated by the renderer.
+@_documentation(visibility: internal)
+public protocol Conditionable {
+}

--- a/Sources/HTMLKit/Framework/Environment/Conditionable.swift
+++ b/Sources/HTMLKit/Framework/Environment/Conditionable.swift
@@ -1,4 +1,0 @@
-/// A type that defines a conditonal value which will be evualuated by the renderer.
-@_documentation(visibility: internal)
-public protocol Conditionable {
-}

--- a/Sources/HTMLKit/Framework/Environment/Conditional.swift
+++ b/Sources/HTMLKit/Framework/Environment/Conditional.swift
@@ -1,0 +1,16 @@
+/// A type that defines a conditonal value which will be evualuated by the renderer.
+@_documentation(visibility: internal)
+public indirect enum Conditional {
+    
+    /// Holds an relation
+    case relation(Relation)
+    
+    /// Holds a condition
+    case condition(Condition)
+    
+    /// Holds a negation
+    case negation(Negation)
+    
+    /// Holds a value
+    case value(EnvironmentValue)
+}

--- a/Sources/HTMLKit/Framework/Environment/Conditional.swift
+++ b/Sources/HTMLKit/Framework/Environment/Conditional.swift
@@ -2,6 +2,9 @@
 @_documentation(visibility: internal)
 public indirect enum Conditional {
     
+    /// Holds an optional
+    case optional(EnvironmentValue)
+    
     /// Holds an relation
     case relation(Relation)
     

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -64,3 +64,29 @@ public final class Environment {
         storage[path] = value
     }
 }
+
+extension Environment {
+    
+    /// Evaluates one condition
+    ///
+    /// - Parameters:
+    ///   - condition: The condition to evaluate
+    ///   - content: The content for the true statement
+    ///
+    /// - Returns: A environment condition
+    public static func when(_ condition: Conditionable, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
+        return Statement(compound: condition, first: content(), second: [])
+    }
+    
+    /// Evaluates one condition
+    ///
+    /// - Parameters:
+    ///   - condition: The condition to evaluate
+    ///   - content: The content for the true statement
+    ///   - then: The content for the false statement
+    ///
+    /// - Returns: A environment condition
+    public static func when(_ condition: Conditionable, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
+        return Statement(compound: condition, first: content(), second: then())
+    }
+}

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -89,4 +89,15 @@ extension Environment {
     public static func when(_ condition: Conditionable, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
         return Statement(compound: condition, first: content(), second: then())
     }
+    
+    /// Iterates through a sequence of values
+    ///
+    /// - Parameters:
+    ///   - sequence: The sequence to iterate over
+    ///   - content: The content for the iteration
+    ///
+    /// - Returns: A environment condition
+    public static func loop(_ sequence: EnvironmentValue, @ContentBuilder<Content> content: (EnvironmentValue) -> [Content]) -> Sequence {
+        return Sequence(value: sequence, content: content(sequence))
+    }
 }

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -145,40 +145,36 @@ public final class Environment {
             
             var result = true
             
-            if let condition = relation.lhs as? Condition {
+            switch relation.lhs {
+            case .condition(let condition):
                 result = try evaluate(condition: condition)
-            }
-            
-            if let relation = relation.lhs as? Relation {
+                
+            case .relation(let relation):
                 result = try evaluate(relation: relation)
-            }
-            
-            if let negation = relation.lhs as? Negation {
+                
+            case .negation(let negation):
                 result = try evaluate(negation: negation)
-            }
-            
-            if let value = relation.lhs as? EnvironmentValue {
+                
+            case .value(let value):
                 result = try evaluate(value: value)
             }
             
             if !result {
-                /// Bail early if the first result already is false
+                // Bail early if the first result already is false
                 return result
             }
-
-            if let condition = relation.rhs as? Condition {
+            
+            switch relation.rhs {
+            case .condition(let condition):
                 result = try evaluate(condition: condition)
-            }
-            
-            if let relation = relation.rhs as? Relation {
+                
+            case .relation(let relation):
                 result = try evaluate(relation: relation)
-            }
-            
-            if let negation = relation.lhs as? Negation {
+                
+            case .negation(let negation):
                 result = try evaluate(negation: negation)
-            }
-            
-            if let value = relation.lhs as? EnvironmentValue {
+                
+            case .value(let value):
                 result = try evaluate(value: value)
             }
             
@@ -188,40 +184,36 @@ public final class Environment {
             
             var result = false
             
-            if let condition = relation.lhs as? Condition {
+            switch relation.lhs {
+            case .condition(let condition):
                 result = try evaluate(condition: condition)
-            }
-            
-            if let relation = relation.lhs as? Relation {
+                
+            case .relation(let relation):
                 result = try evaluate(relation: relation)
-            }
-            
-            if let negation = relation.lhs as? Negation {
+                
+            case .negation(let negation):
                 result = try evaluate(negation: negation)
-            }
-            
-            if let value = relation.lhs as? EnvironmentValue {
+                
+            case .value(let value):
                 result = try evaluate(value: value)
             }
             
             if result {
-                /// Bail early if the first result is already true
+                // Bail early if the first result is already true
                 return result
             }
             
-            if let condition = relation.rhs as? Condition {
+            switch relation.rhs {
+            case .condition(let condition):
                 result = try evaluate(condition: condition)
-            }
-            
-            if let relation = relation.rhs as? Relation {
+                
+            case .relation(let relation):
                 result = try evaluate(relation: relation)
-            }
-            
-            if let negation = relation.lhs as? Negation {
+                
+            case .negation(let negation):
                 result = try evaluate(negation: negation)
-            }
-            
-            if let value = relation.lhs as? EnvironmentValue {
+                
+            case .value(let value):
                 result = try evaluate(value: value)
             }
             
@@ -272,7 +264,18 @@ extension Environment {
     ///   - content: The content for the true statement
     ///
     /// - Returns: A environment condition
-    public static func when(_ condition: Conditionable, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
+    public static func when(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
+        return Statement(compound: .value(condition), first: content(), second: [])
+    }
+    
+    /// Evaluates one condition
+    ///
+    /// - Parameters:
+    ///   - condition: The condition to evaluate
+    ///   - content: The content for the true statement
+    ///
+    /// - Returns: A environment condition
+    public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
         return Statement(compound: condition, first: content(), second: [])
     }
     
@@ -284,7 +287,7 @@ extension Environment {
     ///   - then: The content for the false statement
     ///
     /// - Returns: A environment condition
-    public static func when(_ condition: Conditionable, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
+    public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
         return Statement(compound: condition, first: content(), second: then())
     }
     

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -291,7 +291,7 @@ extension Environment {
     ///   - condition: The condition to evaluate
     ///   - content: The content for the true statement
     ///
-    /// - Returns: A environment condition
+    /// - Returns: A environment statement
     public static func when(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
         return Statement(compound: .value(condition), first: content(), second: [])
     }
@@ -301,10 +301,34 @@ extension Environment {
     /// - Parameters:
     ///   - condition: The condition to evaluate
     ///   - content: The content for the true statement
+    ///   - then: The content for the false statement
     ///
-    /// - Returns: A environment condition
+    /// - Returns: A environment statement
+    public static func when(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
+        return Statement(compound: .value(condition), first: content(), second: then())
+    }
+    
+    /// Evaluates one condition
+    ///
+    /// - Parameters:
+    ///   - condition: The condition to evaluate
+    ///   - content: The content for the true statement
+    ///
+    /// - Returns: A environment statement
     public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
         return Statement(compound: condition, first: content(), second: [])
+    }
+    
+    /// Evaluates one condition
+    ///
+    /// - Parameters:
+    ///   - condition: The condition to evaluate
+    ///   - content: The content for the true statement
+    ///   - then: The content for the false statement
+    ///
+    /// - Returns: A environment statement
+    public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
+        return Statement(compound: condition, first: content(), second: then())
     }
     
     /// Unwraps a optional environment value
@@ -330,25 +354,13 @@ extension Environment {
         return Statement(compound: .optional(value), first: content(value), second: then())
     }
     
-    /// Evaluates one condition
-    ///
-    /// - Parameters:
-    ///   - condition: The condition to evaluate
-    ///   - content: The content for the true statement
-    ///   - then: The content for the false statement
-    ///
-    /// - Returns: A environment condition
-    public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
-        return Statement(compound: condition, first: content(), second: then())
-    }
-    
     /// Iterates through a sequence of values
     ///
     /// - Parameters:
     ///   - sequence: The sequence to iterate over
     ///   - content: The content for the iteration
     ///
-    /// - Returns: A environment condition
+    /// - Returns: A environment sequence
     public static func loop(_ sequence: EnvironmentValue, @ContentBuilder<Content> content: (EnvironmentValue) -> [Content]) -> Sequence {
         return Sequence(value: sequence, content: content(sequence))
     }

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -292,7 +292,7 @@ extension Environment {
     ///   - content: The content for the true statement
     ///
     /// - Returns: A environment statement
-    public static func when(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
+    public static func check(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
         return Statement(compound: .value(condition), first: content(), second: [])
     }
     
@@ -304,7 +304,7 @@ extension Environment {
     ///   - then: The content for the false statement
     ///
     /// - Returns: A environment statement
-    public static func when(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
+    public static func check(_ condition: EnvironmentValue, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
         return Statement(compound: .value(condition), first: content(), second: then())
     }
     
@@ -315,7 +315,7 @@ extension Environment {
     ///   - content: The content for the true statement
     ///
     /// - Returns: A environment statement
-    public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
+    public static func check(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content]) -> Statement {
         return Statement(compound: condition, first: content(), second: [])
     }
     
@@ -327,7 +327,7 @@ extension Environment {
     ///   - then: The content for the false statement
     ///
     /// - Returns: A environment statement
-    public static func when(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
+    public static func check(_ condition: Conditional, @ContentBuilder<Content> content: () -> [Content], @ContentBuilder<Content> then: () -> [Content]) -> Statement {
         return Statement(compound: condition, first: content(), second: then())
     }
     

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A class that represents the environment
 ///
 /// The environment provides storage for various settings used by the renderer
-public class Environment {
+public final class Environment {
     
     /// The storage of the environment
     private var storage: [AnyKeyPath: Any]
@@ -15,16 +15,36 @@ public class Environment {
     }
     
     /// The current time zone of the environment
-    public var timeZone: TimeZone?
+    public var timeZone: TimeZone? {
+        
+        get {
+            retrieve(for: \EnvironmentKeys.timeZone) as? TimeZone
+        }
+    }
     
     /// The current calendar of the environment
-    public var calendar: Calendar?
+    public var calendar: Calendar? {
+        
+        get {
+            retrieve(for: \EnvironmentKeys.calendar) as? Calendar
+        }
+    }
     
     /// The current locale of the environment
-    public var locale: Locale?
+    public var locale: Locale? {
+        
+        get {
+            retrieve(for: \EnvironmentKeys.locale) as? Locale
+        }
+    }
     
     /// The current color scheme of the environment
-    public var colorScheme: String?
+    public var colorScheme: String? {
+        
+        get {
+            retrieve(for: \EnvironmentKeys.colorScheme) as? String
+        }
+    }
     
     /// Retrieves a value from environment for a given key path
     ///
@@ -32,12 +52,7 @@ public class Environment {
     ///
     /// - Returns: The value
     public func retrieve(for path: AnyKeyPath) -> Any? {
-        
-        if let value = self.storage[path] {
-            return value
-        }
-        
-        return nil
+        return storage[path]
     }
     
     /// Inserts or updates a value in the environment for the given key path
@@ -46,6 +61,6 @@ public class Environment {
     ///   - value: The value to be stored or updated
     ///   - path: The key path that identifies where the value is stored
     public func upsert<T>(_ value: T, for path: AnyKeyPath) {
-        self.storage[path] = value
+        storage[path] = value
     }
 }

--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -1,30 +1,36 @@
 import Foundation
 
-/// A type that represents the environment
+/// A class that represents the environment
+///
+/// The environment provides storage for various settings used by the renderer
 public class Environment {
     
     /// The storage of the environment
     private var storage: [AnyKeyPath: Any]
     
-    /// Initiates a manager
+    /// Initializes the environment
     public init() {
         
         self.storage = [:]
     }
     
-    /// The current  time zone of the environment
+    /// The current time zone of the environment
     public var timeZone: TimeZone?
     
-    /// The current calender of the environment
+    /// The current calendar of the environment
     public var calendar: Calendar?
     
-    /// The current local of the environment
+    /// The current locale of the environment
     public var locale: Locale?
     
     /// The current color scheme of the environment
     public var colorScheme: String?
     
-    /// Retrieves an item from storage by its path
+    /// Retrieves a value from environment for a given key path
+    ///
+    /// - Parameter path: The key path used to look up the value
+    ///
+    /// - Returns: The value
     public func retrieve(for path: AnyKeyPath) -> Any? {
         
         if let value = self.storage[path] {
@@ -34,7 +40,11 @@ public class Environment {
         return nil
     }
     
-    /// Adds und updates an item to the storage
+    /// Inserts or updates a value in the environment for the given key path
+    ///
+    /// - Parameters:
+    ///   - value: The value to be stored or updated
+    ///   - path: The key path that identifies where the value is stored
     public func upsert<T>(_ value: T, for path: AnyKeyPath) {
         self.storage[path] = value
     }

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentKeys.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentKeys.swift
@@ -1,12 +1,19 @@
 import Foundation
 
+/// A set of predefined environment keys
+///
+/// The keys are used on the environment modifiers to configure various settings for the environment.
 public struct EnvironmentKeys: Hashable {
     
+    /// A key used to configure the environment's calendar
     public var calender: Calendar
     
+    /// A key used to configure the environment's time zone
     public var timeZone: TimeZone
     
+    /// A key used to configure the environment's locale
     public var locale: Locale
     
+    /// A key used  to configure the environment's color scheme
     public var colorScheme: String
 }

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentKeys.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentKeys.swift
@@ -6,7 +6,7 @@ import Foundation
 public struct EnvironmentKeys: Hashable {
     
     /// A key used to configure the environment's calendar
-    public var calender: Calendar
+    public var calendar: Calendar
     
     /// A key used to configure the environment's time zone
     public var timeZone: TimeZone

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentModifier.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentModifier.swift
@@ -5,13 +5,13 @@
 public struct EnvironmentModifier: Content {
 
     /// The environment key
-    public var key: AnyKeyPath
+    internal var key: AnyKeyPath
     
     /// The environment value
-    public var value: Any?
+    internal var value: Any?
     
     /// The sub-content
-    public var content: [Content]
+    internal var content: [Content]
     
     /// Initializes an environment modifier
     ///

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentModifier.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentModifier.swift
@@ -1,9 +1,6 @@
-/*
- Abstract:
- The file contains the environment modifier.
- */
-
-/// A type that contains the value and the following content, after modifing the environment.
+/// A type that holds the modification details for the environment
+///
+/// The modifier is received by the renderer and applied to the environment.
 @_documentation(visibility: internal)
 public struct EnvironmentModifier: Content {
 
@@ -13,10 +10,15 @@ public struct EnvironmentModifier: Content {
     /// The environment value
     public var value: Any?
     
-    /// The following content
+    /// The sub-content
     public var content: [Content]
     
-    /// Initiates a environment modifier
+    /// Initializes an environment modifier
+    ///
+    /// - Parameters:
+    ///   - key: The key path of the environment value to be modified
+    ///   - value: The new value to update the environment value with
+    ///   - content: The sub-content to be rendered
     public init(key: AnyKeyPath, value: Any? = nil, content: [Content]) {
         
         self.key = key

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentModifier.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentModifier.swift
@@ -5,13 +5,13 @@
 public struct EnvironmentModifier: Content {
 
     /// The environment key
-    internal var key: AnyKeyPath
+    internal let key: AnyKeyPath
     
     /// The environment value
-    internal var value: Any?
+    internal let value: Any?
     
     /// The sub-content
-    internal var content: [Content]
+    internal let content: [Content]
     
     /// Initializes an environment modifier
     ///

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentObject.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentObject.swift
@@ -1,18 +1,20 @@
 import Foundation
 
-/// A property wrapper type to initate an environment object
+/// A property wrapper type to provide access to an environment object
+///
+/// An environment object allows to read shared environment data.
 @frozen @propertyWrapper public struct EnvironmentObject<ObjectType> {
     
-    /// The wrapped value
+    /// The wrapped object
     public var wrappedValue: Wrapper<ObjectType>
     
-    /// Converts the type into the wrapped value
+    /// Initialiizes the environment object
     public init(_ type: ObjectType.Type) {
         
         self.wrappedValue = .init()
     }
     
-    /// A type, that holds the environment object informationen
+    /// A wrapper, that holds the object informationen
     @dynamicMemberLookup public struct Wrapper<WrapperType> {
         
         /// The path of the parent
@@ -21,20 +23,26 @@ import Foundation
         /// The path of the value
         internal var path: AnyKeyPath
         
-        /// Initiates a wrapper
+        /// Initializes the wrapper
         public init() {
             
             self.path = \WrapperType.self
         }
         
-        /// Initiates a wrapper with the necessary information for the environment object
+        /// Initializes the wrapper
+        ///
+        /// - Parameters:
+        ///   - parent: The path of the parent
+        ///   - path: The path of the value
         internal init(parent: AnyKeyPath, path: AnyKeyPath) {
             
             self.parent = parent
             self.path = path
         }
         
-        /// Looks up for a containing property
+        /// Accesses a wrapped value for a given key path dynamically
+        ///
+        /// - Returns: An environment value
         public subscript<T>(dynamicMember member: KeyPath<WrapperType, T>) -> EnvironmentValue {
             
             guard let newPath = self.path.appending(path: member) else {
@@ -48,7 +56,9 @@ import Foundation
             return .init(parentPath: self.path, valuePath: newPath)
         }
         
-        /// Looks up for a containing model
+        ///  Accesses a wrapped model object for a given key path dynamically
+        ///
+        /// - Returns: An environment value
         public subscript<T>(dynamicMember member: KeyPath<WrapperType, T>) -> Wrapper<T> where T: ViewModel {
             
             guard let newPath = self.path.appending(path: member) else {

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentString.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentString.swift
@@ -1,0 +1,31 @@
+/// A type that represents an environment string
+@_documentation(visibility: internal)
+public struct EnvironmentString: ExpressibleByStringLiteral, ExpressibleByStringInterpolation, Content {
+    
+    internal var values: [Content] = []
+    
+    public init(stringLiteral: String) {
+        self.values.append(stringLiteral)
+    }
+    
+    public init(stringInterpolation: StringInterpolation) {
+        self.values.append(contentsOf: stringInterpolation.values)
+    }
+    
+    public struct StringInterpolation: StringInterpolationProtocol {
+        
+        internal var values: [Content] = []
+    
+        public init(literalCapacity: Int, interpolationCount: Int) {
+            values.reserveCapacity(interpolationCount)
+        }
+        
+        public mutating func appendLiteral(_ literal: String) {
+            values.append(literal)
+        }
+        
+        public mutating func appendInterpolation(_ env: EnvironmentValue) {
+            values.append(env)
+        }
+    }
+}

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
@@ -3,20 +3,21 @@ import Foundation
 /// A type that serves as a placeholder for an environment value
 ///
 /// The placeholder will be evaluated and resolved by the renderer when needed.
+@_documentation(visibility: internal)
 public struct EnvironmentValue: Content {
     
     /// The path of the values parent
-    internal var parentPath: AnyKeyPath
+    internal let parentPath: AnyKeyPath
     
     /// The path of the value
-    internal var valuePath: AnyKeyPath
+    internal let valuePath: AnyKeyPath
     
     /// Initializes a environment value
     ///
     /// - Parameters:
     ///   - parentPath: The key path of the parent
     ///   - valuePath: The key path of the value
-    public init(parentPath: AnyKeyPath, valuePath: AnyKeyPath) {
+    internal init(parentPath: AnyKeyPath, valuePath: AnyKeyPath) {
         
         self.parentPath = parentPath
         self.valuePath = valuePath

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
@@ -25,8 +25,36 @@ public struct EnvironmentValue: Content {
 
 extension EnvironmentValue {
     
-    /// Concatenates an environment value with another value
-    static public func + (lhs: Content, rhs: Self) -> Content {
+    /// Concat environment value with environment value
+    public static func + (lhs: Content, rhs: Self) -> Content {
         return [lhs, rhs]
+    }
+    
+    /// Compare an environment value with another comparable value
+    ///
+    /// Makes an unequal evaluation
+    public static func != (lhs: Self, rhs: some Comparable) -> Condition {
+        return Condition(lhs: lhs, rhs: rhs, comparison: .unequal)
+    }
+    
+    /// Compare an environment value with another comparable value
+    ///
+    /// Makes an equal evaluation
+    public static func == (lhs: Self, rhs: some Comparable) -> Condition {
+        return Condition(lhs: lhs, rhs: rhs, comparison: .equal)
+    }
+    
+    /// Compare an environment value with another comparable value
+    ///
+    /// Makes an less than evaluation
+    public static func < (lhs: Self, rhs: some Comparable) -> Condition {
+        return Condition(lhs: lhs, rhs: rhs, comparison: .less)
+    }
+    
+    /// Compare an environment value with another comparable value
+    ///
+    /// Makes an greater than evaluation
+    public static func > (lhs: Self, rhs: some Comparable) -> Condition {
+        return Condition(lhs: lhs, rhs: rhs, comparison: .greater)
     }
 }

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
@@ -24,7 +24,7 @@ public struct EnvironmentValue: Content {
     }
 }
 
-extension EnvironmentValue: Conditionable {
+extension EnvironmentValue {
     
     /// Concat environment value with environment value
     public static func + (lhs: Content, rhs: Self) -> Content {
@@ -34,28 +34,28 @@ extension EnvironmentValue: Conditionable {
     /// Compare an environment value with another comparable value
     ///
     /// Makes an unequal evaluation
-    public static func != (lhs: Self, rhs: some Comparable) -> Condition {
-        return Condition(lhs: lhs, rhs: rhs, comparison: .unequal)
+    public static func != (lhs: Self, rhs: some Comparable) -> Conditional {
+        return .condition(Condition(lhs: lhs, rhs: rhs, comparison: .unequal))
     }
     
     /// Compare an environment value with another comparable value
     ///
     /// Makes an equal evaluation
-    public static func == (lhs: Self, rhs: some Comparable) -> Condition {
-        return Condition(lhs: lhs, rhs: rhs, comparison: .equal)
+    public static func == (lhs: Self, rhs: some Comparable) -> Conditional {
+        return .condition(Condition(lhs: lhs, rhs: rhs, comparison: .equal))
     }
     
     /// Compare an environment value with another comparable value
     ///
     /// Makes an less than evaluation
-    public static func < (lhs: Self, rhs: some Comparable) -> Condition {
-        return Condition(lhs: lhs, rhs: rhs, comparison: .less)
+    public static func < (lhs: Self, rhs: some Comparable) -> Conditional {
+        return .condition(Condition(lhs: lhs, rhs: rhs, comparison: .less))
     }
     
     /// Compare an environment value with another comparable value
     ///
     /// Makes an greater than evaluation
-    public static func > (lhs: Self, rhs: some Comparable) -> Condition {
-        return Condition(lhs: lhs, rhs: rhs, comparison: .greater)
+    public static func > (lhs: Self, rhs: some Comparable) -> Conditional {
+        return .condition(Condition(lhs: lhs, rhs: rhs, comparison: .greater))
     }
 }

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
@@ -23,7 +23,7 @@ public struct EnvironmentValue: Content {
     }
 }
 
-extension EnvironmentValue {
+extension EnvironmentValue: Conditionable {
     
     /// Concat environment value with environment value
     public static func + (lhs: Content, rhs: Self) -> Content {

--- a/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
+++ b/Sources/HTMLKit/Framework/Environment/EnvironmentValue.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-/// A type, that acts as a binding value
+/// A type that serves as a placeholder for an environment value
+///
+/// The placeholder will be evaluated and resolved by the renderer when needed.
 public struct EnvironmentValue: Content {
     
     /// The path of the values parent
@@ -9,7 +11,11 @@ public struct EnvironmentValue: Content {
     /// The path of the value
     internal var valuePath: AnyKeyPath
     
-    /// Initiates a environment value
+    /// Initializes a environment value
+    ///
+    /// - Parameters:
+    ///   - parentPath: The key path of the parent
+    ///   - valuePath: The key path of the value
     public init(parentPath: AnyKeyPath, valuePath: AnyKeyPath) {
         
         self.parentPath = parentPath
@@ -19,6 +25,7 @@ public struct EnvironmentValue: Content {
 
 extension EnvironmentValue {
     
+    /// Concatenates an environment value with another value
     static public func + (lhs: Content, rhs: Self) -> Content {
         return [lhs, rhs]
     }

--- a/Sources/HTMLKit/Framework/Environment/Negation.swift
+++ b/Sources/HTMLKit/Framework/Environment/Negation.swift
@@ -1,6 +1,6 @@
-/// A type thats represents an invert condition
+/// A type thats represents an invert conditional
 @_documentation(visibility: internal)
-public struct Negation: Conditionable {
+public struct Negation {
     
     /// The left-hand side conditional
     internal let value: EnvironmentValue
@@ -14,8 +14,7 @@ public struct Negation: Conditionable {
     }
 }
 
-
-/// Creates a invert condition
+/// Creates a invert conditional
 ///
 /// ```swift
 /// Environment.when(!value) {
@@ -25,7 +24,7 @@ public struct Negation: Conditionable {
 /// - Parameters:
 ///   - lhs: The left-hand side conditional
 ///
-/// - Returns: A invert
-public prefix func ! (value: EnvironmentValue) -> Negation {
-    return Negation(value: value)
+/// - Returns: A invert conditional
+public prefix func ! (value: EnvironmentValue) -> Conditional {
+    return .negation(Negation(value: value))
 }

--- a/Sources/HTMLKit/Framework/Environment/Negation.swift
+++ b/Sources/HTMLKit/Framework/Environment/Negation.swift
@@ -1,0 +1,23 @@
+/// A type thats represents an invert condition
+@_documentation(visibility: internal)
+public struct Negation: Conditionable {
+    
+    /// The left-hand side conditional
+    public let lhs: Conditionable
+}
+
+
+/// Creates a invert condition
+///
+/// ```swift
+/// Environment.when(!value) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///
+/// - Returns: A invert
+public prefix func ! (lhs: Conditionable) -> Negation {
+    return Negation(lhs: lhs)
+}

--- a/Sources/HTMLKit/Framework/Environment/Negation.swift
+++ b/Sources/HTMLKit/Framework/Environment/Negation.swift
@@ -3,7 +3,15 @@
 public struct Negation: Conditionable {
     
     /// The left-hand side conditional
-    public let lhs: Conditionable
+    internal let value: EnvironmentValue
+    
+    /// Initializes the negation
+    ///
+    /// - Parameter lhs: The conditional to evaluate
+    public init(value: EnvironmentValue) {
+        
+        self.value = value
+    }
 }
 
 
@@ -18,6 +26,6 @@ public struct Negation: Conditionable {
 ///   - lhs: The left-hand side conditional
 ///
 /// - Returns: A invert
-public prefix func ! (lhs: Conditionable) -> Negation {
-    return Negation(lhs: lhs)
+public prefix func ! (value: EnvironmentValue) -> Negation {
+    return Negation(value: value)
 }

--- a/Sources/HTMLKit/Framework/Environment/Nullable.swift
+++ b/Sources/HTMLKit/Framework/Environment/Nullable.swift
@@ -1,4 +1,4 @@
-/// A type that represent
+/// A type that represent a nullable value.
 ///
 /// > Note: This protocol is intended as a temporary workaround.
 @_documentation(visibility: internal)
@@ -6,11 +6,4 @@ internal protocol Nullable {
     
     /// Checks whether the value is absent without needing to know the underlying type.
     var isNull: Bool { get }
-}
-
-extension Optional: Nullable {
-    
-    internal var isNull: Bool {
-        return self == nil
-    }
 }

--- a/Sources/HTMLKit/Framework/Environment/Nullable.swift
+++ b/Sources/HTMLKit/Framework/Environment/Nullable.swift
@@ -1,0 +1,16 @@
+/// A type that represent
+///
+/// > Note: This protocol is intended as a temporary workaround.
+@_documentation(visibility: internal)
+internal protocol Nullable {
+    
+    /// Checks whether the value is absent without needing to know the underlying type.
+    var isNull: Bool { get }
+}
+
+extension Optional: Nullable {
+    
+    internal var isNull: Bool {
+        return self == nil
+    }
+}

--- a/Sources/HTMLKit/Framework/Environment/Relation.swift
+++ b/Sources/HTMLKit/Framework/Environment/Relation.swift
@@ -1,6 +1,6 @@
 /// A type representing the logical relation between two conditionals
 @_documentation(visibility: internal)
-public struct Relation: Conditionable {
+public struct Relation {
     
     /// A enumeration of potential logical terms
     public enum Term {
@@ -20,10 +20,10 @@ public struct Relation: Conditionable {
     internal let term: Term
     
     /// The left-hand side conditional
-    internal let lhs: Conditionable
+    internal let lhs: Conditional
     
     /// The right-hand side conditional
-    internal let rhs: Conditionable
+    internal let rhs: Conditional
     
     /// Initializes a relation
     ///
@@ -31,7 +31,7 @@ public struct Relation: Conditionable {
     ///   - term: The term on which the relation acts on
     ///   - lhs: The left-hand side conditional
     ///   - rhs: The right-hand side conditional to test against
-    public init(term: Term, lhs: Conditionable, rhs: Conditionable) {
+    public init(term: Term, lhs: Conditional, rhs: Conditional) {
         
         self.term = term
         self.lhs = lhs
@@ -40,7 +40,40 @@ public struct Relation: Conditionable {
 }
 
 /// Creates a conjunctional relation between two conditionals
-/// 
+///
+/// ```swift
+/// Environment.when(value > 0 && value) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///   - rhs: An environment value
+///
+/// - Returns: A conjunctional relation
+public func && (lhs: Conditional, rhs: EnvironmentValue) -> Conditional {
+    return .relation(Relation(term: .conjunction, lhs: lhs, rhs: .value(rhs)))
+}
+
+/// Creates a conjunctional relation between two conditionals
+///
+/// ```swift
+/// Environment.when(value && value > 0) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///   - rhs: An environment value
+///
+/// - Returns: A conjunctional relation
+public func && (lhs: EnvironmentValue, rhs: Conditional) -> Conditional {
+    return .relation(Relation(term: .conjunction, lhs: .value(lhs), rhs: rhs))
+}
+
+
+/// Creates a conjunctional relation between two conditionals
+///
 /// ```swift
 /// Environment.when(value > 0 && value < 2) {
 /// }
@@ -51,8 +84,40 @@ public struct Relation: Conditionable {
 ///   - rhs: The right-hand side conditional
 ///
 /// - Returns: A conjunctional relation
-public func && (lhs: Conditionable, rhs: Conditionable) -> Relation {
-    return Relation(term: .conjunction, lhs: lhs, rhs: rhs)
+public func && (lhs: Conditional, rhs: Conditional) -> Conditional {
+    return .relation(Relation(term: .conjunction, lhs: lhs, rhs: rhs))
+}
+
+/// Creates a disjunctional relation between two conditionals
+///
+/// ```swift
+/// Environment.when(value > 0 || value) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///   - rhs: The right-hand side conditional
+///
+/// - Returns: A disjunctional relation
+public func || (lhs: Conditional, rhs: EnvironmentValue) -> Conditional {
+    return .relation(Relation(term: .disjunction, lhs: lhs, rhs: .value(rhs)))
+}
+
+/// Creates a disjunctional relation between two conditionals
+///
+/// ```swift
+/// Environment.when(value || value > 0) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///   - rhs: The right-hand side conditional
+///
+/// - Returns: A disjunctional relation
+public func || (lhs: EnvironmentValue, rhs: Conditional) -> Conditional {
+    return .relation(Relation(term: .disjunction, lhs: .value(lhs), rhs: rhs))
 }
 
 /// Creates a disjunctional relation between two conditionals
@@ -67,7 +132,7 @@ public func && (lhs: Conditionable, rhs: Conditionable) -> Relation {
 ///   - rhs: The right-hand side conditional
 ///
 /// - Returns: A disjunctional relation
-public func || (lhs: Conditionable, rhs: Conditionable) -> Relation {
-    return Relation(term: .disjunction, lhs: lhs, rhs: rhs)
+public func || (lhs: Conditional, rhs: Conditional) -> Conditional {
+    return .relation(Relation(term: .disjunction, lhs: lhs, rhs: rhs))
 }
 

--- a/Sources/HTMLKit/Framework/Environment/Relation.swift
+++ b/Sources/HTMLKit/Framework/Environment/Relation.swift
@@ -17,13 +17,26 @@ public struct Relation: Conditionable {
     }
     
     /// The logical term specifying the relation
-    public let term: Term
+    internal let term: Term
     
     /// The left-hand side conditional
-    public let lhs: Conditionable
+    internal let lhs: Conditionable
     
     /// The right-hand side conditional
-    public let rhs: Conditionable
+    internal let rhs: Conditionable
+    
+    /// Initializes a relation
+    ///
+    /// - Parameters:
+    ///   - term: The term on which the relation acts on
+    ///   - lhs: The left-hand side conditional
+    ///   - rhs: The right-hand side conditional to test against
+    public init(term: Term, lhs: Conditionable, rhs: Conditionable) {
+        
+        self.term = term
+        self.lhs = lhs
+        self.rhs = rhs
+    }
 }
 
 /// Creates a conjunctional relation between two conditionals

--- a/Sources/HTMLKit/Framework/Environment/Relation.swift
+++ b/Sources/HTMLKit/Framework/Environment/Relation.swift
@@ -1,0 +1,60 @@
+/// A type representing the logical relation between two conditionals
+@_documentation(visibility: internal)
+public struct Relation: Conditionable {
+    
+    /// A enumeration of potential logical terms
+    public enum Term {
+    
+        /// Indicates a conjunction
+        ///
+        /// All conditions must be true for the relation to be true
+        case conjunction
+        
+        /// Indicates a disjunction
+        ///
+        /// One condition must be at least true for the relation to be true
+        case disjunction
+    }
+    
+    /// The logical term specifying the relation
+    public let term: Term
+    
+    /// The left-hand side conditional
+    public let lhs: Conditionable
+    
+    /// The right-hand side conditional
+    public let rhs: Conditionable
+}
+
+/// Creates a conjunctional relation between two conditionals
+/// 
+/// ```swift
+/// Environment.when(value > 0 && value < 2) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///   - rhs: The right-hand side conditional
+///
+/// - Returns: A conjunctional relation
+public func && (lhs: Conditionable, rhs: Conditionable) -> Relation {
+    return Relation(term: .conjunction, lhs: lhs, rhs: rhs)
+}
+
+/// Creates a disjunctional relation between two conditionals
+///
+/// ```swift
+/// Environment.when(value > 0 || value < 2) {
+/// }
+/// ```
+///
+/// - Parameters:
+///   - lhs: The left-hand side conditional
+///   - rhs: The right-hand side conditional
+///
+/// - Returns: A disjunctional relation
+public func || (lhs: Conditionable, rhs: Conditionable) -> Relation {
+    return Relation(term: .disjunction, lhs: lhs, rhs: rhs)
+}
+

--- a/Sources/HTMLKit/Framework/Environment/Sequence.swift
+++ b/Sources/HTMLKit/Framework/Environment/Sequence.swift
@@ -1,18 +1,19 @@
 /// A type representing a loop rendering content within the environment
+@_documentation(visibility: internal)
 public struct Sequence: Content {
     
     /// The environment value of the sequence
-    let value: EnvironmentValue
+    internal let value: EnvironmentValue
     
     /// The accumulated content
-    let content: [Content]
+    internal let content: [Content]
     
     /// Initializes a loop
     ///
     /// - Parameters:
     ///   - value: The environment value to retrieve the sequence from
     ///   - content: The content to render for each item in the sequence
-    init(value: EnvironmentValue, content: [Content]) {
+    public init(value: EnvironmentValue, content: [Content]) {
         
         self.value = value
         self.content = content

--- a/Sources/HTMLKit/Framework/Environment/Sequence.swift
+++ b/Sources/HTMLKit/Framework/Environment/Sequence.swift
@@ -1,6 +1,6 @@
 /// A type representing a loop rendering content within the environment
 @_documentation(visibility: internal)
-public struct Sequence: Content {
+public struct Sequence: GlobalElement {
     
     /// The environment value of the sequence
     internal let value: EnvironmentValue

--- a/Sources/HTMLKit/Framework/Environment/Sequence.swift
+++ b/Sources/HTMLKit/Framework/Environment/Sequence.swift
@@ -1,0 +1,20 @@
+/// A type representing a loop rendering content within the environment
+public struct Sequence: Content {
+    
+    /// The environment value of the sequence
+    let value: EnvironmentValue
+    
+    /// The accumulated content
+    let content: [Content]
+    
+    /// Initializes a loop
+    ///
+    /// - Parameters:
+    ///   - value: The environment value to retrieve the sequence from
+    ///   - content: The content to render for each item in the sequence
+    init(value: EnvironmentValue, content: [Content]) {
+        
+        self.value = value
+        self.content = content
+    }
+}

--- a/Sources/HTMLKit/Framework/Environment/Statement.swift
+++ b/Sources/HTMLKit/Framework/Environment/Statement.swift
@@ -1,6 +1,6 @@
 /// A type representing a conditional block within the environment
 @_documentation(visibility: internal)
-public struct Statement: Content {
+public struct Statement: GlobalElement {
     
     /// The compound condition
     internal let compound: Conditional

--- a/Sources/HTMLKit/Framework/Environment/Statement.swift
+++ b/Sources/HTMLKit/Framework/Environment/Statement.swift
@@ -3,7 +3,7 @@
 public struct Statement: Content {
     
     /// The compound condition
-    internal let compound: Conditionable
+    internal let compound: Conditional
     
     /// The first statement
     internal let first: [Content]
@@ -17,7 +17,7 @@ public struct Statement: Content {
     ///   - compound: The compound of conditionals
     ///   - first: The statement to execute if conditionals are true
     ///   - second: The statement to execute if conditionals are false
-    public init(compound: Conditionable, first: [Content], second: [Content]) {
+    public init(compound: Conditional, first: [Content], second: [Content]) {
         
         self.compound = compound
         self.first = first

--- a/Sources/HTMLKit/Framework/Environment/Statement.swift
+++ b/Sources/HTMLKit/Framework/Environment/Statement.swift
@@ -1,0 +1,26 @@
+/// A type representing a conditional block within the environment
+@_documentation(visibility: internal)
+public struct Statement: Content {
+    
+    /// The compound condition
+    let compound: Conditionable
+    
+    /// The first statement
+    let first: [Content]
+    
+    /// The second statement
+    let second: [Content]
+    
+    /// Initializes a statement
+    ///
+    /// - Parameters:
+    ///   - compound: The compound of conditionals
+    ///   - first: The statement to execute if conditionals are true
+    ///   - second: The statement to execute if conditionals are false
+    init(compound: Conditionable, first: [Content], second: [Content]) {
+        
+        self.compound = compound
+        self.first = first
+        self.second = second
+    }
+}

--- a/Sources/HTMLKit/Framework/Environment/Statement.swift
+++ b/Sources/HTMLKit/Framework/Environment/Statement.swift
@@ -3,13 +3,13 @@
 public struct Statement: Content {
     
     /// The compound condition
-    let compound: Conditionable
+    internal let compound: Conditionable
     
     /// The first statement
-    let first: [Content]
+    internal let first: [Content]
     
     /// The second statement
-    let second: [Content]
+    internal let second: [Content]
     
     /// Initializes a statement
     ///
@@ -17,7 +17,7 @@ public struct Statement: Content {
     ///   - compound: The compound of conditionals
     ///   - first: The statement to execute if conditionals are true
     ///   - second: The statement to execute if conditionals are false
-    init(compound: Conditionable, first: [Content], second: [Content]) {
+    public init(compound: Conditionable, first: [Content], second: [Content]) {
         
         self.compound = compound
         self.first = first

--- a/Sources/HTMLKit/Framework/Extensions/Comparable+HTMLKit.swift
+++ b/Sources/HTMLKit/Framework/Extensions/Comparable+HTMLKit.swift
@@ -6,7 +6,7 @@ extension Comparable {
     ///   - other: The other value to compare
     ///
     /// - Returns: The result
-    public func equal(_ other: Any) -> Bool {
+    internal func equal(_ other: Any) -> Bool {
 
         guard let other = other as? Self else {
             return false
@@ -21,7 +21,7 @@ extension Comparable {
     ///   - other: The other value to compare
     ///
     /// - Returns: The result
-    public func unequal(_ other: Any) -> Bool {
+    internal func unequal(_ other: Any) -> Bool {
         return !equal(other)
     }
 
@@ -31,7 +31,7 @@ extension Comparable {
     ///   - other: The other value to compare
     ///
     /// - Returns: The result
-    public func greater(_ other: Any) -> Bool {
+    internal func greater(_ other: Any) -> Bool {
 
         guard let other = other as? Self else {
             return false
@@ -46,7 +46,7 @@ extension Comparable {
     ///   - other: The other value to compare
     ///
     /// - Returns: The result
-    public func less(_ other: Any) -> Bool {
+    internal func less(_ other: Any) -> Bool {
         return !greater(other)
     }
 }

--- a/Sources/HTMLKit/Framework/Extensions/Comparable+HTMLKit.swift
+++ b/Sources/HTMLKit/Framework/Extensions/Comparable+HTMLKit.swift
@@ -1,0 +1,52 @@
+extension Comparable {
+    
+    /// Checks for equality
+    ///
+    /// - Parameters:
+    ///   - other: The other value to compare
+    ///
+    /// - Returns: The result
+    public func equal(_ other: Any) -> Bool {
+
+        guard let other = other as? Self else {
+            return false
+        }
+
+        return other == self
+    }
+
+    /// Checks for inequality
+    ///
+    /// - Parameters:
+    ///   - other: The other value to compare
+    ///
+    /// - Returns: The result
+    public func unequal(_ other: Any) -> Bool {
+        return !equal(other)
+    }
+
+    /// Checks for a greater value
+    ///
+    /// - Parameters:
+    ///   - other: The other value to compare
+    ///
+    /// - Returns: The result
+    public func greater(_ other: Any) -> Bool {
+
+        guard let other = other as? Self else {
+            return false
+        }
+
+        return other > self
+    }
+
+    /// Checks for smaller value
+    ///
+    /// - Parameters:
+    ///   - other: The other value to compare
+    ///
+    /// - Returns: The result
+    public func less(_ other: Any) -> Bool {
+        return !greater(other)
+    }
+}

--- a/Sources/HTMLKit/Framework/Extensions/Datatypes+Content.swift
+++ b/Sources/HTMLKit/Framework/Extensions/Datatypes+Content.swift
@@ -15,8 +15,6 @@ extension Float: Content {}
 
 extension Int: Content {}
 
-extension Optional: Content{}
-
 extension String: Content {
     
     static public func + (lhs: Content, rhs: Self) -> Content {

--- a/Sources/HTMLKit/Framework/Extensions/Optional+HTMLKit.swift
+++ b/Sources/HTMLKit/Framework/Extensions/Optional+HTMLKit.swift
@@ -1,0 +1,9 @@
+extension Optional: Nullable {
+    
+    internal var isNull: Bool {
+        return self == nil
+    }
+}
+
+extension Optional: Content {
+}

--- a/Sources/HTMLKit/Framework/Primitives/Elements/Element.swift
+++ b/Sources/HTMLKit/Framework/Primitives/Elements/Element.swift
@@ -1,8 +1,3 @@
-/*
- Abstract:
- The file contains the default definition of an element. It defines which properties and methods an element should come with.
- */
-
 /// A type that represents any html-element.
 @_documentation(visibility: internal)
 public protocol Element: Content {
@@ -10,14 +5,31 @@ public protocol Element: Content {
 
 extension Element {
     
+    /// Sets the environment for the sub-content
+    ///
+    /// - Parameter key: The key
+    ///
+    /// - Returns: The environment modifier
     public func environment<V>(key: KeyPath<EnvironmentKeys, V>) -> EnvironmentModifier {
         return .init(key: key, content: [self])
     }
     
+    /// Supplies a value to the environment
+    ///
+    /// - Parameters:
+    ///   - key: The key to store the value with
+    ///   - value: The value to be stored
+    ///
+    /// - Returns: The environment modifier
     public func environment<V>(key: KeyPath<EnvironmentKeys, V>, value: V) -> EnvironmentModifier {
         return .init(key: key, value: value, content: [self])
     }
     
+    /// Supplies the object to the environment
+    ///
+    /// - Parameter object: The object to be stored
+    ///
+    /// - Returns: The environment modifier
     public func environment<T>(object: T) -> EnvironmentModifier {
         return .init(key: \T.self, value: object, content: [self])
     }

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -157,6 +157,10 @@ public final class Renderer {
                 }
             }
             
+            if let envstring = content as? EnvironmentString {
+                result += try render(envstring: envstring)
+            }
+            
             if let element = content as? String {
                 result += escape(content: element)
             }
@@ -241,6 +245,10 @@ public final class Renderer {
                     } else {
                         result += try render(markdown: string)
                     }
+                }
+                
+                if let envstring = content as? EnvironmentString {
+                    result += try render(envstring: envstring)
                 }
                 
                 if let element = content as? String {
@@ -370,6 +378,10 @@ public final class Renderer {
                     } else {
                         result += try render(markdown: string)
                     }
+                }
+                
+                if let envstring = content as? EnvironmentString {
+                    result += try render(envstring: envstring)
                 }
                 
                 if let element = content as? String {
@@ -593,6 +605,11 @@ public final class Renderer {
         return self.markdown.render(string: escape(content: markdown.raw))
     }
     
+    /// Renders a environment interpolation
+    private func render(envstring: EnvironmentString) throws -> String {
+        return try render(contents: envstring.values)
+    }
+    
     /// Converts specific charaters into encoded values.
     private func escape(attribute value: String) -> String {
         
@@ -669,6 +686,10 @@ public final class Renderer {
                 }
             }
             
+            if let envstring = content as? EnvironmentString {
+                result += try render(envstring: envstring)
+            }
+            
             if let element = content as? String {
                 result += escape(content: element)
             }
@@ -727,5 +748,9 @@ public final class Renderer {
         }
         
         result += "</\(element.name)>"
+    }
+    
+    private func render(loop envstring: EnvironmentString, with value: Any, on result: inout String) throws {
+        try render(loop: envstring.values, with: value, on: &result)
     }
 }

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -380,7 +380,7 @@ public final class Renderer {
                     case \.locale:
                         self.environment.locale = value as? Locale
                         
-                    case \.calender:
+                    case \.calendar:
                         self.environment.calendar = value as? Calendar
                         
                     case \.timeZone:

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -426,24 +426,26 @@ public final class Renderer {
     }
 
     /// Renders a environment statement
+    ///
+    /// - Parameter statement: The statement to resolve
+    ///
+    /// - Returns: The rendered condition
     private func render(statement: Statement) throws -> String {
         
         var result = false
         
-        if let condition = statement.compound as? Condition {
-            result = try environment.evaluate(condition: condition)
-        }
-        
-        if let negation = statement.compound as? Negation {
-            result = try environment.evaluate(negation: negation)
-        }
-        
-        if let relation = statement.compound as? Relation {
-            result = try environment.evaluate(relation: relation)
-        }
-        
-        if let value = statement.compound as? EnvironmentValue {
+        switch statement.compound {
+        case .value(let value):
             result = try environment.evaluate(value: value)
+            
+        case .condition(let condition):
+            result = try environment.evaluate(condition: condition)
+            
+        case .negation(let negation):
+            result = try environment.evaluate(negation: negation)
+            
+        case .relation(let relation):
+            result = try environment.evaluate(relation: relation)
         }
         
         if result {

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -435,6 +435,9 @@ public final class Renderer {
         var result = false
         
         switch statement.compound {
+        case .optional(let optional):
+            result = try environment.evaluate(optional: optional)
+            
         case .value(let value):
             result = try environment.evaluate(value: value)
             

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -479,8 +479,31 @@ public final class Renderer {
         
         var result = false
         
+        if let value = statement.compound as? EnvironmentValue {
+            
+            guard let parent = self.environment.retrieve(for: value.parentPath) else {
+                throw Errors.environmentObjectNotFound
+            }
+
+            guard let value = parent[keyPath: value.valuePath] else {
+                throw Errors.environmentValueNotFound
+            }
+            
+            guard let boolValue = value as? Bool else {
+                throw Errors.unableToCastEnvironmentValue
+            }
+            
+            if boolValue {
+                result = true
+            }
+        }
+        
         if let condition = statement.compound as? Condition {
             result = try render(condition: condition)
+        }
+        
+        if let negation = statement.compound as? Negation {
+            result = try render(negation: negation)
         }
         
         if let relation = statement.compound as? Relation {
@@ -492,6 +515,30 @@ public final class Renderer {
         }
         
         return try render(contents: statement.second)
+    }
+    
+    private func render(negation: Negation) throws -> Bool {
+        
+        if let value = negation.lhs as? EnvironmentValue {
+            
+            guard let parent = self.environment.retrieve(for: value.parentPath) else {
+                throw Errors.environmentObjectNotFound
+            }
+
+            guard let value = parent[keyPath: value.valuePath] else {
+                throw Errors.environmentValueNotFound
+            }
+            
+            guard let boolValue = value as? Bool else {
+                throw Errors.unableToCastEnvironmentValue
+            }
+            
+            if !boolValue {
+                return true
+            }
+        }
+        
+        return false
     }
     
     private func render(relation: Relation) throws -> Bool {

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -369,31 +369,6 @@ public final class Renderer {
         
         if let value = modifier.value {
             self.environment.upsert(value, for: modifier.key)
-            
-        } else {
-            
-            if let value = self.environment.retrieve(for: modifier.key) {
-                
-                if let key = modifier.key as? PartialKeyPath<EnvironmentKeys> {
-                    
-                    switch key {
-                    case \.locale:
-                        self.environment.locale = value as? Locale
-                        
-                    case \.calendar:
-                        self.environment.calendar = value as? Calendar
-                        
-                    case \.timeZone:
-                        self.environment.timeZone = value as? TimeZone
-                        
-                    case \.colorScheme:
-                        self.environment.colorScheme = value as? String
-                        
-                    default:
-                        throw Errors.unindendedEnvironmentKey
-                    }
-                }
-            }
         }
         
         return try render(contents: modifier.content)

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -119,7 +119,7 @@ extension Request {
     }
 }
 
-extension HTMLKit.Renderer.Errors: AbortError {
+extension HTMLKit.Environment.Errors: AbortError {
  
     @_implements(AbortError, reason)
     public var abortReason: String { self.description }
@@ -127,7 +127,7 @@ extension HTMLKit.Renderer.Errors: AbortError {
     public var status: HTTPResponseStatus { .internalServerError }
 }
 
-extension HTMLKit.Renderer.Errors: DebuggableError {
+extension HTMLKit.Environment.Errors: DebuggableError {
 
     @_implements(DebuggableError, reason)
     public var debuggableReason: String {  self.description }

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -112,7 +112,7 @@ extension Request {
     public var htmlkit: ViewRenderer {
         
         if let acceptLanguage = self.acceptLanguage {
-            self.application.htmlkit.environment.locale = HTMLKit.Locale(tag: acceptLanguage)
+            self.application.htmlkit.environment.upsert(HTMLKit.Locale(tag: acceptLanguage), for: \HTMLKit.EnvironmentKeys.locale)
         }
         
         return .init(eventLoop: self.eventLoop, configuration: self.application.htmlkit.configuration, logger: self.logger)

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -336,4 +336,34 @@ final class EnvironmentTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests the string interpolation with an environment value
+    ///
+    /// The renderer is expected to render the string correctly
+    func testStringInterpolationWithEnvironment() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let name: String = "Jane"
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+                    EnvironmentString("Hello, how are you \(object.name)?")
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>Hello, how are you Jane?</p>
+                       """
+        )
+    }
 }

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -71,4 +71,233 @@ final class EnvironmentTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests condtion evaluation for the environment
+    ///
+    /// The renderer is expected to evaluated the condition correctly and renderer the right statement based on the condition.
+    func testEnvironmentCondition() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let firstName: String = "Jane"
+            let lastName: String = "Doe"
+            let age: Int = 40
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+
+                    // Should return false
+                    Environment.when(object.firstName == "John") {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+
+                    // The counter test, should return true
+                    Environment.when(object.firstName == "Jane") {
+                        "True"
+                    }
+
+                    // Should return true
+                    Environment.when(object.firstName != "John") {
+                        "True"
+                    }
+                    
+                    // The counter test, should return false
+                    Environment.when(object.firstName != "Jane") {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+
+                    // Should return false
+                    Environment.when(object.age > 41) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+
+                    // The counter test, should return true
+                    Environment.when(object.age > 39) {
+                        "True"
+                    }
+                    
+                    // Should return true
+                    Environment.when(object.age < 41) {
+                        "True"
+                    }
+
+                    // The counter test, should return false
+                    Environment.when(object.age < 39) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>FalseTrueTrueFalseFalseTrueTrueFalse</p>
+                       """
+        )
+    }
+    
+    /// Tests the evaluation of a statement with a conjunctional relation
+    func testConditionConjuction() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let firstName: String = "Jane"
+            let lastName: String = "Doe"
+            let age: Int = 40
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+                    
+                    // The relation is true, cause both conditions are true
+                    Environment.when(object.age > 39 && object.age < 41) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
+                    // The relation is false, cause both conditions are false
+                    Environment.when(object.age < 39 && object.age > 41) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
+                    // The relation is false, cause the first condition is false
+                    Environment.when(object.age > 41 && object.age > 39) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
+                    // The relation is false, cause the second condition is false
+                    Environment.when(object.age > 39 && object.age > 41) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>TrueFalseFalseFalse</p>
+                       """
+        )
+    }
+    
+    /// Tests the evaluation of a statement with a disjunctional relation
+    func testConditionDisjunction() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let firstName: String = "Jane"
+            let lastName: String = "Doe"
+            let age: Int = 40
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+                    
+                    // The relation is true, cause the second condition is true
+                    Environment.when(object.age > 41 || object.age == 40) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
+                    // The relation is true, cause the first condition is true
+                    Environment.when(object.age == 40 || object.age > 41) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
+                    // The relation is false, cause all conditions are false
+                    Environment.when(object.age == 50 || object.age > 41) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>TrueTrueFalse</p>
+                       """
+        )
+    }
+    
+    /// Tests the evaluation of various relation combinations
+    func testConditionConjunctionAndDisjunction() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let firstName = "Jane"
+            let lastName = "Doe"
+            let age = 40
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+                    
+                    // The statement is true, cause the first relation is true
+                    Environment.when(object.age == 40 || object.age > 41 && object.age < 39) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
+                    // The statement is true, cause the second relation is true
+                    Environment.when(object.age == 50 || object.age < 41 && object.age > 39) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>TrueTrue</p>
+                       """
+        )
+    }
 }

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -82,6 +82,7 @@ final class EnvironmentTests: XCTestCase {
             let firstName: String = "Jane"
             let lastName: String = "Doe"
             let age: Int = 40
+            let loggedIn: Bool = true
         }
         
         struct TestView: View {
@@ -92,6 +93,18 @@ final class EnvironmentTests: XCTestCase {
             var body: Content {
                 Paragraph {
 
+                    // Should return true
+                    Environment.when(object.loggedIn) {
+                        "True"
+                    }
+                    
+                    // Should return false
+                    Environment.when(!object.loggedIn) {
+                        "True"
+                    } then: {
+                        "False"
+                    }
+                    
                     // Should return false
                     Environment.when(object.firstName == "John") {
                         "True"
@@ -146,7 +159,7 @@ final class EnvironmentTests: XCTestCase {
         
         XCTAssertEqual(try renderer.render(view: TestView()),
                        """
-                       <p>FalseTrueTrueFalseFalseTrueTrueFalse</p>
+                       <p>TrueFalseFalseTrueTrueFalseFalseTrueTrueFalse</p>
                        """
         )
     }

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -300,4 +300,40 @@ final class EnvironmentTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests the iteration over a sequence of environment values
+    func testEnvironmentLoop() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let name: String = "Jane"
+            let children: [String] = ["Janek", "Janet"]
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+                    Environment.loop(object.children) { child in
+                        Paragraph {
+                            child
+                        }
+                    }
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>\
+                       <p>Janek</p>\
+                       <p>Janet</p>\
+                       </p>
+                       """
+        )
+    }
 }

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -350,6 +350,49 @@ final class EnvironmentTests: XCTestCase {
         )
     }
     
+    /// Tests the conditional rendering based on an optional environment value
+    ///
+    /// The renderer is expected to evaluate the presence of the value and render the right content
+    /// accordingly.
+    func testEnvironmentUnwrap() throws {
+        
+        struct TestObject: ViewModel {
+            
+            let some: String? = "Some"
+            let none: String? = nil
+        }
+        
+        struct TestView: View {
+            
+            @EnvironmentObject(TestObject.self)
+            var object
+            
+            var body: Content {
+                Paragraph {
+                    
+                    // Should return none, cause the value is nil
+                    Environment.unwrap(object.none) { value in
+                        value
+                    } then: {
+                        "None"
+                    }
+                    
+                    // Should return the value
+                    Environment.unwrap(object.some) { value in
+                        value
+                    }
+                }
+                .environment(object: TestObject())
+            }
+        }
+        
+        XCTAssertEqual(try renderer.render(view: TestView()),
+                       """
+                       <p>NoneSome</p>
+                       """
+        )
+    }
+    
     /// Tests the string interpolation with an environment value
     ///
     /// The renderer is expected to render the string correctly

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -80,7 +80,6 @@ final class EnvironmentTests: XCTestCase {
         struct TestObject: ViewModel {
             
             let firstName = "Jane"
-            let lastName = "Doe"
             let age = 40
             let loggedIn = true
         }
@@ -169,8 +168,6 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let firstName = "Jane"
-            let lastName = "Doe"
             let age = 40
         }
         
@@ -226,8 +223,6 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let firstName = "Jane"
-            let lastName = "Doe"
             let age = 40
         }
         
@@ -276,8 +271,6 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let firstName = "Jane"
-            let lastName = "Doe"
             let age = 40
         }
         
@@ -319,7 +312,6 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let name = "Jane"
             let children = ["Janek", "Janet"]
         }
         

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -1,64 +1,71 @@
-/*
- Abstract:
- The file tests the annotations.
- */
-
 import HTMLKit
 import XCTest
 
 final class EnvironmentTests: XCTestCase {
     
-    struct Object: Encodable {
-        
-        var title: String = "Welcome to WWDC"
-        var name: String = "Mattes!"
-        var image: String = "wwdc.jpeg"
-    }
+    var renderer = Renderer()
     
-    struct ParentView: View {
+    /// Tests the environment access through the environment object
+    ///
+    /// The renderer is expected to evaluate the placeholder and renderer the resulting value.
+    func testEnvironmentAccess() throws {
         
-        var content: [Content]
-        
-        init(@ContentBuilder<Content> content: () -> [Content]) {
-            self.content = content()
+        struct FamilyObject: ViewModel {
+            
+            let name: String = "Doe"
+            let father: FatherObject = FatherObject()
         }
         
-        var body: Content {
-            Division {
-                content
+        struct FatherObject: ViewModel {
+            
+            let avatar: String = "john_doe.jpeg"
+            let name: String = "John"
+        }
+        
+        struct ParentView: View {
+            
+            let content: [Content]
+            
+            init(@ContentBuilder<Content> content: () -> [Content]) {
+                self.content = content()
             }
-            .environment(object: Object())
+            
+            var body: Content {
+                Division {
+                    content
+                }
+                .environment(object: FamilyObject())
+            }
         }
-    }
-    
-    struct ChildView: View {
         
-        @EnvironmentObject(Object.self)
-        var object
-        
-        var body: Content {
-            ParentView {
-                Section{
-                    Image()
-                        .source(object.image)
-                    Heading2 {
-                        object.title + " " + object.name
+        struct ChildView: View {
+            
+            @EnvironmentObject(FamilyObject.self)
+            var object
+            
+            var body: Content {
+                ParentView {
+                    Section{
+                        Image()
+                            .source(object.father.avatar)
+                        Heading1 {
+                            object.name
+                        }
+                        Paragraph {
+                            object.father.name + " " + object.name
+                        }
                     }
                 }
             }
         }
-    }
-    
-    var renderer = Renderer()
-    
-    func testEnvironment() throws {
         
         XCTAssertEqual(try renderer.render(view: ChildView()),
                        """
                        <div>\
                        <section>\
-                       <img src="wwdc.jpeg">\
-                       <h2>Welcome to WWDC Mattes!</h2>\
+                       <img src="john_doe.jpeg">\
+                       <h1>Doe</h1>\
+                       <p>John Doe</p>\
                        </section>\
                        </div>
                        """

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -12,14 +12,14 @@ final class EnvironmentTests: XCTestCase {
         
         struct FamilyObject: ViewModel {
             
-            let name: String = "Doe"
-            let father: FatherObject = FatherObject()
+            let name = "Doe"
+            let father = FatherObject()
         }
         
         struct FatherObject: ViewModel {
             
-            let avatar: String = "john_doe.jpeg"
-            let name: String = "John"
+            let avatar = "john_doe.jpeg"
+            let name = "John"
         }
         
         struct ParentView: View {
@@ -79,10 +79,10 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let firstName: String = "Jane"
-            let lastName: String = "Doe"
-            let age: Int = 40
-            let loggedIn: Bool = true
+            let firstName = "Jane"
+            let lastName = "Doe"
+            let age = 40
+            let loggedIn = true
         }
         
         struct TestView: View {
@@ -169,9 +169,9 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let firstName: String = "Jane"
-            let lastName: String = "Doe"
-            let age: Int = 40
+            let firstName = "Jane"
+            let lastName = "Doe"
+            let age = 40
         }
         
         struct TestView: View {
@@ -226,9 +226,9 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let firstName: String = "Jane"
-            let lastName: String = "Doe"
-            let age: Int = 40
+            let firstName = "Jane"
+            let lastName = "Doe"
+            let age = 40
         }
         
         struct TestView: View {
@@ -319,8 +319,8 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let name: String = "Jane"
-            let children: [String] = ["Janek", "Janet"]
+            let name = "Jane"
+            let children = ["Janek", "Janet"]
         }
         
         struct TestView: View {
@@ -357,7 +357,7 @@ final class EnvironmentTests: XCTestCase {
         
         struct TestObject: ViewModel {
             
-            let name: String = "Jane"
+            let name = "Jane"
         }
         
         struct TestView: View {

--- a/Tests/HTMLKitTests/EnvironmentTests.swift
+++ b/Tests/HTMLKitTests/EnvironmentTests.swift
@@ -93,60 +93,60 @@ final class EnvironmentTests: XCTestCase {
                 Paragraph {
 
                     // Should return true
-                    Environment.when(object.loggedIn) {
+                    Environment.check(object.loggedIn) {
                         "True"
                     }
                     
                     // Should return false
-                    Environment.when(!object.loggedIn) {
+                    Environment.check(!object.loggedIn) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // Should return false
-                    Environment.when(object.firstName == "John") {
+                    Environment.check(object.firstName == "John") {
                         "True"
                     } then: {
                         "False"
                     }
 
                     // The counter test, should return true
-                    Environment.when(object.firstName == "Jane") {
+                    Environment.check(object.firstName == "Jane") {
                         "True"
                     }
 
                     // Should return true
-                    Environment.when(object.firstName != "John") {
+                    Environment.check(object.firstName != "John") {
                         "True"
                     }
                     
                     // The counter test, should return false
-                    Environment.when(object.firstName != "Jane") {
+                    Environment.check(object.firstName != "Jane") {
                         "True"
                     } then: {
                         "False"
                     }
 
                     // Should return false
-                    Environment.when(object.age > 41) {
+                    Environment.check(object.age > 41) {
                         "True"
                     } then: {
                         "False"
                     }
 
                     // The counter test, should return true
-                    Environment.when(object.age > 39) {
+                    Environment.check(object.age > 39) {
                         "True"
                     }
                     
                     // Should return true
-                    Environment.when(object.age < 41) {
+                    Environment.check(object.age < 41) {
                         "True"
                     }
 
                     // The counter test, should return false
-                    Environment.when(object.age < 39) {
+                    Environment.check(object.age < 39) {
                         "True"
                     } then: {
                         "False"
@@ -180,28 +180,28 @@ final class EnvironmentTests: XCTestCase {
                 Paragraph {
                     
                     // The relation is true, cause both conditions are true
-                    Environment.when(object.age > 39 && object.age < 41) {
+                    Environment.check(object.age > 39 && object.age < 41) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // The relation is false, cause both conditions are false
-                    Environment.when(object.age < 39 && object.age > 41) {
+                    Environment.check(object.age < 39 && object.age > 41) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // The relation is false, cause the first condition is false
-                    Environment.when(object.age > 41 && object.age > 39) {
+                    Environment.check(object.age > 41 && object.age > 39) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // The relation is false, cause the second condition is false
-                    Environment.when(object.age > 39 && object.age > 41) {
+                    Environment.check(object.age > 39 && object.age > 41) {
                         "True"
                     } then: {
                         "False"
@@ -235,21 +235,21 @@ final class EnvironmentTests: XCTestCase {
                 Paragraph {
                     
                     // The relation is true, cause the second condition is true
-                    Environment.when(object.age > 41 || object.age == 40) {
+                    Environment.check(object.age > 41 || object.age == 40) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // The relation is true, cause the first condition is true
-                    Environment.when(object.age == 40 || object.age > 41) {
+                    Environment.check(object.age == 40 || object.age > 41) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // The relation is false, cause all conditions are false
-                    Environment.when(object.age == 50 || object.age > 41) {
+                    Environment.check(object.age == 50 || object.age > 41) {
                         "True"
                     } then: {
                         "False"
@@ -283,14 +283,14 @@ final class EnvironmentTests: XCTestCase {
                 Paragraph {
                     
                     // The statement is true, cause the first relation is true
-                    Environment.when(object.age == 40 || object.age > 41 && object.age < 39) {
+                    Environment.check(object.age == 40 || object.age > 41 && object.age < 39) {
                         "True"
                     } then: {
                         "False"
                     }
                     
                     // The statement is true, cause the second relation is true
-                    Environment.when(object.age == 50 || object.age < 41 && object.age > 39) {
+                    Environment.check(object.age == 50 || object.age < 41 && object.age > 39) {
                         "True"
                     } then: {
                         "False"

--- a/Tests/HTMLKitVaporTests/ProviderTests.swift
+++ b/Tests/HTMLKitVaporTests/ProviderTests.swift
@@ -411,7 +411,7 @@ final class ProviderTests: XCTestCase {
             
             var body: HTMLKit.Content {
                 Paragraph {
-                    Environment.when(object.firstName) {
+                    Environment.check(object.firstName) {
                         "True"
                     }
                 }
@@ -425,7 +425,7 @@ final class ProviderTests: XCTestCase {
             
             var body: HTMLKit.Content {
                 Paragraph {
-                    Environment.when(object.firstName) {
+                    Environment.check(object.firstName) {
                         "True"
                     }
                 }

--- a/Tests/HTMLKitVaporTests/ProviderTests.swift
+++ b/Tests/HTMLKitVaporTests/ProviderTests.swift
@@ -42,7 +42,6 @@ final class ProviderTests: XCTestCase {
                         content
                     }
                 }
-                .environment(object: TestObject())
             }
         }
         
@@ -192,11 +191,16 @@ final class ProviderTests: XCTestCase {
         }
     }
     
+    /// Tests the access to environment through provider
+    ///
+    /// The provider is expected to recieve the environment object and resolve it based on the request.
     func testEnvironmentIntegration() throws {
         
         let app = Application(.testing)
         
         defer { app.shutdown() }
+        
+        app.htmlkit.environment.upsert(TestObject(), for: \TestObject.self)
         
         app.get("test") { request async throws -> Vapor.View in
             return try await request.htmlkit.render(TestPage.SipplingView())


### PR DESCRIPTION
This pull request adds statements to the environment allowing views to be shown based on conditional terms or to loop over a sequence within an environment context, while it is unfortunately not feasible with native statements.

```swift
Environment.check(user.loggedIn) {
   Paragraph {
      "True"
   }
}

Environment.check(user.lastName == "Polo" && user.firstName == "Marco") {
   Paragraph {
      "True"
   }
} then: {
   Paragraph {
      "False"
   }
}

Environment.loop(user.roles) { role in
   Paragraph {
      role
   }
}

Environment.unwrap(user.avatar) { avatar in
   Image()
      .source(avatar)
} then: {
   Paragraph {
      "No image found"
   }
}
```

I also want to state that I am not completely satisfied with the naming yet and may change it in the future.