### PR TITLE
Fix the incorrect tag for the variable element

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -10961,19 +10961,31 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     }
 }
 
-/// The element indicates a variable name.
+/// The element represents a variable.
 ///
-/// ```html
-/// <v></v>
+/// Use `Variable` to denote a value that can change or vary, typically in mathematical expressions
+/// or programming contexts.
+///
+/// ```swift
+/// Paragraph {
+///     "Lorem ipsum..."
+///     Variable {
+///         "x"
+///     }
+///     "Lorem ipsum..."
+/// }
 /// ```
 public struct Variable: ContentNode, HtmlElement, BodyElement, FormElement, FigureElement, ObjectElement {
 
-    internal var name: String { "v" }
+    internal var name: String { "var" }
 
     internal var attributes: OrderedDictionary<String, Any>?
 
     internal var content: [Content]
 
+    /// Create a variable
+    ///
+    /// - Parameter content: The variable's content.
     public init(@ContentBuilder<Content> content: () -> [Content]) {
         self.content = content()
     }

--- a/Tests/HTMLKitTests/ElementTests.swift
+++ b/Tests/HTMLKitTests/ElementTests.swift
@@ -767,8 +767,8 @@ final class ElementTests: XCTestCase {
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
-                       <v></v>\
-                       <v></v>
+                       <var></var>\
+                       <var></var>
                        """
         )
     }


### PR DESCRIPTION
The tag for the variable element is incorrect. It should be `<var>` instead. The pull request fixes this.