### PR TITLE
Make the selected attribute conditional

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -3065,16 +3065,26 @@ extension PropertyAttribute where Self: EmptyNode {
     }
 }
 
-/// The protocol provides the element with the selected handler.
+/// A type that provides the `selected` modifier
 @_documentation(visibility: internal)
 public protocol SelectedAttribute: Attribute {
     
-    /// The function represents the html-attribute 'selected'.
+    /// Mark a select option as default.
     ///
-    /// ```html
-    /// <tag selected />
+    /// ```swift
+    /// Select {
+    ///     Option()
+    ///         .value("lorem")
+    ///         .selected()
+    /// }
+    /// .name("lorem")
+    /// .id("lorem")
     /// ```
-    func selected() -> Self
+    ///
+    /// - Parameter condition: Whether to default the option.
+    ///
+    /// - Returns: The element
+    func selected(_ condition: Bool) -> Self
 }
 
 extension SelectedAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -528,8 +528,13 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(value: value)
     }
     
-    public func selected() -> Option {
-        return mutate(selected: "selected")
+    public func selected(_ condition: Bool = true) -> Option {
+        
+        if condition {
+            return mutate(selected: "selected")
+        }
+        
+        return self
     }
     
     public func popover(_ value: Values.Popover.State) -> Option {

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -573,8 +573,13 @@ final class AttributesTests: XCTestCase {
             return self.mutate(property: value.rawValue)
         }
         
-        func selected() -> Tag {
-            return self.mutate(selected: "selected")
+        func selected(_ condition: Bool = true) -> Tag {
+            
+            if condition {
+                return self.mutate(selected: "selected")
+            }
+            
+            return self
         }
         
         func draw(_ value: String) -> Tag {
@@ -2119,11 +2124,18 @@ final class AttributesTests: XCTestCase {
     func testSelectedAttribute() throws {
         
         let view = TestView {
+            // unconditionally
             Tag {}.selected()
+            // with a false condition
+            Tag {}.selected(false)
+            // with a true condition
+            Tag {}.selected(true)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
                        """
+                       <tag selected="selected"></tag>\
+                       <tag></tag>\
                        <tag selected="selected"></tag>
                        """
         )


### PR DESCRIPTION
This pull request makes the selected attribute conditional.

```swift
let foo = "bar"

Select {
   Option()
      .selected(foo == "bar")
}
```