### PR TITLE
Make attributes localizable

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -2697,12 +2697,34 @@ extension TargetAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol TitleAttribute: Attribute {
  
-    /// The function represents the html-attribute 'title'.
+    /// Supply extra information about the element..
     ///
-    /// ```html
-    /// <tag title="" />
+    /// ```swift
+    /// Paragraph {
+    ///     "Lorem ipsum..."
+    /// }
+    /// .title("Lorem ipsum")
     /// ```
+    ///
+    /// - Parameter value: The extra information to display
+    ///
+    /// - Returns: The element
     func title(_ value: String) -> Self
+    
+    /// Supply extra information about the element..
+    /// 
+    /// ```swift
+    /// Paragraph {
+    ///     "Lorem ipsum..."
+    /// }
+    /// .title("Lorem ipsum")
+    /// ```
+    ///
+    /// - Parameter localizedKey: The string key to be translated
+    /// - Parameter tableName: The translation table to look in
+    ///
+    /// - Returns: The element
+    func title(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
 }
 
 extension TitleAttribute where Self: ContentNode {
@@ -2710,11 +2732,19 @@ extension TitleAttribute where Self: ContentNode {
     internal func mutate(title value: String) -> Self {
         return self.mutate(key: "title", value: value)
     }
+    
+    internal func mutate(title value: LocalizedString) -> Self {
+        return self.mutate(key: "title", value: value)
+    }
 }
 
 extension TitleAttribute where Self: EmptyNode {
     
     internal func mutate(title value: String) -> Self {
+        return self.mutate(key: "title", value: value)
+    }
+    
+    internal func mutate(title value: LocalizedString) -> Self {
         return self.mutate(key: "title", value: value)
     }
 }

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -121,6 +121,19 @@ public protocol AlternateAttribute: Attribute {
     ///
     /// - Returns: The element
     func alternate(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
+    
+    /// Provide an alternative information without localization.
+    ///
+    /// ```swift
+    /// Image()
+    ///     .alternate(verbatim: "Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter value: The text to describe the image
+    ///
+    /// - Returns: The element
+    func alternate(verbatim value: String) -> Self
+    
 }
 
 extension AlternateAttribute where Self: ContentNode {
@@ -482,6 +495,19 @@ public protocol ContentAttribute: Attribute {
     ///
     /// - Returns: The element
     func content(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
+    
+    /// Supply a value to the associated name without localization
+    ///
+    /// ```swift
+    /// Meta()
+    ///     .name(.description)
+    ///     .content(verbatim: "Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter value: The value to describe the name
+    ///
+    /// - Returns: The element
+    func content(verbatim value: String) -> Self
 }
 
 extension ContentAttribute where Self: ContentNode {
@@ -1991,6 +2017,18 @@ public protocol PlaceholderAttribute: Attribute {
     ///
     /// - Returns: The element
     func placeholder(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
+    
+    /// Supply a short hint without localization.
+    ///
+    /// ```swift
+    /// Input()
+    ///     .placeholder(verbatim: "Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter value: The text to display as a hint
+    ///
+    /// - Returns: The element
+    func placeholder(verbatim value: String) -> Self
 }
 
 extension PlaceholderAttribute where Self: ContentNode {
@@ -2725,7 +2763,7 @@ extension TargetAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol TitleAttribute: Attribute {
  
-    /// Supply extra information about the element..
+    /// Supply extra information about the element.
     ///
     /// ```swift
     /// Paragraph {
@@ -2753,6 +2791,20 @@ public protocol TitleAttribute: Attribute {
     ///
     /// - Returns: The element
     func title(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
+    
+    /// Supply extra information about the element without localization.
+    ///
+    /// ```swift
+    /// Paragraph {
+    ///     "Lorem ipsum..."
+    /// }
+    /// .title(verbatim: "Lorem ipsum")
+    /// ```
+    ///
+    /// - Parameter value: The extra information to display
+    ///
+    /// - Returns: The element
+    func title(verbatim value: String) -> Self
 }
 
 extension TitleAttribute where Self: ContentNode {
@@ -2896,6 +2948,19 @@ public protocol ValueAttribute: Attribute {
     ///
     /// - Returns: The element
     func value(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
+    
+    /// Set a initial value for the element without localization.
+    ///
+    /// ```swift
+    /// Input()
+    ///     .type(.text)
+    ///     .value(verbatim: "Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter value: The initial value
+    ///
+    /// - Returns: The element
+    func value(verbatim value: String) -> Self
 }
 
 extension ValueAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -456,12 +456,32 @@ extension ColumnSpanAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol ContentAttribute: Attribute {
     
-    /// The function represents the html-attribute 'content'.
+    /// Supply a value to the associated name.
     ///
-    /// ```html
-    /// <tag content="" />
+    /// ```swift
+    /// Meta()
+    ///     .name(.description)
+    ///     .content("Lorem ipsum...")
     /// ```
+    ///
+    /// - Parameter value: The value to describe the name
+    ///
+    /// - Returns: The element
     func content(_ value: String) -> Self
+    
+    /// Supply a value to the associated name.
+    ///
+    /// ```swift
+    /// Meta()
+    ///     .name(.description)
+    ///     .content("Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter localizedKey: The string key to be translated
+    /// - Parameter tableName: The translation table to look in
+    ///
+    /// - Returns: The element
+    func content(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
 }
 
 extension ContentAttribute where Self: ContentNode {
@@ -469,11 +489,19 @@ extension ContentAttribute where Self: ContentNode {
     internal func mutate(content value: String) -> Self {
         return self.mutate(key: "content", value: value)
     }
+    
+    internal func mutate(content value: LocalizedString) -> Self {
+        return self.mutate(key: "content", value: value)
+    }
 }
 
 extension ContentAttribute where Self: EmptyNode {
     
     internal func mutate(content value: String) -> Self {
+        return self.mutate(key: "content", value: value)
+    }
+    
+    internal func mutate(content value: LocalizedString) -> Self {
         return self.mutate(key: "content", value: value)
     }
 }

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -97,12 +97,30 @@ extension ActionAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol AlternateAttribute: Attribute {
     
-    /// The function represents the html-attribute 'alt'.
+    /// Provide an alternative information
     ///
-    /// ```html
-    /// <tag alt="" />
+    /// ```swift
+    /// Image()
+    ///     .alternate("Lorem ipsum...")
     /// ```
+    ///
+    /// - Parameter value: The text to describe the image
+    ///
+    /// - Returns: The element
     func alternate(_ value: String) -> Self
+    
+    /// Provide an alternative information
+    /// 
+    /// ```swift
+    /// Image()
+    ///     .alternate("Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter localizedKey: The string key to be translated
+    /// - Parameter tableName: The translation table to look in
+    ///
+    /// - Returns: The element
+    func alternate(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
 }
 
 extension AlternateAttribute where Self: ContentNode {
@@ -110,11 +128,19 @@ extension AlternateAttribute where Self: ContentNode {
     internal func mutate(alternate value: String) -> Self {
         return self.mutate(key: "alt", value: value)
     }
+    
+    internal func mutate(alternate value: LocalizedString) -> Self {
+        return self.mutate(key: "alt", value: value)
+    }
 }
 
 extension AlternateAttribute where Self: EmptyNode {
     
     internal func mutate(alternate value: String) -> Self {
+        return self.mutate(key: "alt", value: value)
+    }
+    
+    internal func mutate(alternate value: LocalizedString) -> Self {
         return self.mutate(key: "alt", value: value)
     }
 }

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -2812,12 +2812,32 @@ extension UseMapAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol ValueAttribute: Attribute {
     
-    /// The function represents the html-attribute 'value'.
+    /// Set a initial value for the element.
     ///
-    /// ```html
-    /// <tag value="" />
+    /// ```swift
+    /// Input()
+    ///     .type(.text)
+    ///     .value("Lorem ipsum...")
     /// ```
+    ///
+    /// - Parameter value: The initial value
+    ///
+    /// - Returns: The element
     func value(_ value: String) -> Self
+    
+    /// Set a initial value for the element.
+    /// 
+    /// ```swift
+    /// Input()
+    ///     .type(.text)
+    ///     .value("Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter localizedKey: The string key to be translated
+    /// - Parameter tableName: The translation table to look in
+    ///
+    /// - Returns: The element
+    func value(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
 }
 
 extension ValueAttribute where Self: ContentNode {
@@ -2825,11 +2845,19 @@ extension ValueAttribute where Self: ContentNode {
     internal func mutate(value: String) -> Self {
         return self.mutate(key: "value", value: value)
     }
+    
+    internal func mutate(value: LocalizedString) -> Self {
+        return self.mutate(key: "value", value: value)
+    }
 }
 
 extension ValueAttribute where Self: EmptyNode {
     
     internal func mutate(value: String) -> Self {
+        return self.mutate(key: "value", value: value)
+    }
+    
+    internal func mutate(value: LocalizedString) -> Self {
         return self.mutate(key: "value", value: value)
     }
 }

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -1913,12 +1913,30 @@ extension PingAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol PlaceholderAttribute: Attribute {
     
-    /// The function represents the html-attribute 'placeholder'.
+    /// Supply a short hint.
     ///
-    /// ```html
-    /// <tag placeholder="" />
+    /// ```swift
+    /// Input()
+    ///     .placeholder("Lorem ipsum...")
     /// ```
+    ///
+    /// - Parameter value: The text to display as a hint
+    ///
+    /// - Returns: The element
     func placeholder(_ value: String) -> Self
+    
+    /// Supply a short hint.
+    /// 
+    /// ```swift
+    /// Input()
+    ///     .placeholder("Lorem ipsum...")
+    /// ```
+    ///
+    /// - Parameter localizedKey: The string key to be translated
+    /// - Parameter tableName: The translation table to look in
+    ///
+    /// - Returns: The element
+    func placeholder(_ localizedKey: LocalizedStringKey, tableName: String?) -> Self
 }
 
 extension PlaceholderAttribute where Self: ContentNode {
@@ -1926,11 +1944,19 @@ extension PlaceholderAttribute where Self: ContentNode {
     internal func mutate(placeholder value: String) -> Self {
         return self.mutate(key: "placeholder", value: value)
     }
+    
+    internal func mutate(placeholder value: LocalizedString) -> Self {
+        return self.mutate(key: "placeholder", value: value)
+    }
 }
 
 extension PlaceholderAttribute where Self: EmptyNode {
     
     internal func mutate(placeholder value: String) -> Self {
+        return self.mutate(key: "placeholder", value: value)
+    }
+    
+    internal func mutate(placeholder value: LocalizedString) -> Self {
         return self.mutate(key: "placeholder", value: value)
     }
 }

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -189,6 +189,10 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Html {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Html {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -185,6 +185,7 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Html {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -194,6 +194,10 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Html {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Html {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -15766,6 +15766,10 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(alternate: value)
     }
     
+    public func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Image {
+        return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func source(_ value: String) -> Image {
         return mutate(source: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -520,6 +520,10 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func title(_ value: String) -> Article {
         return mutate(title: value)
     }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Article {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
 
     public func translate(_ value: Values.Decision) -> Article {
         return mutate(translate: value.rawValue)
@@ -794,6 +798,10 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
 
     public func title(_ value: String) -> Section {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Section {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
 
     public func translate(_ value: Values.Decision) -> Section {
@@ -1071,6 +1079,10 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Navigation {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Navigation {
         return mutate(translate: value.rawValue)
     }
@@ -1346,6 +1358,10 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Aside {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Aside {
         return mutate(translate: value.rawValue)
     }
@@ -1619,6 +1635,10 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ value: String) -> Heading1 {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading1 {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Heading1 {
@@ -1903,6 +1923,10 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading2 {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Heading2 {
         return mutate(translate: value.rawValue)
     }
@@ -2183,6 +2207,10 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> Heading3 {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading3 {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Heading3 {
@@ -2467,6 +2495,10 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading4 {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Heading4 {
         return mutate(translate: value.rawValue)
     }
@@ -2747,6 +2779,10 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> Heading5 {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading5 {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Heading5 {
@@ -3031,6 +3067,10 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading6 {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Heading6 {
         return mutate(translate: value.rawValue)
     }
@@ -3313,6 +3353,10 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> HeadingGroup {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> HeadingGroup {
         return mutate(translate: value.rawValue)
     }
@@ -3586,6 +3630,10 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
 
     public func title(_ value: String) -> Header {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Header {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Header {
@@ -3863,6 +3911,10 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Footer {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Footer {
         return mutate(translate: value.rawValue)
     }
@@ -4138,6 +4190,10 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Address {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Address {
         return mutate(translate: value.rawValue)
     }
@@ -4411,6 +4467,10 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func title(_ value: String) -> Paragraph {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Paragraph {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Paragraph {
@@ -4690,6 +4750,10 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> HorizontalRule {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> HorizontalRule {
         return mutate(translate: value.rawValue)
     }
@@ -4965,6 +5029,10 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> PreformattedText {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> PreformattedText {
         return mutate(translate: value.rawValue)
     }
@@ -5238,6 +5306,10 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func title(_ value: String) -> Blockquote {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Blockquote {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Blockquote {
@@ -5524,6 +5596,10 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
 
     public func title(_ value: String) -> OrderedList {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> OrderedList {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> OrderedList {
@@ -5813,6 +5889,10 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> UnorderedList {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> UnorderedList {
         return mutate(translate: value.rawValue)
     }
@@ -6088,6 +6168,10 @@ extension Menu: GlobalAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Menu {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Menu {
         return mutate(translate: value.rawValue)
     }
@@ -6265,6 +6349,10 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
 
     public func title(_ value: String) -> DescriptionList {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> DescriptionList {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> DescriptionList {
@@ -6542,6 +6630,10 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Figure {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Figure {
         return mutate(translate: value.rawValue)
     }
@@ -6815,6 +6907,10 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func title(_ value: String) -> Anchor {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Anchor {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Anchor {
@@ -7135,6 +7231,10 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Emphasize {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Emphasize {
         return mutate(translate: value.rawValue)
     }
@@ -7410,6 +7510,10 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Strong {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Strong {
         return mutate(translate: value.rawValue)
     }
@@ -7683,6 +7787,10 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func title(_ value: String) -> Small {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Small {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Small {
@@ -7967,6 +8075,10 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> StrikeThrough {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> StrikeThrough {
         return mutate(translate: value.rawValue)
     }
@@ -8171,6 +8283,10 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func title(_ value: String) -> Main {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Main {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Main {
@@ -8448,6 +8564,10 @@ extension Search: GlobalAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Search {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Search {
         return mutate(translate: value.rawValue)
     }
@@ -8625,6 +8745,10 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> Division {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Division {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Division {
@@ -8902,6 +9026,10 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Definition {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Definition {
         return mutate(translate: value.rawValue)
     }
@@ -9177,6 +9305,10 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Cite {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Cite {
         return mutate(translate: value.rawValue)
     }
@@ -9450,6 +9582,10 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func title(_ value: String) -> ShortQuote {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> ShortQuote {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> ShortQuote {
@@ -9731,6 +9867,10 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Abbreviation {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Abbreviation {
         return mutate(translate: value.rawValue)
     }
@@ -10006,6 +10146,10 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Ruby {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Ruby {
         return mutate(translate: value.rawValue)
     }
@@ -10279,6 +10423,10 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
 
     public func title(_ value: String) -> Data {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Data {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Data {
@@ -10564,6 +10712,10 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Time {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Time {
         return mutate(translate: value.rawValue)
     }
@@ -10841,6 +10993,10 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func title(_ value: String) -> Code {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Code {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Code {
@@ -11130,6 +11286,10 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Variable {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Variable {
         return mutate(translate: value.rawValue)
     }
@@ -11403,6 +11563,10 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
 
     public func title(_ value: String) -> SampleOutput {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> SampleOutput {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> SampleOutput {
@@ -11680,6 +11844,10 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> KeyboardInput {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> KeyboardInput {
         return mutate(translate: value.rawValue)
     }
@@ -11952,6 +12120,10 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func title(_ value: String) -> Subscript {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Subscript {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Subscript {
@@ -12229,6 +12401,10 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Superscript {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Superscript {
         return mutate(translate: value.rawValue)
     }
@@ -12502,6 +12678,10 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
 
     public func title(_ value: String) -> Italic {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Italic {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Italic {
@@ -12786,6 +12966,10 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Bold {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Bold {
         return mutate(translate: value.rawValue)
     }
@@ -13066,6 +13250,10 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func title(_ value: String) -> Underline {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Underline {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Underline {
@@ -13350,6 +13538,10 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Mark {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Mark {
         return mutate(translate: value.rawValue)
     }
@@ -13625,6 +13817,10 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Bdi {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Bdi {
         return mutate(translate: value.rawValue)
     }
@@ -13893,6 +14089,10 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
 
     public func title(_ value: String) -> Bdo {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Bdo {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Bdo {
@@ -14170,6 +14370,10 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Span {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Span {
         return mutate(translate: value.rawValue)
     }
@@ -14440,6 +14644,10 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> LineBreak {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> LineBreak {
         return mutate(translate: value.rawValue)
     }
@@ -14708,6 +14916,10 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func title(_ value: String) -> WordBreak {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> WordBreak {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> WordBreak {
@@ -14983,6 +15195,10 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
 
     public func title(_ value: String) -> InsertedText {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> InsertedText {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> InsertedText {
@@ -15268,6 +15484,10 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> DeletedText {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> DeletedText {
         return mutate(translate: value.rawValue)
     }
@@ -15551,6 +15771,10 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Picture {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Picture {
         return mutate(translate: value.rawValue)
     }
@@ -15747,6 +15971,10 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func title(_ value: String) -> Image {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Image {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Image {
@@ -16076,6 +16304,10 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> InlineFrame {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> InlineFrame {
         return mutate(translate: value.rawValue)
     }
@@ -16386,6 +16618,10 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Embed {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Embed {
         return mutate(translate: value.rawValue)
     }
@@ -16679,6 +16915,10 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func title(_ value: String) -> Object {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Object {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Object {
@@ -16978,6 +17218,10 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func title(_ value: String) -> Video {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Video {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Video {
@@ -17314,6 +17558,10 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Audio {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Audio {
         return mutate(translate: value.rawValue)
     }
@@ -17631,6 +17879,10 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Map {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Map {
         return mutate(translate: value.rawValue)
     }
@@ -17832,6 +18084,10 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
 
     public func title(_ value: String) -> Form {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Form {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Form {
@@ -18151,6 +18407,10 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> DataList {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> DataList {
         return mutate(translate: value.rawValue)
     }
@@ -18424,6 +18684,10 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func title(_ value: String) -> Output {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Output {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Output {
@@ -18713,6 +18977,10 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Progress {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Progress {
         return mutate(translate: value.rawValue)
     }
@@ -18998,6 +19266,10 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func title(_ value: String) -> Meter {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Meter {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Meter {
@@ -19303,6 +19575,10 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Details {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Details {
         return mutate(translate: value.rawValue)
     }
@@ -19580,6 +19856,10 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func title(_ value: String) -> Dialog {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Dialog {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Dialog {
@@ -19861,6 +20141,10 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Script {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Script {
         return mutate(translate: value.rawValue)
     }
@@ -20088,6 +20372,10 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> NoScript {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> NoScript {
         return mutate(translate: value.rawValue)
     }
@@ -20285,6 +20573,10 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
 
     public func title(_ value: String) -> Template {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Template {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Template {
@@ -20488,6 +20780,10 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func title(_ value: String) -> Canvas {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Canvas {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Canvas {
@@ -20771,6 +21067,10 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
 
     public func title(_ value: String) -> Table {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Table {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Table {
@@ -21162,6 +21462,10 @@ extension Slot: GlobalAttributes, NameAttribute {
     
     public func title(_ value: String) -> Slot {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Slot {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Slot {

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -10302,6 +10302,10 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         return mutate(value: value)
     }
     
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Data {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func popover(_ value: Values.Popover.State) -> Data {
         return mutate(popover: value.rawValue)
     }
@@ -18734,6 +18738,10 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(value: value)
     }
     
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Progress {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func popover(_ value: Values.Popover.State) -> Progress {
         return mutate(popover: value.rawValue)
     }
@@ -19031,6 +19039,10 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func value(_ value: String) -> Meter {
         return mutate(value: value)
+    }
+    
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Meter {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func popover(_ value: Values.Popover.State) -> Meter {

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -517,6 +517,7 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Article {
         return mutate(title: value)
     }
@@ -796,6 +797,7 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Section {
         return mutate(title: value)
     }
@@ -1075,6 +1077,7 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Navigation {
         return mutate(title: value)
     }
@@ -1354,6 +1357,7 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Aside {
         return mutate(title: value)
     }
@@ -1633,6 +1637,7 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Heading1 {
         return mutate(title: value)
     }
@@ -1919,6 +1924,7 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Heading2 {
         return mutate(title: value)
     }
@@ -2205,6 +2211,7 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Heading3 {
         return mutate(title: value)
     }
@@ -2491,6 +2498,7 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Heading4 {
         return mutate(title: value)
     }
@@ -2777,6 +2785,7 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Heading5 {
         return mutate(title: value)
     }
@@ -3063,6 +3072,7 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Heading6 {
         return mutate(title: value)
     }
@@ -3349,6 +3359,7 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> HeadingGroup {
         return mutate(title: value)
     }
@@ -3628,6 +3639,7 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Header {
         return mutate(title: value)
     }
@@ -3907,6 +3919,7 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Footer {
         return mutate(title: value)
     }
@@ -4186,6 +4199,7 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Address {
         return mutate(title: value)
     }
@@ -4465,6 +4479,7 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Paragraph {
         return mutate(title: value)
     }
@@ -4746,6 +4761,7 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> HorizontalRule {
         return mutate(title: value)
     }
@@ -5025,6 +5041,7 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> PreformattedText {
         return mutate(title: value)
     }
@@ -5304,6 +5321,7 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Blockquote {
         return mutate(title: value)
     }
@@ -5594,6 +5612,7 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> OrderedList {
         return mutate(title: value)
     }
@@ -5885,6 +5904,7 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> UnorderedList {
         return mutate(title: value)
     }
@@ -6164,6 +6184,7 @@ extension Menu: GlobalAttributes {
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Menu {
         return mutate(title: value)
     }
@@ -6347,6 +6368,7 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> DescriptionList {
         return mutate(title: value)
     }
@@ -6626,6 +6648,7 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Figure {
         return mutate(title: value)
     }
@@ -6905,6 +6928,7 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Anchor {
         return mutate(title: value)
     }
@@ -7227,6 +7251,7 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Emphasize {
         return mutate(title: value)
     }
@@ -7506,6 +7531,7 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Strong {
         return mutate(title: value)
     }
@@ -7785,6 +7811,7 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Small {
         return mutate(title: value)
     }
@@ -8071,6 +8098,7 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> StrikeThrough {
         return mutate(title: value)
     }
@@ -8281,6 +8309,7 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Main {
         return mutate(title: value)
     }
@@ -8560,6 +8589,7 @@ extension Search: GlobalAttributes {
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Search {
         return mutate(title: value)
     }
@@ -8743,6 +8773,7 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Division {
         return mutate(title: value)
     }
@@ -9022,6 +9053,7 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Definition {
         return mutate(title: value)
     }
@@ -9301,6 +9333,7 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Cite {
         return mutate(title: value)
     }
@@ -9580,6 +9613,7 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> ShortQuote {
         return mutate(title: value)
     }
@@ -9863,6 +9897,7 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Abbreviation {
         return mutate(title: value)
     }
@@ -10142,6 +10177,7 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Ruby {
         return mutate(title: value)
     }
@@ -10421,6 +10457,7 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Data {
         return mutate(title: value)
     }
@@ -10446,6 +10483,7 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         return self
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> Data {
         return mutate(value: value)
     }
@@ -10708,6 +10746,7 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Time {
         return mutate(title: value)
     }
@@ -10991,6 +11030,7 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Code {
         return mutate(title: value)
     }
@@ -11282,6 +11322,7 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Variable {
         return mutate(title: value)
     }
@@ -11561,6 +11602,7 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> SampleOutput {
         return mutate(title: value)
     }
@@ -11840,6 +11882,7 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> KeyboardInput {
         return mutate(title: value)
     }
@@ -12118,6 +12161,7 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Subscript {
         return mutate(title: value)
     }
@@ -12397,6 +12441,7 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Superscript {
         return mutate(title: value)
     }
@@ -12676,6 +12721,7 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Italic {
         return mutate(title: value)
     }
@@ -12962,6 +13008,7 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Bold {
         return mutate(title: value)
     }
@@ -13248,6 +13295,7 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Underline {
         return mutate(title: value)
     }
@@ -13534,6 +13582,7 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Mark {
         return mutate(title: value)
     }
@@ -13813,6 +13862,7 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Bdi {
         return mutate(title: value)
     }
@@ -14087,6 +14137,7 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Bdo {
         return mutate(title: value)
     }
@@ -14366,6 +14417,7 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Span {
         return mutate(title: value)
     }
@@ -14640,6 +14692,7 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> LineBreak {
         return mutate(title: value)
     }
@@ -14914,6 +14967,7 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> WordBreak {
         return mutate(title: value)
     }
@@ -15193,6 +15247,7 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> InsertedText {
         return mutate(title: value)
     }
@@ -15480,6 +15535,7 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> DeletedText {
         return mutate(title: value)
     }
@@ -15767,6 +15823,7 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Picture {
         return mutate(title: value)
     }
@@ -15969,6 +16026,7 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Image {
         return mutate(title: value)
     }
@@ -15994,6 +16052,7 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return self
     }
     
+    @_disfavoredOverload
     public func alternate(_ value: String) -> Image {
         return mutate(alternate: value)
     }
@@ -16300,6 +16359,7 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> InlineFrame {
         return mutate(title: value)
     }
@@ -16614,6 +16674,7 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Embed {
         return mutate(title: value)
     }
@@ -16913,6 +16974,7 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Object {
         return mutate(title: value)
     }
@@ -17216,6 +17278,7 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Video {
         return mutate(title: value)
     }
@@ -17554,6 +17617,7 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Audio {
         return mutate(title: value)
     }
@@ -17875,6 +17939,7 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Map {
         return mutate(title: value)
     }
@@ -18082,6 +18147,7 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Form {
         return mutate(title: value)
     }
@@ -18403,6 +18469,7 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> DataList {
         return mutate(title: value)
     }
@@ -18682,6 +18749,7 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Output {
         return mutate(title: value)
     }
@@ -18973,6 +19041,7 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Progress {
         return mutate(title: value)
     }
@@ -19002,6 +19071,7 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(max: value)
     }
 
+    @_disfavoredOverload
     public func value(_ value: String) -> Progress {
         return mutate(value: value)
     }
@@ -19264,6 +19334,7 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Meter {
         return mutate(title: value)
     }
@@ -19309,6 +19380,7 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(optimum: value)
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> Meter {
         return mutate(value: value)
     }
@@ -19571,6 +19643,7 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Details {
         return mutate(title: value)
     }
@@ -19854,6 +19927,7 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Dialog {
         return mutate(title: value)
     }
@@ -20137,6 +20211,7 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Script {
         return mutate(title: value)
     }
@@ -20368,6 +20443,7 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> NoScript {
         return mutate(title: value)
     }
@@ -20571,6 +20647,7 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Template {
         return mutate(title: value)
     }
@@ -20778,6 +20855,7 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Canvas {
         return mutate(title: value)
     }
@@ -21065,6 +21143,7 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Table {
         return mutate(title: value)
     }
@@ -21460,6 +21539,7 @@ extension Slot: GlobalAttributes, NameAttribute {
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Slot {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -525,6 +525,10 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Article {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
+    
+    public func title(verbatim value: String) -> Article {
+        return mutate(title: value)
+    }
 
     public func translate(_ value: Values.Decision) -> Article {
         return mutate(translate: value.rawValue)
@@ -804,6 +808,10 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Section {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Section {
+        return mutate(title: value)
     }
 
     public func translate(_ value: Values.Decision) -> Section {
@@ -1086,6 +1094,10 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Navigation {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Navigation {
         return mutate(translate: value.rawValue)
     }
@@ -1366,6 +1378,10 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Aside {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Aside {
         return mutate(translate: value.rawValue)
     }
@@ -1644,6 +1660,10 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading1 {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Heading1 {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Heading1 {
@@ -1933,6 +1953,10 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Heading2 {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Heading2 {
         return mutate(translate: value.rawValue)
     }
@@ -2218,6 +2242,10 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading3 {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Heading3 {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Heading3 {
@@ -2507,6 +2535,10 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Heading4 {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Heading4 {
         return mutate(translate: value.rawValue)
     }
@@ -2792,6 +2824,10 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Heading5 {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Heading5 {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Heading5 {
@@ -3081,6 +3117,10 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Heading6 {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Heading6 {
         return mutate(translate: value.rawValue)
     }
@@ -3368,6 +3408,10 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> HeadingGroup {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> HeadingGroup {
         return mutate(translate: value.rawValue)
     }
@@ -3646,6 +3690,10 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Header {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Header {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Header {
@@ -3928,6 +3976,10 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Footer {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Footer {
         return mutate(translate: value.rawValue)
     }
@@ -4208,6 +4260,10 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Address {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Address {
         return mutate(translate: value.rawValue)
     }
@@ -4486,6 +4542,10 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Paragraph {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Paragraph {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Paragraph {
@@ -4770,6 +4830,10 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> HorizontalRule {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> HorizontalRule {
         return mutate(translate: value.rawValue)
     }
@@ -5050,6 +5114,10 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> PreformattedText {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> PreformattedText {
         return mutate(translate: value.rawValue)
     }
@@ -5328,6 +5396,10 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Blockquote {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Blockquote {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Blockquote {
@@ -5619,6 +5691,10 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> OrderedList {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> OrderedList {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> OrderedList {
@@ -5913,6 +5989,10 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> UnorderedList {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> UnorderedList {
         return mutate(translate: value.rawValue)
     }
@@ -6193,6 +6273,10 @@ extension Menu: GlobalAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Menu {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Menu {
         return mutate(translate: value.rawValue)
     }
@@ -6375,6 +6459,10 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> DescriptionList {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> DescriptionList {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> DescriptionList {
@@ -6657,6 +6745,10 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Figure {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Figure {
         return mutate(translate: value.rawValue)
     }
@@ -6935,6 +7027,10 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Anchor {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Anchor {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Anchor {
@@ -7260,6 +7356,10 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Emphasize {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Emphasize {
         return mutate(translate: value.rawValue)
     }
@@ -7540,6 +7640,10 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Strong {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Strong {
         return mutate(translate: value.rawValue)
     }
@@ -7818,6 +7922,10 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Small {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Small {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Small {
@@ -8107,6 +8215,10 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> StrikeThrough {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> StrikeThrough {
         return mutate(translate: value.rawValue)
     }
@@ -8316,6 +8428,10 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Main {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Main {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Main {
@@ -8598,6 +8714,10 @@ extension Search: GlobalAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Search {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Search {
         return mutate(translate: value.rawValue)
     }
@@ -8780,6 +8900,10 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Division {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Division {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Division {
@@ -9062,6 +9186,10 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Definition {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Definition {
         return mutate(translate: value.rawValue)
     }
@@ -9342,6 +9470,10 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Cite {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Cite {
         return mutate(translate: value.rawValue)
     }
@@ -9620,6 +9752,10 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> ShortQuote {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> ShortQuote {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> ShortQuote {
@@ -9906,6 +10042,10 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Abbreviation {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Abbreviation {
         return mutate(translate: value.rawValue)
     }
@@ -10184,6 +10324,10 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Ruby {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Ruby {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Ruby {
@@ -10466,6 +10610,10 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Data {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Data {
         return mutate(translate: value.rawValue)
     }
@@ -10490,6 +10638,10 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Data {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Data {
+        return mutate(value: value)
     }
     
     public func popover(_ value: Values.Popover.State) -> Data {
@@ -10753,6 +10905,10 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Time {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Time {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Time {
@@ -11037,6 +11193,10 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Code {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Code {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Code {
@@ -11331,6 +11491,10 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Variable {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Variable {
         return mutate(translate: value.rawValue)
     }
@@ -11609,6 +11773,10 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> SampleOutput {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> SampleOutput {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> SampleOutput {
@@ -11891,6 +12059,10 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> KeyboardInput {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> KeyboardInput {
         return mutate(translate: value.rawValue)
     }
@@ -12168,6 +12340,10 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Subscript {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Subscript {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Subscript {
@@ -12450,6 +12626,10 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Superscript {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Superscript {
         return mutate(translate: value.rawValue)
     }
@@ -12728,6 +12908,10 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Italic {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Italic {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Italic {
@@ -13017,6 +13201,10 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Bold {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Bold {
         return mutate(translate: value.rawValue)
     }
@@ -13302,6 +13490,10 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Underline {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Underline {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Underline {
@@ -13591,6 +13783,10 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Mark {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Mark {
         return mutate(translate: value.rawValue)
     }
@@ -13871,6 +14067,10 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Bdi {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Bdi {
         return mutate(translate: value.rawValue)
     }
@@ -14144,6 +14344,10 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Bdo {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Bdo {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Bdo {
@@ -14426,6 +14630,10 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Span {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Span {
         return mutate(translate: value.rawValue)
     }
@@ -14701,6 +14909,10 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> LineBreak {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> LineBreak {
         return mutate(translate: value.rawValue)
     }
@@ -14974,6 +15186,10 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> WordBreak {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> WordBreak {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> WordBreak {
@@ -15254,6 +15470,10 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> InsertedText {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> InsertedText {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> InsertedText {
@@ -15544,6 +15764,10 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> DeletedText {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> DeletedText {
         return mutate(translate: value.rawValue)
     }
@@ -15832,6 +16056,10 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Picture {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Picture {
         return mutate(translate: value.rawValue)
     }
@@ -16035,6 +16263,10 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Image {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Image {
         return mutate(translate: value.rawValue)
     }
@@ -16059,6 +16291,10 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Image {
         return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func alternate(verbatim value: String) -> Image {
+        return mutate(alternate: value)
     }
     
     public func source(_ value: String) -> Image {
@@ -16366,6 +16602,10 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> InlineFrame {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> InlineFrame {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> InlineFrame {
@@ -16683,6 +16923,10 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Embed {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Embed {
         return mutate(translate: value.rawValue)
     }
@@ -16981,6 +17225,10 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Object {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Object {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Object {
@@ -17285,6 +17533,10 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Video {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Video {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Video {
@@ -17626,6 +17878,10 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Audio {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Audio {
         return mutate(translate: value.rawValue)
     }
@@ -17948,6 +18204,10 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Map {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Map {
         return mutate(translate: value.rawValue)
     }
@@ -18154,6 +18414,10 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Form {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Form {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Form {
@@ -18478,6 +18742,10 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> DataList {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> DataList {
         return mutate(translate: value.rawValue)
     }
@@ -18756,6 +19024,10 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Output {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Output {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Output {
@@ -19050,6 +19322,10 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Progress {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Progress {
         return mutate(translate: value.rawValue)
     }
@@ -19078,6 +19354,10 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Progress {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Progress {
+        return mutate(value: value)
     }
     
     public func popover(_ value: Values.Popover.State) -> Progress {
@@ -19343,6 +19623,10 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Meter {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Meter {
         return mutate(translate: value.rawValue)
     }
@@ -19387,6 +19671,10 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Meter {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Meter {
+        return mutate(value: value)
     }
     
     public func popover(_ value: Values.Popover.State) -> Meter {
@@ -19650,6 +19938,10 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Details {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Details {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Details {
@@ -19936,6 +20228,10 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Dialog {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Dialog {
         return mutate(translate: value.rawValue)
     }
@@ -20220,6 +20516,10 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Script {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Script {
         return mutate(translate: value.rawValue)
     }
@@ -20452,6 +20752,10 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> NoScript {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> NoScript {
         return mutate(translate: value.rawValue)
     }
@@ -20654,6 +20958,10 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Template {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Template {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Template {
@@ -20862,6 +21170,10 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Canvas {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Canvas {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Canvas {
@@ -21150,6 +21462,10 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Table {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Table {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Table {
@@ -21546,6 +21862,10 @@ extension Slot: GlobalAttributes, NameAttribute {
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Slot {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Slot {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Slot {

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -185,6 +185,10 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TermName {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
+    
+    public func title(verbatim value: String) -> TermName {
+        return mutate(title: value)
+    }
 
     public func translate(_ value: Values.Decision) -> TermName {
         return mutate(translate: value.rawValue)
@@ -464,6 +468,10 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TermDefinition {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> TermDefinition {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> TermDefinition {

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -177,6 +177,7 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TermName {
         return mutate(title: value)
     }
@@ -456,6 +457,7 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TermDefinition {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -180,6 +180,10 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     public func title(_ value: String) -> TermName {
         return mutate(title: value)
     }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TermName {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
 
     public func translate(_ value: Values.Decision) -> TermName {
         return mutate(translate: value.rawValue)
@@ -454,6 +458,10 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
 
     public func title(_ value: String) -> TermDefinition {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TermDefinition {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> TermDefinition {

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -176,6 +176,10 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> FigureCaption {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> FigureCaption {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -171,6 +171,10 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> FigureCaption {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> FigureCaption {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -167,6 +167,7 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> FigureCaption {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -181,6 +181,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(alternate: value)
     }
     
+    public func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Input {
+        return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     @available(*, deprecated, message: "The autocomplete attribute is actually a enum attribute. You should use autocomplete(_:) instead.")
     public func hasCompletion(_ value: Bool) -> Input {
 

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -331,6 +331,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(value: value)
     }
     
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Input {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func width(_ size: Int) -> Input {
         return mutate(width: size)
     }
@@ -1486,6 +1490,10 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func value(_ value: String) -> Button {
         return mutate(value: value)
+    }
+    
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Button {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func popover(_ value: Values.Popover.State) -> Button {

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -152,6 +152,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Input {
         return mutate(title: value)
     }
@@ -181,6 +182,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(accept: value)
     }
     
+    @_disfavoredOverload
     public func alternate(_ value: String) -> Input {
         return mutate(alternate: value)
     }
@@ -277,6 +279,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(pattern: regex)
     }
     
+    @_disfavoredOverload
     public func placeholder(_ value: String) -> Input {
         return mutate(placeholder: value)
     }
@@ -331,6 +334,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(type: value.rawValue)
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> Input {
         return mutate(value: value)
     }
@@ -529,6 +533,7 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Label {
         return mutate(title: value)
     }
@@ -819,6 +824,7 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Select {
         return mutate(title: value)
     }
@@ -1082,6 +1088,7 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TextArea {
         return mutate(title: value)
     }
@@ -1158,6 +1165,7 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(name: value)
     }
     
+    @_disfavoredOverload
     public func placeholder(_ value: String) -> TextArea {
         return mutate(placeholder: value)
     }
@@ -1454,6 +1462,7 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Button {
         return mutate(title: value)
     }
@@ -1508,6 +1517,7 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(type: value.rawValue)
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> Button {
         return mutate(value: value)
     }
@@ -1785,6 +1795,7 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Fieldset {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -156,6 +156,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Input {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Input {
         return mutate(translate: value.rawValue)
     }
@@ -529,6 +533,10 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Label {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Label {
         return mutate(translate: value.rawValue)
     }
@@ -815,6 +823,10 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Select {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Select {
         return mutate(translate: value.rawValue)
     }
@@ -1072,6 +1084,10 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> TextArea {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TextArea {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> TextArea {
@@ -1442,6 +1458,10 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Button {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Button {
         return  mutate(translate: value.rawValue)
     }
@@ -1767,6 +1787,10 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> Fieldset {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Fieldset {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Fieldset {

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -161,6 +161,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Input {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Input {
         return mutate(translate: value.rawValue)
     }
@@ -189,6 +193,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
     
     public func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Input {
         return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func alternate(verbatim value: String) -> Input {
+        return mutate(alternate: value)
     }
     
     @available(*, deprecated, message: "The autocomplete attribute is actually a enum attribute. You should use autocomplete(_:) instead.")
@@ -288,6 +296,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(placeholder: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func placeholder(verbatim value: String) -> Input {
+        return mutate(placeholder: value)
+    }
+    
     public func readonly() -> Input {
         return mutate(readonly: "readonly")
     }
@@ -341,6 +353,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Input {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Input {
+        return mutate(value: value)
     }
     
     public func width(_ size: Int) -> Input {
@@ -540,6 +556,10 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Label {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Label {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Label {
@@ -833,6 +853,10 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Select {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Select {
         return mutate(translate: value.rawValue)
     }
@@ -1097,6 +1121,10 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> TextArea {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> TextArea {
         return mutate(translate: value.rawValue)
     }
@@ -1172,6 +1200,10 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func placeholder(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TextArea {
         return mutate(placeholder: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func placeholder(verbatim value: String) -> TextArea {
+        return mutate(placeholder: value)
     }
     
     public func readonly() -> TextArea {
@@ -1471,6 +1503,10 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Button {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Button {
         return  mutate(translate: value.rawValue)
     }
@@ -1524,6 +1560,10 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Button {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Button {
+        return mutate(value: value)
     }
     
     public func popover(_ value: Values.Popover.State) -> Button {
@@ -1802,6 +1842,10 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Fieldset {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Fieldset {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Fieldset {

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -273,6 +273,10 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(placeholder: value)
     }
     
+    public func placeholder(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Input {
+        return mutate(placeholder: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func readonly() -> Input {
         return mutate(readonly: "readonly")
     }
@@ -1132,6 +1136,10 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func placeholder(_ value: String) -> TextArea {
         return mutate(placeholder: value)
+    }
+    
+    public func placeholder(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TextArea {
+        return mutate(placeholder: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func readonly() -> TextArea {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -166,6 +166,10 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Title {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Title {
         return mutate(translate: value.rawValue)
     }
@@ -363,6 +367,10 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Base {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Base {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Base {
@@ -572,6 +580,10 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Meta {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Meta {
         return mutate(translate: value.rawValue)
     }
@@ -596,6 +608,10 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
     
     public func content(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Meta {
         return mutate(content: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func content(verbatim value: String) -> Meta {
+        return mutate(content: value)
     }
     
     public func name(_ value: Values.Name) -> Meta {
@@ -799,6 +815,10 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Style {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Style {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Style {
@@ -1010,6 +1030,10 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Link {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Link {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Link {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -590,6 +590,10 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         return mutate(content: value)
     }
     
+    public func content(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Meta {
+        return mutate(content: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func name(_ value: Values.Name) -> Meta {
         return mutate(name: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -161,6 +161,10 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Title {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Title {
         return mutate(translate: value.rawValue)
     }
@@ -353,6 +357,10 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
     
     public func title(_ value: String) -> Base {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Base {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Base {
@@ -555,6 +563,10 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
 
     public func title(_ value: String) -> Meta {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Meta {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Meta {
@@ -776,6 +788,10 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Style {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Style {
         return mutate(translate: value.rawValue)
     }
@@ -980,6 +996,10 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
 
     public func title(_ value: String) -> Link {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Link {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Link {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -157,6 +157,7 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Title {
         return mutate(title: value)
     }
@@ -355,6 +356,7 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Base {
         return mutate(title: value)
     }
@@ -561,6 +563,7 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Meta {
         return mutate(title: value)
     }
@@ -586,6 +589,7 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         return self
     }
 
+    @_disfavoredOverload
     public func content(_ value: String) -> Meta {
         return mutate(content: value)
     }
@@ -788,6 +792,7 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Style {
         return mutate(title: value)
     }
@@ -998,6 +1003,7 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Link {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -166,6 +166,10 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Head {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Head {
         return mutate(translate: value.rawValue)
     }
@@ -368,6 +372,10 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Body {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Body {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Body {

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -161,6 +161,10 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Head {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Head {
         return mutate(translate: value.rawValue)
     }
@@ -358,6 +362,10 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
 
     public func title(_ value: String) -> Body {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Body {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Body {

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -157,6 +157,7 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return mutate(tabindex: value)
     }
     
+    @_disfavoredOverload
     public func title(_ value: String) -> Head {
         return mutate(title: value)
     }
@@ -360,6 +361,7 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Body {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -171,6 +171,10 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> OptionGroup {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> OptionGroup {
         return mutate(translate: value.rawValue)
     }
@@ -461,6 +465,10 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
 
     public func title(_ value: String) -> Option {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Option {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Option {
@@ -769,6 +777,10 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Legend {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Legend {
         return mutate(translate: value.rawValue)
     }
@@ -1042,6 +1054,10 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
 
     public func title(_ value: String) -> Summary {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Summary {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Summary {

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -172,6 +172,10 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(title: value)
     }
     
+    public func title(verbatim value: String) -> OptionGroup {
+        return mutate(title: value)
+    }
+    
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> OptionGroup {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
@@ -473,6 +477,10 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Option {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Option {
         return mutate(translate: value.rawValue)
     }
@@ -514,6 +522,10 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Option {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Option {
+        return mutate(value: value)
     }
     
     public func selected() -> Option {
@@ -783,6 +795,10 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Legend {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Legend {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Legend {
@@ -1063,6 +1079,10 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Summary {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Summary {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Summary {

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -167,6 +167,7 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> OptionGroup {
         return mutate(title: value)
     }
@@ -463,6 +464,7 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Option {
         return mutate(title: value)
     }
@@ -505,6 +507,7 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(label: value)
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> Option {
         return mutate(value: value)
     }
@@ -773,6 +776,7 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Legend {
         return mutate(title: value)
     }
@@ -1052,6 +1056,7 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Summary {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -501,6 +501,10 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(value: value)
     }
     
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Option {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func selected() -> Option {
         return mutate(selected: "selected")
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -192,6 +192,10 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(value: value)
     }
     
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> ListItem {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func popover(_ value: Values.Popover.State) -> ListItem {
         return mutate(popover: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -171,6 +171,10 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> ListItem {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> ListItem {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -167,6 +167,7 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> ListItem {
         return mutate(title: value)
     }
@@ -192,6 +193,7 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> ListItem {
         return mutate(value: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -176,6 +176,10 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> ListItem {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> ListItem {
         return mutate(translate: value.rawValue)
     }
@@ -200,6 +204,10 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> ListItem {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> ListItem {
+        return mutate(value: value)
     }
     
     public func popover(_ value: Values.Popover.State) -> ListItem {

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -174,6 +174,10 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Area {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Area {
         return mutate(translate: value.rawValue)
     }
@@ -198,6 +202,10 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
     
     public func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Area {
         return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func alternate(verbatim value: String) -> Area {
+        return mutate(alternate: value)
     }
     
     public func coordinates(_ value: String) -> Area {

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -165,6 +165,7 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Area {
         return mutate(title: value)
     }
@@ -190,6 +191,7 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return self
     }
     
+    @_disfavoredOverload
     public func alternate(_ value: String) -> Area {
         return mutate(alternate: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -190,6 +190,10 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(alternate: value)
     }
     
+    public func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Area {
+        return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func coordinates(_ value: String) -> Area {
         return mutate(coords: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -169,6 +169,10 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Area {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Area {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -152,6 +152,7 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Source {
         return mutate(title: value)
     }
@@ -382,6 +383,7 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Track {
         return  mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -156,6 +156,10 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Source {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Source {
         return mutate(translate: value.rawValue)
     }
@@ -380,6 +384,10 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
 
     public func title(_ value: String) -> Track {
         return  mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Track {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> Track {

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -161,6 +161,10 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Source {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Source {
         return mutate(translate: value.rawValue)
     }
@@ -390,6 +394,10 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Track {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> Track {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> Track {

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -162,6 +162,7 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Parameter {
         return mutate(title: value)
     }
@@ -191,6 +192,7 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return mutate(name: value)
     }
     
+    @_disfavoredOverload
     public func value(_ value: String) -> Parameter {
         return mutate(value: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -171,6 +171,10 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Parameter {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Parameter {
         return mutate(translate: value.rawValue)
     }
@@ -199,6 +203,10 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
     
     public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Parameter {
         return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func value(verbatim value: String) -> Parameter {
+        return mutate(value: value)
     }
     
     public func popover(_ value: Values.Popover.State) -> Parameter {

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -191,6 +191,10 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return mutate(value: value)
     }
     
+    public func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Parameter {
+        return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func popover(_ value: Values.Popover.State) -> Parameter {
         return mutate(popover: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -166,6 +166,10 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Parameter {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Parameter {
         return mutate(translate: value.rawValue)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -186,6 +186,10 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> RubyText {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> RubyText {
         return mutate(translate: value.rawValue)
     }
@@ -464,6 +468,10 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> RubyPronunciation {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> RubyPronunciation {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> RubyPronunciation {

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -177,6 +177,7 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> RubyText {
         return mutate(title: value)
     }
@@ -456,6 +457,7 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> RubyPronunciation {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -181,6 +181,10 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> RubyText {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> RubyText {
         return mutate(translate: value.rawValue)
     }
@@ -454,6 +458,10 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
 
     public func title(_ value: String) -> RubyPronunciation {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> RubyPronunciation {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> RubyPronunciation {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -237,6 +237,7 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Caption {
         return mutate(title: value)
     }
@@ -516,6 +517,7 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> ColumnGroup {
         return mutate(title: value)
     }
@@ -731,6 +733,7 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> Column {
         return mutate(title: value)
     }
@@ -938,6 +941,7 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TableBody {
         return mutate(title: value)
     }
@@ -1225,6 +1229,7 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TableHead {
         return mutate(title: value)
     }
@@ -1512,6 +1517,7 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TableFoot {
         return mutate(title: value)
     }
@@ -1791,6 +1797,7 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> TableRow {
         return mutate(title: value)
     }
@@ -2078,6 +2085,7 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> DataCell {
         return mutate(title: value)
     }
@@ -2369,6 +2377,7 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(tabindex: value)
     }
 
+    @_disfavoredOverload
     public func title(_ value: String) -> HeaderCell {
         return mutate(title: value)
     }

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -241,6 +241,10 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Caption {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Caption {
         return mutate(translate: value.rawValue)
     }
@@ -516,6 +520,10 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> ColumnGroup {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> ColumnGroup {
         return mutate(translate: value.rawValue)
     }
@@ -727,6 +735,10 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Column {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> Column {
         return mutate(translate: value.rawValue)
     }
@@ -928,6 +940,10 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
 
     public func title(_ value: String) -> TableBody {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TableBody {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> TableBody {
@@ -1213,6 +1229,10 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TableHead {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> TableHead {
         return mutate(translate: value.rawValue)
     }
@@ -1496,6 +1516,10 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: value)
     }
     
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TableFoot {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
     public func translate(_ value: Values.Decision) -> TableFoot {
         return mutate(translate: value.rawValue)
     }
@@ -1769,6 +1793,10 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> TableRow {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TableRow {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> TableRow {
@@ -2052,6 +2080,10 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
 
     public func title(_ value: String) -> DataCell {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> DataCell {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> DataCell {
@@ -2339,6 +2371,10 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
 
     public func title(_ value: String) -> HeaderCell {
         return mutate(title: value)
+    }
+    
+    public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> HeaderCell {
+        return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
     public func translate(_ value: Values.Decision) -> HeaderCell {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -246,6 +246,10 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Caption {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Caption {
         return mutate(translate: value.rawValue)
     }
@@ -526,6 +530,10 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> ColumnGroup {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> ColumnGroup {
         return mutate(translate: value.rawValue)
     }
@@ -742,6 +750,10 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> Column {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> Column {
         return mutate(translate: value.rawValue)
     }
@@ -948,6 +960,10 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TableBody {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> TableBody {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> TableBody {
@@ -1238,6 +1254,10 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> TableHead {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> TableHead {
         return mutate(translate: value.rawValue)
     }
@@ -1526,6 +1546,10 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
     }
     
+    public func title(verbatim value: String) -> TableFoot {
+        return mutate(title: value)
+    }
+    
     public func translate(_ value: Values.Decision) -> TableFoot {
         return mutate(translate: value.rawValue)
     }
@@ -1804,6 +1828,10 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> TableRow {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> TableRow {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> TableRow {
@@ -2092,6 +2120,10 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> DataCell {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> DataCell {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> DataCell {
@@ -2384,6 +2416,10 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     
     public func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> HeaderCell {
         return mutate(title: LocalizedString(key: localizedKey, table: tableName))
+    }
+    
+    public func title(verbatim value: String) -> HeaderCell {
+        return mutate(title: value)
     }
     
     public func translate(_ value: Values.Decision) -> HeaderCell {

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -522,7 +522,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func value(_ value: String) -> Tag {
-            return self.mutate(value: value)
+            return mutate(value: value)
+        }
+        
+        func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
+            return mutate(value: LocalizedString(key: localizedKey, table: tableName))
         }
         
         func width(_ size: Int) -> Tag {
@@ -2128,6 +2132,19 @@ final class AttributesTests: XCTestCase {
         XCTAssertEqual(try renderer.render(view: view),
                        """
                        <tag decoding="async"></tag>
+                       """
+        )
+    }
+    
+    func testValueAttribute() throws {
+        
+        let view = TestView {
+            Tag {}.value("value")
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <tag value="value"></tag>
                        """
         )
     }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -134,6 +134,7 @@ final class AttributesTests: XCTestCase {
             return self.mutate(tabindex: value)
         }
         
+        @_disfavoredOverload
         func title(_ value: String) -> Tag {
             return self.mutate(title: value)
         }
@@ -154,6 +155,7 @@ final class AttributesTests: XCTestCase {
             return self.mutate(action: value)
         }
         
+        @_disfavoredOverload
         func alternate(_ value: String) -> Tag {
             return self.mutate(alternate: value)
         }
@@ -394,6 +396,7 @@ final class AttributesTests: XCTestCase {
             return self.mutate(ping: value)
         }
         
+        @_disfavoredOverload
         func placeholder(_ value: String) -> Tag {
             return self.mutate(placeholder: value)
         }
@@ -529,6 +532,7 @@ final class AttributesTests: XCTestCase {
             return self.mutate(type: value)
         }
         
+        @_disfavoredOverload
         func value(_ value: String) -> Tag {
             return mutate(value: value)
         }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -138,6 +138,10 @@ final class AttributesTests: XCTestCase {
             return self.mutate(title: value)
         }
         
+        func title(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
+            return self.mutate(title: LocalizedString(key: localizedKey, table: tableName))
+        }
+        
         func translate(_ value: Values.Decision) -> Tag {
             return self.mutate(translate: value.rawValue)
         }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -143,6 +143,10 @@ final class AttributesTests: XCTestCase {
             return self.mutate(title: LocalizedString(key: localizedKey, table: tableName))
         }
         
+        func title(verbatim value: String) -> Tag {
+            return self.mutate(title: value)
+        }
+        
         func translate(_ value: Values.Decision) -> Tag {
             return self.mutate(translate: value.rawValue)
         }
@@ -162,6 +166,10 @@ final class AttributesTests: XCTestCase {
         
         func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
             return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+        }
+        
+        func alternate(verbatim value: String) -> Tag {
+            return self.mutate(alternate: value)
         }
         
         func asynchronously() -> Tag {
@@ -224,6 +232,10 @@ final class AttributesTests: XCTestCase {
         
         public func content(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
             return mutate(content: LocalizedString(key: localizedKey, table: tableName))
+        }
+        
+        public func content(verbatim value: String) -> Tag {
+            return mutate(content: value)
         }
         
         func controls() -> Tag {
@@ -405,6 +417,10 @@ final class AttributesTests: XCTestCase {
             return self.mutate(placeholder: LocalizedString(key: localizedKey, table: tableName))
         }
         
+        func placeholder(verbatim value: String) -> Tag {
+            return self.mutate(placeholder: value)
+        }
+        
         func playInline(_ condition: Bool = true) -> Tag {
             
             if condition {
@@ -539,6 +555,10 @@ final class AttributesTests: XCTestCase {
         
         func value(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
             return mutate(value: LocalizedString(key: localizedKey, table: tableName))
+        }
+        
+        func value(verbatim value: String) -> Tag {
+            return mutate(value: value)
         }
         
         func width(_ size: Int) -> Tag {

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -386,6 +386,10 @@ final class AttributesTests: XCTestCase {
             return self.mutate(placeholder: value)
         }
         
+        func placeholder(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
+            return self.mutate(placeholder: LocalizedString(key: localizedKey, table: tableName))
+        }
+        
         func playInline(_ condition: Bool = true) -> Tag {
             
             if condition {

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -154,6 +154,10 @@ final class AttributesTests: XCTestCase {
             return self.mutate(alternate: value)
         }
         
+        func alternate(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
+            return mutate(alternate: LocalizedString(key: localizedKey, table: tableName))
+        }
+        
         func asynchronously() -> Tag {
             return self.mutate(async: "async")
         }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -217,7 +217,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func content(_ value: String) -> Tag {
-            return self.mutate(content: value)
+            return mutate(content: value)
+        }
+        
+        public func content(_ localizedKey: LocalizedStringKey, tableName: String? = nil) -> Tag {
+            return mutate(content: LocalizedString(key: localizedKey, table: tableName))
         }
         
         func controls() -> Tag {

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -37,6 +37,8 @@ final class LocalizationTests: XCTestCase {
         
         struct TestView: View {
             
+            let placeholder = "hello.world"
+            
             var body: Content {
                 Input()
                     .placeholder("hello.world", tableName: nil)
@@ -44,14 +46,17 @@ final class LocalizationTests: XCTestCase {
                     .value(LocalizedStringKey("hello.world"), tableName: "web")
                     .title("hello.world", tableName: "mobile")
                 Meta()
-                    .content("hello.world", tableName: nil)
+                    .content("hello.world")
+                TextArea {}
+                    .placeholder(placeholder)
             }
         }
         
         XCTAssertEqual(try renderer!.render(view: TestView()),
                        """
                        <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">\
-                       <meta content="Hello World">
+                       <meta content="Hello World">\
+                       <textarea placeholder="hello.world"></textarea>
                        """
         )
     }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -40,12 +40,13 @@ final class LocalizationTests: XCTestCase {
             var body: Content {
                 Input()
                     .placeholder("hello.world", tableName: nil)
+                    .alternate(LocalizedStringKey("hello.world"))
             }
         }
         
         XCTAssertEqual(try renderer!.render(view: TestView()),
                        """
-                       <input placeholder="Hello World">
+                       <input placeholder="Hello World" alt="Hello World">
                        """
         )
     }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -47,6 +47,11 @@ final class LocalizationTests: XCTestCase {
                     .title("hello.world", tableName: "mobile")
                 Meta()
                     .content("hello.world")
+                Input()
+                    .placeholder(verbatim: "hello.world")
+                    .alternate(verbatim: "hello.world")
+                    .value(verbatim: placeholder)
+                    .title(verbatim: "hello.world")
                 TextArea {}
                     .placeholder(placeholder)
             }
@@ -56,6 +61,7 @@ final class LocalizationTests: XCTestCase {
                        """
                        <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">\
                        <meta content="Hello World">\
+                       <input placeholder="hello.world" alt="hello.world" value="hello.world" title="hello.world">\
                        <textarea placeholder="hello.world"></textarea>
                        """
         )

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -41,12 +41,13 @@ final class LocalizationTests: XCTestCase {
                 Input()
                     .placeholder("hello.world", tableName: nil)
                     .alternate(LocalizedStringKey("hello.world"))
+                    .value(LocalizedStringKey("hello.world"), tableName: "web")
             }
         }
         
         XCTAssertEqual(try renderer!.render(view: TestView()),
                        """
-                       <input placeholder="Hello World" alt="Hello World">
+                       <input placeholder="Hello World" alt="Hello World" value="Hello World">
                        """
         )
     }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -43,12 +43,15 @@ final class LocalizationTests: XCTestCase {
                     .alternate(LocalizedStringKey("hello.world"))
                     .value(LocalizedStringKey("hello.world"), tableName: "web")
                     .title("hello.world", tableName: "mobile")
+                Meta()
+                    .content("hello.world", tableName: nil)
             }
         }
         
         XCTAssertEqual(try renderer!.render(view: TestView()),
                        """
-                       <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">
+                       <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">\
+                       <meta content="Hello World">
                        """
         )
     }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -42,12 +42,13 @@ final class LocalizationTests: XCTestCase {
                     .placeholder("hello.world", tableName: nil)
                     .alternate(LocalizedStringKey("hello.world"))
                     .value(LocalizedStringKey("hello.world"), tableName: "web")
+                    .title("hello.world", tableName: "mobile")
             }
         }
         
         XCTAssertEqual(try renderer!.render(view: TestView()),
                        """
-                       <input placeholder="Hello World" alt="Hello World" value="Hello World">
+                       <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">
                        """
         )
     }

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -30,6 +30,26 @@ final class LocalizationTests: XCTestCase {
         )
     }
     
+    /// Tests the localization of a attribute
+    ///
+    /// The test expects the key to exist in the default translation table and to be rendered correctly.
+    func testLocalizationAttribute() throws {
+        
+        struct TestView: View {
+            
+            var body: Content {
+                Input()
+                    .placeholder("hello.world", tableName: nil)
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: TestView()),
+                       """
+                       <input placeholder="Hello World">
+                       """
+        )
+    }
+    
     /// Tests the localization of string interpolation
     ///
     /// The test expects the key to exist in the default translation table and to be correctly formatted


### PR DESCRIPTION
Currently, only a few of the elements are localizable. However, there a some cases where you might want to localize the value of certain attributes e.g. `.title()`, `.value()`, `.placeholder()`, `.alternate()` and `.content()` as well. This pull request adds support for that.

It also adds support for verbatim content, in case someone has localization enabled but explicitly does not want the value to be translated.

```swift
Input()
   .placeholder(verbatim: "Lorem ipsum....")
```