### PR TITLE
Make the type modifier of the orderedlist element accept the marker enum

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -5551,8 +5551,8 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(start: size)
     }
     
-    public func type(_ value: String) -> OrderedList {
-        return mutate(type: value)
+    public func type(_ value: Values.Marker) -> OrderedList {
+        return mutate(type: value.rawValue)
     }
     
     public func popover(_ value: Values.Popover.State) -> OrderedList {

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -437,17 +437,28 @@ public enum Values {
         case xIcon = "image/x-icon"
     }
 
-    /// The type is for
+    /// A enumeration of potential list markers
     ///
-    /// ```html
-    /// <ol type="I"></ol>
+    /// ```swift
+    /// OrderedList {
+    /// }
+    /// .type(.lowercaseAlpha)
     /// ```
     public enum Marker: String {
         
+        /// Uses numbers e.g. 1, 2, 3
         case decimal = "1"
+        
+        /// Uses uppercase letters e.g. A, B, C
         case uppercaseAlpha = "A"
+        
+        /// Uses lowercase letters e.g. a, b, c
         case lowercaseAlpha = "a"
+        
+        /// Uses uppercase Roman numerals e.g. I, II, III
         case uppercaseRoman = "I"
+        
+        /// Uses lowercase Roman numerals e.g. i, ii, iii
         case lowercaseRoman = "i"
     }
 


### PR DESCRIPTION
The type modifier of the `OrderedList` element should accept the marker enum. This pull request corrects that.

```swift
OrderedList {
}
.type(.lowercaseAlpha)
```