### PR TITLE
Make localization errors non-fatal

### DIFF
--- a/Sources/HTMLKit/Framework/Localization/Localization.swift
+++ b/Sources/HTMLKit/Framework/Localization/Localization.swift
@@ -252,4 +252,32 @@ public class Localization {
         
         throw Errors.missingKey(string.key.value, currentLocale.tag)
     }
+    
+    /// Recovers from an error.
+    ///
+    /// - Parameters:
+    ///   - priorError: The prior error to compare to
+    ///   - string: The string to localize
+    ///
+    /// - Returns: The translation or the string literal
+    internal func recover(from priorError: Errors, with string: LocalizedString) throws -> String {
+        
+        do {
+            
+            return try localize(string: string)
+            
+        } catch let error as Errors {
+            
+            switch error {
+            case .missingKey where error != priorError:
+                return try recover(from: error, with: string)
+                
+            case .missingTable where error != priorError:
+                return try recover(from: error, with: string)
+                
+            default:
+                return string.key.literal
+            }
+        }
+    }
 }

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -302,7 +302,7 @@ public struct Renderer {
                     
                     logger.debug("Trying to recover from missing key")
                     
-                    return try localization.localize(string: string)
+                    return try localization.recover(from: error, with: string)
                 }
                 
                 fallthrough
@@ -311,7 +311,7 @@ public struct Renderer {
                 
                 logger.debug("Trying to recover from missing table")
                 
-                return try localization.localize(string: string)
+                return try localization.recover(from: error, with: string)
                 
             default:
                 return string.key.literal

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -302,6 +302,12 @@ public struct Renderer {
             }
             
             return string.key.literal
+            
+        }  catch Localization.Errors.missingTable(let tag) {
+            
+            logger.warning("Unable to find a translation table for the locale '\(tag)'.")
+            
+            return try localization.localize(string: string)
         }
     }
     

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -311,6 +311,10 @@ public struct Renderer {
                 
                 logger.debug("Trying to recover from missing table")
                 
+                // Clear the locale on the environment, since it cannot be used for the remainder of the rendering,
+                // otherwise it will throw an error each time
+                environment.upsert(Optional<Locale>.none, for: \EnvironmentKeys.locale)
+                
                 return try localization.recover(from: error, with: string)
                 
             default:

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -308,6 +308,12 @@ public struct Renderer {
             logger.warning("Unable to find a translation table for the locale '\(tag)'.")
             
             return try localization.localize(string: string)
+            
+        } catch {
+            
+            logger.warning("\(error)")
+            
+            return string.key.literal
         }
     }
     

