### PR TITLE
Make the scope modifier accept an enum

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -2189,16 +2189,26 @@ extension SandboxAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides the element with the scope handler.
+/// A type that provides the `scope` modifier.
 @_documentation(visibility: internal)
 public protocol ScopeAttribute: Attribute {
     
-    /// The function represents the html-attribute 'scope'.
+    /// Define the scope for a header cell
     ///
-    /// ```html
-    /// <tag scope="" />
+    /// It specifies wether the cell is for a column, row or a group of columns
+    /// and rows.
+    ///
+    /// ```swift
+    /// TableRow {
+    ///     HeaderCell {
+    ///         "..."
+    ///     }
+    ///     .scope(.column)
+    /// }
     /// ```
-    func scope(_ value: String) -> Self
+    ///
+    /// - Parameter value: The scope of the header cell
+    func scope(_ value: Values.Scope) -> Self
 }
 
 extension ScopeAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -2321,6 +2321,10 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(scope: value)
     }
     
+    public func scope(_ value: Values.Scope) -> HeaderCell {
+        return mutate(scope: value.rawValue)
+    }
+    
     public func popover(_ value: Values.Popover.State) -> HeaderCell {
         return mutate(popover: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -2316,7 +2316,8 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     public func headers(_ value: String) -> HeaderCell {
         return mutate(headers: value)
     }
-    
+
+    @available(*, deprecated, message: "The scope attribute is actually an enumerated attribute. Use the scope(_: Scope) modifier instead.")
     public func scope(_ value: String) -> HeaderCell {
         return mutate(scope: value)
     }

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -958,4 +958,27 @@ public enum Values {
             case hide
         }
     }
+    
+    /// A enumeration of potential scopes for a header cell.
+    ///
+    /// ```swift
+    /// HeaderCell {
+    ///     "..."
+    /// }
+    /// .scope(.column)
+    /// ```
+    public enum Scope: String {
+        
+        /// The cell applies to subsequent cells in the same row.
+        case row
+        
+        /// The cell applies to subsequent cells in the same column.
+        case column = "col"
+        
+        /// The cell applies to all remaining cells in the row group.
+        case rowGroup = "rowgroup"
+        
+        /// The cell applies to all remaining cells in the column group.
+        case columnGroup = "colgroup"
+    }
 }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -435,8 +435,8 @@ final class AttributesTests: XCTestCase {
             return self.mutate(sandbox: "sandbox")
         }
         
-        func scope(_ value: String) -> Tag {
-            return self.mutate(scope: value)
+        func scope(_ value: Values.Scope) -> Tag {
+            return self.mutate(scope: value.rawValue)
         }
         
         func shape(_ value: Values.Shape) -> Tag {
@@ -1832,12 +1832,18 @@ final class AttributesTests: XCTestCase {
     func testScopeAttribute() throws {
         
         let view = TestView {
-            Tag {}.scope("scope")
+            Tag {}.scope(.column)
+            Tag {}.scope(.row)
+            Tag {}.scope(.columnGroup)
+            Tag {}.scope(.rowGroup)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
-                       <tag scope="scope"></tag>
+                       <tag scope="col"></tag>\
+                       <tag scope="row"></tag>\
+                       <tag scope="colgroup"></tag>\
+                       <tag scope="rowgroup"></tag>
                        """
         )
     }


### PR DESCRIPTION
The scope attribute is actually an enumerated attribute. Therefore the modifier should accept an enum. This pull request corrects that.