### PR TITLE
Add missing form method

### DIFF
--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -62,10 +62,13 @@ public enum Values {
         case plainText = "text/plain"
     }
 
-    /// A method for the form submission.
+    /// A method for form submission.
     ///
-    /// ```html
-    /// <form method="get"></form>
+    /// ```swift
+    /// Form {
+    ///     ...
+    /// }
+    /// .method(.post)
     /// ```
     public enum Method: String {
         
@@ -74,6 +77,9 @@ public enum Values {
         
         /// Appends the form data to name/value pairs.
         case get
+        
+        /// Closes the dialog and triggers a submit event, without actually sending the form data.
+        case dialog
     }
 
     /// A type of input elements.

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -1563,11 +1563,15 @@ final class AttributesTests: XCTestCase {
         
         let view = TestView {
             Tag {}.method(.get)
+            Tag {}.method(.post)
+            Tag {}.method(.dialog)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
-                       <tag method="get"></tag>
+                       <tag method="get"></tag>\
+                       <tag method="post"></tag>\
+                       <tag method="dialog"></tag>
                        """
         )
     }


### PR DESCRIPTION
This pull request adds the missing form method `dialog`.

```swift
Form()
    .method(.dialog)
```