--- a/Tests/HTMLKitTests/LocalizationTests.swift
+++ b/Tests/HTMLKitTests/LocalizationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class LocalizationTests: XCTestCase {
     
-    var renderer: Renderer?
+    var localization: Localization?
     
     override func setUp() {
         super.setUp()
@@ -16,55 +16,15 @@ final class LocalizationTests: XCTestCase {
     /// The test expects the key to exist in the default translation table and to be rendered correctly.
     func testLocalization() throws {
         
-        struct MainView: View {
-            
-            var body: Content {
-                Heading1("hello.world")
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: MainView()),
-                       """
-                       <h1>Hello World</h1>
-                       """
-        )
+        XCTAssertEqual(try localization!.localize(string: .init(key: "hello.world")), "Hello World")
     }
     
-    /// Tests the localization of a attribute
+    /// Tests the localization of a translation key in a specified translation table
     ///
-    /// The test expects the key to exist in the default translation table and to be rendered correctly.
-    func testLocalizationAttribute() throws {
+    /// The test expects the key to exist in the specified translation table and to be rendered accurately.
+    func testLocalizationWithTable() throws {
         
-        struct TestView: View {
-            
-            let placeholder = "hello.world"
-            
-            var body: Content {
-                Input()
-                    .placeholder("hello.world", tableName: nil)
-                    .alternate(LocalizedStringKey("hello.world"))
-                    .value(LocalizedStringKey("hello.world"), tableName: "web")
-                    .title("hello.world", tableName: "mobile")
-                Meta()
-                    .content("hello.world")
-                Input()
-                    .placeholder(verbatim: "hello.world")
-                    .alternate(verbatim: "hello.world")
-                    .value(verbatim: placeholder)
-                    .title(verbatim: "hello.world")
-                TextArea {}
-                    .placeholder(placeholder)
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: TestView()),
-                       """
-                       <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">\
-                       <meta content="Hello World">\
-                       <input placeholder="hello.world" alt="hello.world" value="hello.world" title="hello.world">\
-                       <textarea placeholder="hello.world"></textarea>
-                       """
-        )
+        XCTAssertEqual(try localization!.localize(string: .init(key: "hello.world", table: "web")), "Hello World")
     }
     
     /// Tests the localization of string interpolation
@@ -73,24 +33,10 @@ final class LocalizationTests: XCTestCase {
     /// and rendered accurately.
     func testLocalizationWithStringInterpolation() throws {
         
-        struct TestView: View {
-            
-            var body: Content {
-                Paragraph("String: \("John Doe")")
-                Paragraph("Integer: \(31)")
-                Paragraph("Double: \(12.5)")
-                Paragraph("Date: \(Date(timeIntervalSince1970: 50000))")
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: TestView()),
-                       """
-                       <p>String: John Doe</p>\
-                       <p>Integer: 31</p>\
-                       <p>Double: 12.5</p>\
-                       <p>Date: 01/01/1970</p>
-                       """
-        )
+        XCTAssertEqual(try localization!.localize(string: .init(key: "String: \("John Doe")")), "String: John Doe")
+        XCTAssertEqual(try localization!.localize(string: .init(key: "Integer: \(31)")), "Integer: 31")
+        XCTAssertEqual(try localization!.localize(string: .init(key: "Double: \(12.5)")), "Double: 12.5")
+        XCTAssertEqual(try localization!.localize(string: .init(key: "Date: \(Date(timeIntervalSince1970: 50000))")), "Date: 01/01/1970")
     }
     
     /// Tests the localization of string interpolation with multiple arguments and various data types
@@ -99,122 +45,35 @@ final class LocalizationTests: XCTestCase {
     /// with the arguments in the proper order, and to be rendered accurately.
     func testStringInterpolationWithMultipleArguments() throws {
         
-        struct TestView: View {
-            
-            var body: Content {
-                Paragraph("Hello \("Jane") and \("John Doe")")
-                Paragraph("Do you \(2) have time at \(Date(timeIntervalSince1970: 50000))?")
-                Paragraph("cheers.person \("Jean")")
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: TestView()),
-                       """
-                       <p>Hello Jane and John Doe</p>\
-                       <p>Do you 2 have time at 01/01/1970?</p>\
-                       <p>Cheers Jean</p>
-                       """
-        )
-    }
-    
-    /// Tests the localization of a translation key in a specified translation table
-    ///
-    /// The test expects the key to exist in the specified translation tabl and to be rendered accurately.
-    func testLocaliationWithTable() throws {
-        
-        struct TestView: View {
-            
-            var body: Content {
-                Paragraph("hello.world", tableName: "web")
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: TestView()),
-                       """
-                       <p>Hello World</p>
-                       """
-        )
-    }
-    
-    /// Tests the change of the locale by the environment modifier
-    ///
-    /// The test expects that the localization environment modifier correctly applies the locale
-    /// down to nested views
-    func testEnvironmentLocalization() throws {
-        
-        struct MainView: View {
-            
-            var content: [Content]
-            
-            init(@ContentBuilder<Content> content: () -> [Content]) {
-                self.content = content()
-            }
-            
-            var body: Content {
-                Division {
-                    content
-                }
-                .environment(key: \.locale, value: Locale(tag: .french))
-            }
-        }
-        
-        struct ChildView: View {
-            
-            var body: Content {
-                MainView {
-                    Heading1("hello.world")
-                        .environment(key: \.locale)
-                }
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: ChildView()),
-                       """
-                       <div>\
-                       <h1>Bonjour le monde</h1>\
-                       </div>
-                       """
-        )
+        XCTAssertEqual(try localization!.localize(string: .init(key: "Hello \("Jane") and \("John Doe")")), "Hello Jane and John Doe")
+        XCTAssertEqual(try localization!.localize(string: .init(key: "Do you \(2) have time at \(Date(timeIntervalSince1970: 50000))?")), "Do you 2 have time at 01/01/1970?")
+        XCTAssertEqual(try localization!.localize(string: .init(key: "cheers.person \("Jean")")), "Cheers Jean")
     }
     
     /// Tests the behavior when a localization key is missing
     ///
     /// A key is considered as missing if it cannot be found in the translation table. In this case,
-    /// the renderer is expected to use the fallback literal string.
+    /// the localization is expected to throw an error.
     func testMissingKey() throws {
         
-        struct MainView: View {
+        XCTAssertThrowsError(try localization!.localize(string: .init(key: "unknown.key")), "unknown.key") { error in
             
-            var body: Content {
-                Heading1("unknown.key")
+            guard let localizationError = error as? Localization.Errors else {
+                return XCTFail("Unexpected error type: \(error)")
             }
+            
+            XCTAssertEqual(localizationError, .missingKey("unknown.key", "en-GB"))
+            XCTAssertEqual(localizationError.description, "Unable to find translation key 'unknown.key' for the locale 'en-GB'.")
         }
-        
-        XCTAssertEqual(try renderer!.render(view: MainView()),
-                       """
-                       <h1>unknown.key</h1>
-                       """
-        )
     }
     
-    /// Tests the behavior when a translation table is missing
+    /// Tests the behavior when a translation table is missing.
     ///
     /// A table is considered as missing if there is no translation table for the given locale. In this case,
-    /// the renderer is expected to throw an error.
+    /// the localization is expected to throw an error.
     func testMissingTable() throws {
         
-        struct MainView: View {
-            
-            var body: Content {
-                Division {
-                    Heading1("greeting.world")
-                        .environment(key: \.locale)
-                }
-                .environment(key: \.locale, value: Locale(tag: "unknown.tag"))
-            }
-        }
-        
-        XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
+        XCTAssertThrowsError(try localization!.localize(string: .init(key: "hello.world"), for: .init(tag: "unknown.tag"))) { error in
             
             guard let localizationError = error as? Localization.Errors else {
                 return XCTFail("Unexpected error type: \(error)")
@@ -225,20 +84,13 @@ final class LocalizationTests: XCTestCase {
         }
     }
     
-    /// Tests the behavior when a translation table is unknown
+    /// Tests the behavior when a translation table is unknown.
     ///
     /// A table is considered as unknown if it cannot be found by the given table name. In this case,
-    /// the renderer is expected to throw an error.
+    /// the localization is expected to throw an error.
     func testUnknownTable() throws {
         
-        struct MainView: View {
-            
-            var body: Content {
-                Heading1("greeting.world", tableName: "unknown.table")
-            }
-        }
-        
-        XCTAssertThrowsError(try renderer!.render(view: MainView())) { error in
+        XCTAssertThrowsError(try localization!.localize(string: .init(key: "hello.world", table: "unknown.table"))) { error in
             
             guard let localizationError = error as? Localization.Errors else {
                 return XCTFail("Unexpected error type: \(error)")
@@ -247,46 +99,6 @@ final class LocalizationTests: XCTestCase {
             XCTAssertEqual(localizationError, .unknownTable("unknown.table", "en-GB"))
             XCTAssertEqual(localizationError.description, "Unable to find translation table 'unknown.table' for the locale 'en-GB'.")
         }
-    }
-    
-    /// Tests the recovery from a missing key
-    ///
-    /// The renderer should attempt a secondary lookup in the translation tables of the default locale.
-    func testRecoveryFromMissingKey() throws {
-        
-        struct MainView: View {
-            
-            var content: [Content]
-            
-            init(@ContentBuilder<Content> content: () -> [Content]) {
-                self.content = content()
-            }
-            
-            var body: Content {
-                Division {
-                    content
-                }
-                .environment(key: \.locale, value: Locale(tag: .french))
-            }
-        }
-        
-        struct ChildView: View {
-            
-            var body: Content {
-                MainView {
-                    Heading1("Hello \("John Doe")")
-                        .environment(key: \.locale)
-                }
-            }
-        }
-        
-        XCTAssertEqual(try renderer!.render(view: ChildView()),
-                       """
-                       <div>\
-                       <h1>Hello John Doe</h1>\
-                       </div>
-                       """
-        )
     }
 }
 
@@ -298,6 +110,6 @@ extension LocalizationTests {
             return
         }
         
-        self.renderer = Renderer(localization: .init(source: sourcePath, locale: .init(tag: "en-GB")))
+        self.localization = Localization(source: sourcePath, locale: .init(tag: "en-GB"))
     }
 }

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -553,6 +553,29 @@ final class RenderingTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests the recovery from a unknown table.
+    ///
+    /// The renderer should return the key instead.
+    func testRecoveryFromUnknownTable() throws {
+        
+        struct TestView: View {
+            
+            var body: Content {
+                Division {
+                    Heading1("hello.world", tableName: "unknown.table")
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: TestView()),
+                       """
+                       <div>\
+                       <h1>hello.world</h1>\
+                       </div>
+                       """
+        )
+    }
 }
 
 extension RenderingTests {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -576,6 +576,29 @@ final class RenderingTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests a cascade of recovery attempts, each triggered by the failure of the last.
+    ///
+    /// The renderer should bail with the string literal if recovery gets stuck.
+    func testRecoveryCascade() throws {
+        
+        struct TestView: View {
+            
+            var body: Content {
+                Division {
+                    Heading1("unknown.key", tableName: "unknown.table")
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: TestView()),
+                       """
+                       <div>\
+                       <h1>unknown.key</h1>\
+                       </div>
+                       """
+        )
+    }
 }
 
 extension RenderingTests {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -13,7 +13,14 @@ final class RenderingTests: XCTestCase {
         @ContentBuilder<Content> var body: Content
     }
     
-    var renderer = Renderer(features: [.markdown])
+    var renderer: Renderer?
+    
+    override func setUp() {
+        super.setUp()
+        
+        try! setupRendering()
+    }
+    
     
     func testRenderingDocument() throws {
         
@@ -28,7 +35,7 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <!DOCTYPE html>\
                        <html>\
@@ -50,7 +57,7 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <div>\
                        <p>text</p>\
@@ -65,7 +72,7 @@ final class RenderingTests: XCTestCase {
             Input()
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <input>
                        """
@@ -78,7 +85,7 @@ final class RenderingTests: XCTestCase {
             Comment("text")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <!--text-->
                        """
@@ -95,7 +102,7 @@ final class RenderingTests: XCTestCase {
             .class("class")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <p class="class">text</p>
                        """
@@ -112,7 +119,7 @@ final class RenderingTests: XCTestCase {
             .class("cl_ass")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <p class="cl_ass">text</p>
                        """
@@ -128,7 +135,7 @@ final class RenderingTests: XCTestCase {
             .class("cl-ass")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <p class="cl-ass">text</p>
                        """
@@ -145,7 +152,7 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <div>\
                        <p>text</p>\
@@ -167,7 +174,7 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <div class="modified"></div>
                        """
@@ -187,7 +194,7 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <div class="unmodified"></div>
                        """
@@ -205,7 +212,7 @@ final class RenderingTests: XCTestCase {
                 }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <input placeholder="test">
                        """
@@ -223,7 +230,7 @@ final class RenderingTests: XCTestCase {
             .custom(key: "key", value: "value")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <div key="value">\
                        <p>text</p>\
@@ -243,7 +250,7 @@ final class RenderingTests: XCTestCase {
             MarkdownString("\(italic: "italic")")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <em>italic</em>\
                        <em>italic</em>\
@@ -263,7 +270,7 @@ final class RenderingTests: XCTestCase {
             MarkdownString("\(bold: "bold")")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <strong>bold</strong>\
                        <strong>bold</strong>\
@@ -282,7 +289,7 @@ final class RenderingTests: XCTestCase {
             MarkdownString("___bold and italic___")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <em><strong>bold and italic</strong></em>\
                        <em><strong>bold and italic</strong></em>
@@ -300,7 +307,7 @@ final class RenderingTests: XCTestCase {
             MarkdownString("\(code: "code")")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <code>code</code>\
                        <code>code</code>
@@ -319,7 +326,7 @@ final class RenderingTests: XCTestCase {
             MarkdownString("\(strike: "strikethrough")")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <del>strikethrough</del>\
                        <del>strikethrough</del>\
@@ -339,7 +346,7 @@ final class RenderingTests: XCTestCase {
             MarkdownString("\(email: "alone@home.com")")
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <a href="https://www.vapor.codes" target="_blank">Link</a>\
                        <a href="https://www.vapor.codes" target="_blank">https://www.vapor.codes</a>\
@@ -357,7 +364,7 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <p>It consists of a list of features, like <strong>declarative syntax</strong>, <strong>language localization</strong>, <strong>dynamic context</strong>.</p>
                        """
@@ -378,10 +385,159 @@ final class RenderingTests: XCTestCase {
             }
         }
         
-        XCTAssertEqual(try renderer.render(view: view),
+        XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <strong>This text is <em>extremely</em> important.</strong>
                        """
         )
+    }
+    
+    /// Tests the localization of an element
+    ///
+    /// The test expects the key to exist in the default translation table and to be rendered correctly.
+    func testLocalization() throws {
+        
+        struct MainView: View {
+            
+            var body: Content {
+                Heading1("hello.world")
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: MainView()),
+                       """
+                       <h1>Hello World</h1>
+                       """
+        )
+    }
+    
+    /// Tests the localization of a attribute
+    ///
+    /// The test expects the key to exist in the default translation table and to be rendered correctly.
+    func testLocalizationAttribute() throws {
+        
+        struct TestView: View {
+            
+            let placeholder = "hello.world"
+            
+            var body: Content {
+                Input()
+                    .placeholder("hello.world", tableName: nil)
+                    .alternate(LocalizedStringKey("hello.world"))
+                    .value(LocalizedStringKey("hello.world"), tableName: "web")
+                    .title("hello.world", tableName: "mobile")
+                Meta()
+                    .content("hello.world")
+                Input()
+                    .placeholder(verbatim: "hello.world")
+                    .alternate(verbatim: "hello.world")
+                    .value(verbatim: placeholder)
+                    .title(verbatim: "hello.world")
+                TextArea {}
+                    .placeholder(placeholder)
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: TestView()),
+                       """
+                       <input placeholder="Hello World" alt="Hello World" value="Hello World" title="Hello World">\
+                       <meta content="Hello World">\
+                       <input placeholder="hello.world" alt="hello.world" value="hello.world" title="hello.world">\
+                       <textarea placeholder="hello.world"></textarea>
+                       """
+        )
+    }
+    
+    /// Tests the change of the locale by the environment modifier
+    ///
+    /// The test expects that the localization environment modifier correctly applies the locale
+    /// down to nested views
+    func testEnvironmentLocalization() throws {
+        
+        struct MainView: View {
+            
+            var content: [Content]
+            
+            init(@ContentBuilder<Content> content: () -> [Content]) {
+                self.content = content()
+            }
+            
+            var body: Content {
+                Division {
+                    content
+                }
+                .environment(key: \.locale, value: Locale(tag: .french))
+            }
+        }
+        
+        struct ChildView: View {
+            
+            var body: Content {
+                MainView {
+                    Heading1("hello.world")
+                        .environment(key: \.locale)
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: ChildView()),
+                       """
+                       <div>\
+                       <h1>Bonjour le monde</h1>\
+                       </div>
+                       """
+        )
+    }
+    
+    /// Tests the recovery from a missing key
+    ///
+    /// The renderer should attempt a secondary lookup in the translation tables of the default locale.
+    func testRecoveryFromMissingKey() throws {
+        
+        struct MainView: View {
+            
+            var content: [Content]
+            
+            init(@ContentBuilder<Content> content: () -> [Content]) {
+                self.content = content()
+            }
+            
+            var body: Content {
+                Division {
+                    content
+                }
+                .environment(key: \.locale, value: Locale(tag: .french))
+            }
+        }
+        
+        struct ChildView: View {
+            
+            var body: Content {
+                MainView {
+                    Heading1("Hello \("John Doe")")
+                        .environment(key: \.locale)
+                }
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: ChildView()),
+                       """
+                       <div>\
+                       <h1>Hello John Doe</h1>\
+                       </div>
+                       """
+        )
+    }
+}
+
+extension RenderingTests {
+    
+    func setupRendering() throws {
+        
+        guard let sourcePath = Bundle.module.url(forResource: "Localization", withExtension: nil) else {
+            return
+        }
+        
+        self.renderer = Renderer(localization: .init(source: sourcePath, locale: .init(tag: "en-GB")),features: [.escaping, .markdown])
     }
 }

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -528,6 +528,31 @@ final class RenderingTests: XCTestCase {
                        """
         )
     }
+    
+    /// Tests the recovery from a missing table
+    ///
+    /// The renderer should fallback to the default locale.
+    func testRecoveryFromMissingTable() throws {
+        
+        struct TestView: View {
+            
+            var body: Content {
+                Division {
+                    Heading1("hello.world")
+                        .environment(key: \.locale)
+                }
+                .environment(key: \.locale, value: Locale(tag: "unknown.tag"))
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: TestView()),
+                       """
+                       <div>\
+                       <h1>Hello World</h1>\
+                       </div>
+                       """
+        )
+    }
 }
 
 extension RenderingTests {

--- a/Tests/HTMLKitVaporTests/ProviderTests.swift
+++ b/Tests/HTMLKitVaporTests/ProviderTests.swift
@@ -237,17 +237,6 @@ final class ProviderTests: XCTestCase {
             }
         }
         
-        struct UnknownTagView: HTMLKit.View {
-            
-            var body: HTMLKit.Content {
-                Division {
-                    Heading1("greeting.world")
-                        .environment(key: \.locale)
-                }
-                .environment(key: \.locale, value: Locale(tag: "unknown.tag"))
-            }
-        }
-        
         guard let source = Bundle.module.url(forResource: "Localization", withExtension: nil) else {
             return
         }
@@ -264,11 +253,6 @@ final class ProviderTests: XCTestCase {
             return try await request.htmlkit.render(UnknownTableView())
         }
         
-        app.get("unknowntag") { request async throws -> Vapor.View in
-            
-            return try await request.htmlkit.render(UnknownTagView())
-        }
-        
         try app.test(.GET, "unknowntable") { response in
             
             XCTAssertEqual(response.status, .internalServerError)
@@ -276,15 +260,6 @@ final class ProviderTests: XCTestCase {
             let abort = try response.content.decode(AbortResponse.self)
             
             XCTAssertEqual(abort.reason, "Unable to find translation table 'unknown.table' for the locale 'fr'.")
-        }
-        
-        try app.test(.GET, "unknowntag") { response in
-            
-            XCTAssertEqual(response.status, .internalServerError)
-            
-            let abort = try response.content.decode(AbortResponse.self)
-            
-            XCTAssertEqual(abort.reason, "Unable to find a translation table for the locale 'unknown.tag'.")
         }
     }
     
@@ -329,6 +304,49 @@ final class ProviderTests: XCTestCase {
                             """
             )
         }
+    }
+    
+    /// Tests the localization behavior when the preferred language is unknown.
+    ///
+    /// A language is considered unknown if the locale couldn't be found (e.g. typo) or isn't set up in the first place.
+    /// In such a case, the renderer is expected to fall back to the default locale.
+    func testUnknownPreferredLanguage() async throws {
+        
+        guard let source = Bundle.module.url(forResource: "Localization", withExtension: nil) else {
+            return
+        }
+        
+        let app = try await Application.make(.testing)
+        
+        app.htmlkit.localization.set(source: source)
+        app.htmlkit.localization.set(locale: "en-GB")
+        
+        app.get("test") { request async throws -> Vapor.View in
+            
+            // Overwrite the accept language header to simulate a different language
+            request.headers.replaceOrAdd(name: "accept-language", value: "en-US")
+            
+            return try await request.htmlkit.render(TestPage.ChildView())
+        }
+        
+        try await app.test(.GET, "test") { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.body.string,
+                            """
+                            <!DOCTYPE html>\
+                            <html>\
+                            <head>\
+                            <title>TestPage</title>\
+                            </head>\
+                            <body>\
+                            <p>Hello World</p>\
+                            </body>\
+                            </html>
+                            """
+            )
+        }
+        
+        try await app.asyncShutdown()
     }
     
     /// Tests the access to environment through provider

--- a/Tests/HTMLKitVaporTests/ProviderTests.swift
+++ b/Tests/HTMLKitVaporTests/ProviderTests.swift
@@ -225,44 +225,6 @@ final class ProviderTests: XCTestCase {
         }
     }
     
-    /// Tests the error reporting to Vapor for issues that may occur during localization
-    ///
-    /// The error is expected to be classified as an internal server error and includes a error message.
-    func testLocalizationErrorReporting() throws {
-        
-        struct UnknownTableView: HTMLKit.View {
-            
-            var body: HTMLKit.Content {
-                Paragraph("hello.world", tableName: "unknown.table")
-            }
-        }
-        
-        guard let source = Bundle.module.url(forResource: "Localization", withExtension: nil) else {
-            return
-        }
-        
-        let app = Application(.testing)
-        
-        defer { app.shutdown() }
-        
-        app.htmlkit.localization.set(source: source)
-        app.htmlkit.localization.set(locale: "fr")
-        
-        app.get("unknowntable") { request async throws -> Vapor.View in
-            
-            return try await request.htmlkit.render(UnknownTableView())
-        }
-        
-        try app.test(.GET, "unknowntable") { response in
-            
-            XCTAssertEqual(response.status, .internalServerError)
-            
-            let abort = try response.content.decode(AbortResponse.self)
-            
-            XCTAssertEqual(abort.reason, "Unable to find translation table 'unknown.table' for the locale 'fr'.")
-        }
-    }
-    
     /// Tests the localization behavior based on the accept language of the client
     ///
     /// The environment locale is expected to be changed according to the language given by the provider.


### PR DESCRIPTION
Currently, there is a bug: if the preferred language (coming from the accept-language header) is not available, an error is thrown, which should not happen, as the fallback language should be used instead. This pull-request fixes that.

It also ensures that the remaining errors are non-fatal, as suggested in #148.