### PR TITLE
Fix localization fallback behaviour

### DIFF
--- a/Sources/HTMLKit/Framework/Localization/Localization.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localization.swift
@@ -56,6 +56,16 @@ public class Localization {
         }
     }
     
+    /// Indicates whether the localization is properly configured
+    internal var isConfigured: Bool {
+        
+        if self.tables != nil && self.locale != nil {
+            return true
+        }
+        
+        return false
+    }
+    
     /// The translations tables
     internal var tables: [Locale: [TranslationTable]]?
     

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -354,7 +354,12 @@ public final class Renderer {
     private func render(localized string: LocalizedString) throws -> String {
         
         guard let localization = self.localization else {
-            // Bail early with the fallback since the localization isn't set up
+            // Bail early with the fallback since the localization is not in use
+            return string.key.literal
+        }
+        
+        if !localization.isConfigured {
+            // Bail early, since the localization is not properly configured
             return string.key.literal
         }
         

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -112,7 +112,7 @@ extension Request {
     public var htmlkit: ViewRenderer {
         
         if let acceptLanguage = self.acceptLanguage {
-            self.application.htmlkit.localization.set(locale: acceptLanguage)
+            self.application.htmlkit.environment.locale = HTMLKit.Locale(tag: acceptLanguage)
         }
         
         return .init(eventLoop: self.eventLoop, configuration: self.application.htmlkit.configuration, logger: self.logger)

--- a/Tests/HTMLKitVaporTests/ProviderTests.swift
+++ b/Tests/HTMLKitVaporTests/ProviderTests.swift
@@ -192,6 +192,39 @@ final class ProviderTests: XCTestCase {
         }
     }
     
+    /// Tests the behavior when localization is not properly configured
+    ///
+    /// Localization is considered improperly configured when one or both of the essential factors are missing.
+    /// In such case the renderer is expected to skip the localization and directly return the fallback string literal.
+    func testLocalizationFallback() throws {
+        
+        let app = Application(.testing)
+        
+        defer { app.shutdown() }
+        
+        app.get("test") { request async throws -> Vapor.View in
+            
+            return try await request.htmlkit.render(TestPage.ChildView())
+        }
+        
+        try app.test(.GET, "test") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.body.string,
+                            """
+                            <!DOCTYPE html>\
+                            <html>\
+                            <head>\
+                            <title>TestPage</title>\
+                            </head>\
+                            <body>\
+                            <p>hello.world</p>\
+                            </body>\
+                            </html>
+                            """
+            )
+        }
+    }
+    
     func testEnvironmentIntegration() throws {
         
         let app = Application(.testing)

--- a/Tests/HTMLKitVaporTests/Utilities/AbortResponse.swift
+++ b/Tests/HTMLKitVaporTests/Utilities/AbortResponse.swift
@@ -1,0 +1,6 @@
+import Vapor
+
+struct AbortResponse: Vapor.Content {
+    
+    var reason: String
+}


### PR DESCRIPTION
This pull request adds an additional fallback check to the rendering for the localization. Currently, the only check is whether the localization is initialized, which can result in a false positive because the Vapor provider initializes it during configuration. To address this, another check has been introduced to determine if the localization is intended for use, based on the configuration setter.

```swift
app.htmlkit.localization.set(source:)
app.htmlkit.localization.set(locale:)
```

It also prevents the default locale from being overridden. Currently, the default locale gets overridden by the client's accept language header through the provider, but the environment locale is the value that should actually be overridden instead.