### PR TITLE
Make the inputmode modifier accept an enum 

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -1113,16 +1113,19 @@ extension IsMapAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides the element with the inputmode handler.
+/// A type that provides the `inputMode` modifier.
 @_documentation(visibility: internal)
 public protocol InputModeAttribute: Attribute {
- 
-    /// The function represents the html-attribute 'inputmode'.
+    
+    /// Set the virtual keyboard mode for the editable element.
     ///
-    /// ```html
-    /// <tag inputmode="" />
+    /// ```swift
+    /// Input()
+    ///     .inputMode(.numeric)
     /// ```
-    func inputMode(_ value: String) -> Self
+    ///
+    /// - Parameter value: The mode to set on
+    func inputMode(_ value: Values.Mode) -> Self
 }
 
 extension InputModeAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -124,6 +124,7 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Html {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -127,6 +127,10 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
     public func inputMode(_ value: String) -> Html {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Html {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Html {
         return mutate(is: value)

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -459,6 +459,10 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func inputMode(_ value: String) -> Article {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Article {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Article {
         return mutate(is: value)
@@ -729,6 +733,10 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func inputMode(_ value: String) -> Section {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Section {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Section {
         return mutate(is: value)
@@ -998,6 +1006,10 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func inputMode(_ value: String) -> Navigation {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Navigation {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Navigation {
@@ -1270,6 +1282,10 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Aside {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Aside {
         return mutate(is: value)
     }
@@ -1538,6 +1554,10 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func inputMode(_ value: String) -> Heading1 {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Heading1 {
+        return mutate(inputmode: value.rawValue)
     }
     
     public func `is`(_ value: String) -> Heading1 {
@@ -1817,6 +1837,10 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(inputmode: value)
     }
     
+    public func inputMode(_ value: Values.Mode) -> Heading2 {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Heading2 {
         return mutate(is: value)
     }
@@ -2092,6 +2116,10 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> Heading3 {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Heading3 {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Heading3 {
@@ -2370,6 +2398,10 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func inputMode(_ value: String) -> Heading4 {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Heading4 {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Heading4 {
         return mutate(is: value)
@@ -2647,6 +2679,10 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func inputMode(_ value: String) -> Heading5 {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Heading5 {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Heading5 {
         return mutate(is: value)
@@ -2923,6 +2959,10 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> Heading6 {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Heading6 {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Heading6 {
@@ -3202,6 +3242,10 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> HeadingGroup {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> HeadingGroup {
         return mutate(is: value)
     }
@@ -3470,6 +3514,10 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
 
     public func inputMode(_ value: String) -> Header {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Header {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Header {
@@ -3741,6 +3789,10 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     public func inputMode(_ value: String) -> Footer {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Footer {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Footer {
         return mutate(is: value)
@@ -4011,6 +4063,10 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func inputMode(_ value: String) -> Address {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Address {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Address {
         return mutate(is: value)
@@ -4280,6 +4336,10 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func inputMode(_ value: String) -> Paragraph {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Paragraph {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Paragraph {
@@ -4553,6 +4613,10 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
     public func inputMode(_ value: String) -> HorizontalRule {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> HorizontalRule {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> HorizontalRule {
         return mutate(is: value)
@@ -4822,6 +4886,10 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
 
     public func inputMode(_ value: String) -> PreformattedText {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> PreformattedText {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> PreformattedText {
@@ -5094,6 +5162,10 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Blockquote {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Blockquote {
         return mutate(is: value)
     }
@@ -5373,6 +5445,10 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func inputMode(_ value: String) -> OrderedList {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> OrderedList {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> OrderedList {
@@ -5656,6 +5732,10 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
     public func inputMode(_ value: String) -> UnorderedList {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> UnorderedList {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> UnorderedList {
         return mutate(is: value)
@@ -5927,6 +6007,10 @@ extension Menu: GlobalAttributes {
         return mutate(inputmode: value)
     }
     
+    public func inputMode(_ value: Values.Mode) -> Menu {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Menu {
         return mutate(is: value)
     }
@@ -6099,6 +6183,10 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
 
     public func inputMode(_ value: String) -> DescriptionList {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> DescriptionList {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> DescriptionList {
@@ -6370,6 +6458,10 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     public func inputMode(_ value: String) -> Figure {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Figure {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Figure {
         return mutate(is: value)
@@ -6639,6 +6731,10 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func inputMode(_ value: String) -> Anchor {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Anchor {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Anchor {
@@ -6954,6 +7050,10 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Emphasize {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Emphasize {
         return mutate(is: value)
     }
@@ -7224,6 +7324,10 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Strong {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Strong {
         return mutate(is: value)
     }
@@ -7492,6 +7596,10 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func inputMode(_ value: String) -> Small {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Small {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Small {
@@ -7770,6 +7878,10 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
     public func inputMode(_ value: String) -> StrikeThrough {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> StrikeThrough {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> StrikeThrough {
         return mutate(is: value)
@@ -7972,6 +8084,10 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Main {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Main {
         return mutate(is: value)
     }
@@ -8242,6 +8358,10 @@ extension Search: GlobalAttributes {
         return mutate(inputmode: value)
     }
     
+    public func inputMode(_ value: Values.Mode) -> Search {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Search {
         return mutate(is: value)
     }
@@ -8414,6 +8534,10 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> Division {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Division {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Division {
@@ -8685,6 +8809,10 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     public func inputMode(_ value: String) -> Definition {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Definition {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Definition {
         return mutate(is: value)
@@ -8955,6 +9083,10 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func inputMode(_ value: String) -> Cite {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Cite {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Cite {
         return mutate(is: value)
@@ -9224,6 +9356,10 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     
     public func inputMode(_ value: String) -> ShortQuote {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> ShortQuote {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> ShortQuote {
@@ -9499,6 +9635,10 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
     public func inputMode(_ value: String) -> Abbreviation {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Abbreviation {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Abbreviation {
         return mutate(is: value)
@@ -9770,6 +9910,10 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(inputmode: value)
     }
     
+    public func inputMode(_ value: Values.Mode) -> Ruby {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Ruby {
         return mutate(is: value)
     }
@@ -10038,6 +10182,10 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
 
     public func inputMode(_ value: String) -> Data {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Data {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Data {
@@ -10312,6 +10460,10 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
 
     public func inputMode(_ value: String) -> Time {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Time {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Time {
@@ -10588,6 +10740,10 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Code {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Code {
         return mutate(is: value)
     }
@@ -10856,6 +11012,10 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> Variable {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Variable {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Variable {
@@ -11128,6 +11288,10 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> SampleOutput {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> SampleOutput {
         return mutate(is: value)
     }
@@ -11396,6 +11560,10 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
 
     public func inputMode(_ value: String) -> KeyboardInput {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> KeyboardInput {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> KeyboardInput {
@@ -11667,6 +11835,10 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func inputMode(_ value: String) -> Subscript {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Subscript {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Subscript {
         return mutate(is: value)
@@ -11935,6 +12107,10 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func inputMode(_ value: String) -> Superscript {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Superscript {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Superscript {
@@ -12207,6 +12383,10 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Italic {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Italic {
         return mutate(is: value)
     }
@@ -12482,6 +12662,10 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func inputMode(_ value: String) -> Bold {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Bold {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Bold {
@@ -12760,6 +12944,10 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func inputMode(_ value: String) -> Underline {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Underline {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Underline {
         return mutate(is: value)
@@ -13037,6 +13225,10 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func inputMode(_ value: String) -> Mark {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Mark {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Mark {
         return mutate(is: value)
@@ -13307,6 +13499,10 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func inputMode(_ value: String) -> Bdi {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Bdi {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Bdi {
         return mutate(is: value)
@@ -13571,6 +13767,10 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func inputMode(_ value: String) -> Bdo {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Bdo {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Bdo {
@@ -13842,6 +14042,10 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     public func inputMode(_ value: String) -> Span {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Span {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Span {
         return mutate(is: value)
@@ -14106,6 +14310,10 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func inputMode(_ value: String) -> LineBreak {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> LineBreak {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> LineBreak {
@@ -14373,6 +14581,10 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> WordBreak {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> WordBreak {
         return mutate(is: value)
     }
@@ -14643,6 +14855,10 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> InsertedText {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> InsertedText {
         return mutate(is: value)
     }
@@ -14919,6 +15135,10 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func inputMode(_ value: String) -> DeletedText {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> DeletedText {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> DeletedText {
@@ -15198,6 +15418,10 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
     public func inputMode(_ value: String) -> Picture {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Picture {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Picture {
         return mutate(is: value)
@@ -15388,6 +15612,10 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Image {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Image {
         return mutate(is: value)
     }
@@ -15701,6 +15929,10 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     public func inputMode(_ value: String) -> InlineFrame {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> InlineFrame {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> InlineFrame {
         return mutate(is: value)
@@ -15994,6 +16226,10 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     public func inputMode(_ value: String) -> Embed {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Embed {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Embed {
         return mutate(is: value)
@@ -16283,6 +16519,10 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func inputMode(_ value: String) -> Object {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Object {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Object {
@@ -16577,6 +16817,10 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func inputMode(_ value: String) -> Video {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Video {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Video {
@@ -16893,6 +17137,10 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     public func inputMode(_ value: String) -> Audio {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Audio {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Audio {
         return mutate(is: value)
@@ -17200,6 +17448,10 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
     public func inputMode(_ value: String) -> Map {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Map {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Map {
         return mutate(is: value)
@@ -17397,6 +17649,10 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
 
     public func inputMode(_ value: String) -> Form {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Form {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Form {
@@ -17697,6 +17953,10 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> DataList {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> DataList {
         return mutate(is: value)
     }
@@ -17965,6 +18225,10 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func inputMode(_ value: String) -> Output {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Output {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Output {
@@ -18249,6 +18513,10 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Progress {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Progress {
         return mutate(is: value)
     }
@@ -18527,6 +18795,10 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Meter {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Meter {
         return mutate(is: value)
     }
@@ -18821,6 +19093,10 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Details {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Details {
         return mutate(is: value)
     }
@@ -19093,6 +19369,10 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func inputMode(_ value: String) -> Dialog {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Dialog {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Dialog {
@@ -19368,6 +19648,10 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
     public func inputMode(_ value: String) -> Script {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Script {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Script {
         return mutate(is: value)
@@ -19591,6 +19875,10 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> NoScript {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> NoScript {
         return mutate(is: value)
     }
@@ -19783,6 +20071,10 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
 
     public func inputMode(_ value: String) -> Template {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Template {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Template {
@@ -19983,6 +20275,10 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Canvas {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Canvas {
         return mutate(is: value)
     }
@@ -20261,6 +20557,10 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Table {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Table {
         return mutate(is: value)
     }
@@ -20645,6 +20945,10 @@ extension Slot: GlobalAttributes, NameAttribute {
     
     public func inputMode(_ value: String) -> Slot {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Slot {
+        return mutate(inputmode: value.rawValue)
     }
     
     public func `is`(_ value: String) -> Slot {

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -456,6 +456,7 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Article {
         return mutate(inputmode: value)
     }
@@ -730,6 +731,7 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Section {
         return mutate(inputmode: value)
     }
@@ -1004,6 +1006,7 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Navigation {
         return mutate(inputmode: value)
     }
@@ -1278,6 +1281,7 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Aside {
         return mutate(inputmode: value)
     }
@@ -1552,6 +1556,7 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Heading1 {
         return mutate(inputmode: value)
     }
@@ -1833,6 +1838,7 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Heading2 {
         return mutate(inputmode: value)
     }
@@ -2114,6 +2120,7 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Heading3 {
         return mutate(inputmode: value)
     }
@@ -2395,6 +2402,7 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Heading4 {
         return mutate(inputmode: value)
     }
@@ -2676,6 +2684,7 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Heading5 {
         return mutate(inputmode: value)
     }
@@ -2957,6 +2966,7 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Heading6 {
         return mutate(inputmode: value)
     }
@@ -3238,6 +3248,7 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> HeadingGroup {
         return mutate(inputmode: value)
     }
@@ -3512,6 +3523,7 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Header {
         return mutate(inputmode: value)
     }
@@ -3786,6 +3798,7 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Footer {
         return mutate(inputmode: value)
     }
@@ -4060,6 +4073,7 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Address {
         return mutate(inputmode: value)
     }
@@ -4334,6 +4348,7 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Paragraph {
         return mutate(inputmode: value)
     }
@@ -4610,6 +4625,7 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> HorizontalRule {
         return mutate(inputmode: value)
     }
@@ -4884,6 +4900,7 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> PreformattedText {
         return mutate(inputmode: value)
     }
@@ -5158,6 +5175,7 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Blockquote {
         return mutate(inputmode: value)
     }
@@ -5443,6 +5461,7 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> OrderedList {
         return mutate(inputmode: value)
     }
@@ -5729,6 +5748,7 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> UnorderedList {
         return mutate(inputmode: value)
     }
@@ -6003,6 +6023,7 @@ extension Menu: GlobalAttributes {
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Menu {
         return mutate(inputmode: value)
     }
@@ -6181,6 +6202,7 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> DescriptionList {
         return mutate(inputmode: value)
     }
@@ -6454,7 +6476,8 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         
         return self
     }
-
+    
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Figure {
         return mutate(inputmode: value)
     }
@@ -6729,6 +6752,7 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Anchor {
         return mutate(inputmode: value)
     }
@@ -7046,6 +7070,7 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Emphasize {
         return mutate(inputmode: value)
     }
@@ -7320,6 +7345,7 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Strong {
         return mutate(inputmode: value)
     }
@@ -7594,6 +7620,7 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Small {
         return mutate(inputmode: value)
     }
@@ -7875,6 +7902,7 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> StrikeThrough {
         return mutate(inputmode: value)
     }
@@ -8080,6 +8108,7 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Main {
         return mutate(inputmode: value)
     }
@@ -8354,6 +8383,7 @@ extension Search: GlobalAttributes {
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Search {
         return mutate(inputmode: value)
     }
@@ -8532,6 +8562,7 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Division {
         return mutate(inputmode: value)
     }
@@ -8806,6 +8837,7 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Definition {
         return mutate(inputmode: value)
     }
@@ -9079,7 +9111,8 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         
         return self
     }
-
+    
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Cite {
         return mutate(inputmode: value)
     }
@@ -9354,6 +9387,7 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> ShortQuote {
         return mutate(inputmode: value)
     }
@@ -9632,6 +9666,7 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Abbreviation {
         return mutate(inputmode: value)
     }
@@ -9905,7 +9940,8 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         
         return self
     }
-    
+   
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Ruby {
         return mutate(inputmode: value)
     }
@@ -10179,7 +10215,8 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         
         return self
     }
-
+    
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Data {
         return mutate(inputmode: value)
     }
@@ -10458,6 +10495,7 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Time {
         return mutate(inputmode: value)
     }
@@ -10736,6 +10774,7 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Code {
         return mutate(inputmode: value)
     }
@@ -11010,6 +11049,7 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Variable {
         return mutate(inputmode: value)
     }
@@ -11284,6 +11324,7 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> SampleOutput {
         return mutate(inputmode: value)
     }
@@ -11558,6 +11599,7 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> KeyboardInput {
         return mutate(inputmode: value)
     }
@@ -11832,6 +11874,7 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Subscript {
         return mutate(inputmode: value)
     }
@@ -12105,6 +12148,7 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Superscript {
         return mutate(inputmode: value)
     }
@@ -12379,6 +12423,7 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Italic {
         return mutate(inputmode: value)
     }
@@ -12660,6 +12705,7 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Bold {
         return mutate(inputmode: value)
     }
@@ -12941,6 +12987,7 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Underline {
         return mutate(inputmode: value)
     }
@@ -13222,6 +13269,7 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Mark {
         return mutate(inputmode: value)
     }
@@ -13496,6 +13544,7 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Bdi {
         return mutate(inputmode: value)
     }
@@ -13765,6 +13814,7 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Bdo {
         return mutate(inputmode: value)
     }
@@ -14039,6 +14089,7 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Span {
         return mutate(inputmode: value)
     }
@@ -14308,6 +14359,7 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> LineBreak {
         return mutate(inputmode: value)
     }
@@ -14577,6 +14629,7 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> WordBreak {
         return mutate(inputmode: value)
     }
@@ -14851,6 +14904,7 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> InsertedText {
         return mutate(inputmode: value)
     }
@@ -15133,6 +15187,7 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> DeletedText {
         return mutate(inputmode: value)
     }
@@ -15415,6 +15470,7 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Picture {
         return mutate(inputmode: value)
     }
@@ -15608,6 +15664,7 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Image {
         return mutate(inputmode: value)
     }
@@ -15926,6 +15983,7 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> InlineFrame {
         return mutate(inputmode: value)
     }
@@ -16223,6 +16281,7 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Embed {
         return mutate(inputmode: value)
     }
@@ -16517,6 +16576,7 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Object {
         return mutate(inputmode: value)
     }
@@ -16815,6 +16875,7 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Video {
         return mutate(inputmode: value)
     }
@@ -17134,6 +17195,7 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Audio {
         return mutate(inputmode: value)
     }
@@ -17445,6 +17507,7 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Map {
         return mutate(inputmode: value)
     }
@@ -17647,6 +17710,7 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Form {
         return mutate(inputmode: value)
     }
@@ -17949,6 +18013,7 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> DataList {
         return mutate(inputmode: value)
     }
@@ -18223,6 +18288,7 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Output {
         return mutate(inputmode: value)
     }
@@ -18509,6 +18575,7 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Progress {
         return mutate(inputmode: value)
     }
@@ -18791,6 +18858,7 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Meter {
         return mutate(inputmode: value)
     }
@@ -19089,6 +19157,7 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Details {
         return mutate(inputmode: value)
     }
@@ -19367,6 +19436,7 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Dialog {
         return mutate(inputmode: value)
     }
@@ -19645,6 +19715,7 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Script {
         return mutate(inputmode: value)
     }
@@ -19871,6 +19942,7 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> NoScript {
         return mutate(inputmode: value)
     }
@@ -20069,6 +20141,7 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Template {
         return mutate(inputmode: value)
     }
@@ -20271,6 +20344,7 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Canvas {
         return mutate(inputmode: value)
     }
@@ -20553,6 +20627,7 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Table {
         return mutate(inputmode: value)
     }
@@ -20943,6 +21018,7 @@ extension Slot: GlobalAttributes, NameAttribute {
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Slot {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -119,6 +119,10 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func inputMode(_ value: String) -> TermName {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> TermName {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> TermName {
         return mutate(is: value)
@@ -388,6 +392,10 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
 
     public func inputMode(_ value: String) -> TermDefinition {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> TermDefinition {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> TermDefinition {

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -116,6 +116,7 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TermName {
         return mutate(inputmode: value)
     }
@@ -390,6 +391,7 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TermDefinition {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -109,6 +109,10 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
     public func inputMode(_ value: String) -> FigureCaption {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> FigureCaption {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> FigureCaption {
         return mutate(is: value)

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -106,6 +106,7 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> FigureCaption {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -94,6 +94,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
     public func inputMode(_ value: String) -> Input {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Input {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Input {
         return mutate(is: value)
@@ -436,6 +440,10 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     public func inputMode(_ value: String) -> Label {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Label {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Label {
         return mutate(is: value)
@@ -717,6 +725,10 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
     public func inputMode(_ value: String) -> Select {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Select {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Select {
         return mutate(is: value)
@@ -956,6 +968,10 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> TextArea {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> TextArea {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> TextArea {
@@ -1302,6 +1318,10 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     public func inputMode(_ value: String) -> Button {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Button {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Button {
         return mutate(is: value)
@@ -1619,6 +1639,10 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> Fieldset {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Fieldset {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Fieldset {

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -91,6 +91,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Input {
         return mutate(inputmode: value)
     }
@@ -437,6 +438,7 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Label {
         return mutate(inputmode: value)
     }
@@ -722,6 +724,7 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Select {
         return mutate(inputmode: value)
     }
@@ -966,6 +969,7 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TextArea {
         return mutate(inputmode: value)
     }
@@ -1315,6 +1319,7 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Button {
         return mutate(inputmode: value)
     }
@@ -1637,6 +1642,7 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Fieldset {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -100,6 +100,10 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return mutate(inputmode: value)
     }
     
+    public func inputMode(_ value: Values.Mode) -> Title {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Title {
         return mutate(is: value)
     }
@@ -287,6 +291,10 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
     
     public func inputMode(_ value: String) -> Base {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Base {
+        return mutate(inputmode: value.rawValue)
     }
     
     public func `is`(_ value: String) -> Base {
@@ -484,6 +492,10 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
 
     public func inputMode(_ value: String) -> Meta {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Meta {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Meta {
@@ -699,6 +711,10 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
     public func inputMode(_ value: String) -> Style {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Style {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Style {
         return mutate(is: value)
@@ -899,6 +915,10 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
 
     public func inputMode(_ value: String) -> Link {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Link {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Link {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -96,6 +96,7 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Title {
         return mutate(inputmode: value)
     }
@@ -289,6 +290,7 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Base {
         return mutate(inputmode: value)
     }
@@ -490,6 +492,7 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Meta {
         return mutate(inputmode: value)
     }
@@ -708,6 +711,7 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Style {
         return mutate(inputmode: value)
     }
@@ -913,6 +917,7 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Link {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -100,6 +100,10 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return mutate(inputmode: value)
     }
     
+    public func inputMode(_ value: Values.Mode) -> Head {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Head {
         return mutate(is: value)
     }
@@ -292,6 +296,10 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
 
     public func inputMode(_ value: String) -> Body {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Body {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Body {

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -96,6 +96,7 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Head {
         return mutate(inputmode: value)
     }
@@ -294,6 +295,7 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Body {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -106,6 +106,7 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> OptionGroup {
         return mutate(inputmode: value)
     }
@@ -397,6 +398,7 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Option {
         return mutate(inputmode: value)
     }
@@ -698,6 +700,7 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Legend {
         return mutate(inputmode: value)
     }
@@ -972,6 +975,7 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Summary {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -109,6 +109,10 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     public func inputMode(_ value: String) -> OptionGroup {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> OptionGroup {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> OptionGroup {
         return mutate(is: value)
@@ -395,6 +399,10 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func inputMode(_ value: String) -> Option {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Option {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Option {
@@ -693,6 +701,10 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     public func inputMode(_ value: String) -> Legend {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Legend {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Legend {
         return mutate(is: value)
@@ -962,6 +974,10 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
 
     public func inputMode(_ value: String) -> Summary {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Summary {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Summary {

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -110,6 +110,10 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> ListItem {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> ListItem {
         return mutate(is: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -106,6 +106,7 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> ListItem {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -100,6 +100,10 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Area {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Area {
         return mutate(is: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -96,6 +96,7 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return self
     }
     
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Area {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -91,6 +91,7 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Source {
         return mutate(inputmode: value)
     }
@@ -316,6 +317,7 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Track {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -94,6 +94,10 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
     public func inputMode(_ value: String) -> Source {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Source {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Source {
         return mutate(is: value)
@@ -314,6 +318,10 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
 
     public func inputMode(_ value: String) -> Track {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> Track {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> Track {

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -104,6 +104,10 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
     public func inputMode(_ value: String) -> Parameter {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Parameter {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Parameter {
         return mutate(is: value)

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -101,6 +101,7 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Parameter {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -116,6 +116,7 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> RubyText {
         return mutate(inputmode: value)
     }
@@ -390,6 +391,7 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> RubyPronunciation {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -119,6 +119,10 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func inputMode(_ value: String) -> RubyText {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> RubyText {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> RubyText {
         return mutate(is: value)
@@ -390,6 +394,10 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> RubyPronunciation {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> RubyPronunciation {
         return mutate(is: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -179,6 +179,10 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func inputMode(_ value: String) -> Caption {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> Caption {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> Caption {
         return mutate(is: value)
@@ -449,6 +453,10 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
     public func inputMode(_ value: String) -> ColumnGroup {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> ColumnGroup {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> ColumnGroup {
         return mutate(is: value)
@@ -648,6 +656,10 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(inputmode: value)
     }
 
+    public func inputMode(_ value: Values.Mode) -> Column {
+        return mutate(inputmode: value.rawValue)
+    }
+    
     public func `is`(_ value: String) -> Column {
         return mutate(is: value)
     }
@@ -844,6 +856,10 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func inputMode(_ value: String) -> TableBody {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> TableBody {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> TableBody {
@@ -1123,6 +1139,10 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func inputMode(_ value: String) -> TableHead {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> TableHead {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> TableHead {
         return mutate(is: value)
@@ -1401,6 +1421,10 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     public func inputMode(_ value: String) -> TableFoot {
         return mutate(inputmode: value)
     }
+    
+    public func inputMode(_ value: Values.Mode) -> TableFoot {
+        return mutate(inputmode: value.rawValue)
+    }
 
     public func `is`(_ value: String) -> TableFoot {
         return mutate(is: value)
@@ -1670,6 +1694,10 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> TableRow {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> TableRow {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> TableRow {
@@ -1948,6 +1976,10 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func inputMode(_ value: String) -> DataCell {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> DataCell {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> DataCell {
@@ -2230,6 +2262,10 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func inputMode(_ value: String) -> HeaderCell {
         return mutate(inputmode: value)
+    }
+    
+    public func inputMode(_ value: Values.Mode) -> HeaderCell {
+        return mutate(inputmode: value.rawValue)
     }
 
     public func `is`(_ value: String) -> HeaderCell {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -176,6 +176,7 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Caption {
         return mutate(inputmode: value)
     }
@@ -450,6 +451,7 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> ColumnGroup {
         return mutate(inputmode: value)
     }
@@ -652,6 +654,7 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> Column {
         return mutate(inputmode: value)
     }
@@ -854,6 +857,7 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TableBody {
         return mutate(inputmode: value)
     }
@@ -1136,6 +1140,7 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TableHead {
         return mutate(inputmode: value)
     }
@@ -1418,6 +1423,7 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TableFoot {
         return mutate(inputmode: value)
     }
@@ -1692,6 +1698,7 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> TableRow {
         return mutate(inputmode: value)
     }
@@ -1974,6 +1981,7 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> DataCell {
         return mutate(inputmode: value)
     }
@@ -2260,6 +2268,7 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return self
     }
 
+    @available(*, deprecated, message: "The inputmode attribute is actually an enumerated attribute. Use the inputMode(_: Mode) modifier instead.")
     public func inputMode(_ value: String) -> HeaderCell {
         return mutate(inputmode: value)
     }

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -1009,7 +1009,7 @@ public enum Values {
         case search
         
         /// Displays a keyboard for telephone number input.
-        case tel
+        case phone = "tel"
         
         /// Displays a keyboard optimized for URL input.
         case url

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -958,4 +958,37 @@ public enum Values {
             case hide
         }
     }
+    
+    /// A enumeration of potential input modes for the virtual keyboard.
+    ///
+    /// ```swift
+    /// Input()
+    ///     .inputMode(.numeric)
+    /// ```
+    public enum Mode: String {
+        
+        /// Displays a virtual keyboard for text input in the user's locale.
+        case text
+        
+        /// Does not display a virtual keyboard.
+        case none
+        
+        /// Displays a keyboard for fractional numeric input.
+        case decimal
+        
+        /// Displays a keyboard for email input
+        case email
+        
+        /// Displays a keyboard for numeric input.
+        case numeric
+        
+        /// Displays a keyboard for search input.
+        case search
+        
+        /// Displays a keyboard for telephone number input.
+        case tel
+        
+        /// Displays a keyboard optimized for URL input.
+        case url
+    }
 }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -82,8 +82,8 @@ final class AttributesTests: XCTestCase {
             return self.mutate(id: value)
         }
         
-        func inputMode(_ value: String) -> Tag {
-            return self.mutate(inputmode: value)
+        func inputMode(_ value: Values.Mode) -> Tag {
+            return mutate(inputmode: value.rawValue)
         }
         
         func `is`(_ value: String) -> Tag {

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -2751,4 +2751,31 @@ final class AttributesTests: XCTestCase {
                        """
         )
     }
+    
+    func testInputModeAttribute() throws {
+        
+        let view = TestView {
+            Tag {}.inputMode(.decimal)
+            Tag {}.inputMode(.email)
+            Tag {}.inputMode(.none)
+            Tag {}.inputMode(.numeric)
+            Tag {}.inputMode(.phone)
+            Tag {}.inputMode(.search)
+            Tag {}.inputMode(.text)
+            Tag {}.inputMode(.url)
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <tag inputmode="decimal"></tag>\
+                       <tag inputmode="email"></tag>\
+                       <tag inputmode="none"></tag>\
+                       <tag inputmode="numeric"></tag>\
+                       <tag inputmode="tel"></tag>\
+                       <tag inputmode="search"></tag>\
+                       <tag inputmode="text"></tag>\
+                       <tag inputmode="url"></tag>
+                       """
+        )
+    }
 }


### PR DESCRIPTION
The inputmode attribute is actually an enumerated attribute. Therefore the modifier should accept an enum. This pull request corrects that.