### PR TITLE
Make area element an empty node

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -31,6 +31,9 @@ public struct Area: EmptyNode, MapElement {
     /// Creates a area
     public init() {}
     
+    @available(*, deprecated, message: "The area element is actually an empty element. Use Area() instead.")
+    public init(@ContentBuilder<Content> content: () -> [Content]) {}
+    
     internal init(attributes: OrderedDictionary<String, Any>?) {
         self.attributes = attributes
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -8,26 +8,31 @@
 
 import OrderedCollections
 
-/// The element defines an image map.
+/// A element that defines an image map area.
 ///
-/// ```html
-/// <area></area>
+/// Use `Area` to define specific clickable regions within an image map.
+///
+/// ```swift
+/// Image()
+///     .source(...png)
+///     .useMap("#...")
+/// Map {
+///     Area()
+///         .coordinates("...")
+/// }
+/// .name("...")
 /// ```
-public struct Area: ContentNode, MapElement {
+public struct Area: EmptyNode, MapElement {
 
     internal var name: String { "area" }
 
     internal var attributes: OrderedDictionary<String, Any>?
 
-    internal var content: [Content]
-
-    public init(@ContentBuilder<Content> content: () -> [Content]) {
-        self.content = content()
-    }
+    /// Creates a area
+    public init() {}
     
-    internal init(attributes: OrderedDictionary<String, Any>?, content: [Content]) {
+    internal init(attributes: OrderedDictionary<String, Any>?) {
         self.attributes = attributes
-        self.content = content
     }
     
     public func modify(if condition: Bool, element: (Area) -> Area) -> Area {

--- a/Tests/HTMLKitTests/ElementTests.swift
+++ b/Tests/HTMLKitTests/ElementTests.swift
@@ -1142,12 +1142,12 @@ final class ElementTests: XCTestCase {
     func testAreaElement() throws {
         
         let view = TestView {
-            Area {}
+            Area()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
-                       <area></area>
+                       <area>
                        """
         )
     }


### PR DESCRIPTION
The area element should have been an empty node from the start. This pull request corrects that.