### PR TITLE
Make column element an empty node

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -568,24 +568,29 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
 
 /// The element represents a column in a table.
 ///
-/// ```html
-/// <col></col>
+/// Use `Column` for applying styles to entire columns, instead of repeating the styles for each cell, for each row.
+///
+/// ```swift
+/// Table {
+///     ColumnGroup {
+///         Column()
+///             .span(2)
+///         Column()
+///             .style("...")
+///     }
+/// }
 /// ```
-public struct Column: ContentNode, TableElement {
-
+public struct Column: EmptyNode, TableElement {
+    
     internal var name: String { "col" }
 
     internal var attributes: OrderedDictionary<String, Any>?
 
-    internal  var content: [Content]
-
-    public init(@ContentBuilder<Content> content: () -> [Content]) {
-        self.content = content()
-    }
+    /// Create a column
+    public init() {}
     
-    internal init(attributes: OrderedDictionary<String, Any>?, content: [Content]) {
+    internal init(attributes: OrderedDictionary<String, Any>?) {
         self.attributes = attributes
-        self.content = content
     }
     
     public func modify(if condition: Bool, element: (Column) -> Column) -> Column {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -589,6 +589,9 @@ public struct Column: EmptyNode, TableElement {
     /// Create a column
     public init() {}
     
+    @available(*, deprecated, message: "The column element is actually an empty element. Use Column() instead.")
+     public init(@ContentBuilder<Content> content: () -> [Content]) {}
+    
     internal init(attributes: OrderedDictionary<String, Any>?) {
         self.attributes = attributes
     }

--- a/Tests/HTMLKitTests/ElementTests.swift
+++ b/Tests/HTMLKitTests/ElementTests.swift
@@ -1196,14 +1196,14 @@ final class ElementTests: XCTestCase {
     func testColumnElement() throws {
         
         let view = TestView {
-            Column {}
-            Col {}
+            Column()
+            Col()
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
-                       <col></col>\
-                       <col></col>
+                       <col>\
+                       <col>
                        """
         )
     }


### PR DESCRIPTION
The column element should have been an empty node from the start. This pull request corrects that.