### PR TITLE
Introduce integrity attribute

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -1484,6 +1484,51 @@ extension InputModeAttribute where Self: EmptyNode {
     }
 }
 
+/// A type that provides the `integrity` modifier
+@_documentation(visibility: internal)
+public protocol IntegrityAttribute: Attribute {
+    
+    /// Check the integrity of the resource.
+    ///
+    /// ```swift
+    /// Script {
+    /// }
+    /// .integrity("sha384...", "sha384...")
+    /// ```
+    ///
+    /// - Parameter hashes: The hashes of the resource to validate against.
+    ///
+    /// - Returns: The element
+    func integrity(_ hashes: String...) -> Self
+    
+    /// Check the integrity of the resource.
+    ///
+    /// ```swift
+    /// Script {
+    /// }
+    /// .integrity(["sha384...", "sha384..."])
+    /// ```
+    ///
+    /// - Parameter hashes: The hashes of the resource to validate against.
+    ///
+    /// - Returns: The element
+    func integrity(_ hashes: [String]) -> Self
+}
+
+extension IntegrityAttribute where Self: ContentNode {
+    
+    internal func mutate(integrity value: String) -> Self {
+        return self.mutate(key: "integrity", value: value)
+    }
+}
+
+extension IntegrityAttribute where Self: EmptyNode {
+    
+    internal func mutate(integrity value: String) -> Self {
+        return self.mutate(key: "integrity", value: value)
+    }
+}
+
 /// A type that provides the `is` modifier.
 @_documentation(visibility: internal)
 public protocol IsAttribute: Attribute {

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -21718,7 +21718,7 @@ public struct Script: ContentNode, HeadElement, BodyElement, FormElement, Figure
     }
 }
 
-extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribute, ReferrerPolicyAttribute, SourceAttribute, TypeAttribute, FetchPriorityAttribute, BlockingAttribute {
+extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribute, ReferrerPolicyAttribute, SourceAttribute, TypeAttribute, FetchPriorityAttribute, BlockingAttribute, IntegrityAttribute {
 
     public func accessKey(_ value: Character) -> Script {
         return mutate(accesskey: value)
@@ -21772,6 +21772,14 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
     
     public func inputMode(_ value: Values.Mode) -> Script {
         return mutate(inputmode: value.rawValue)
+    }
+    
+    public func integrity(_ hashes: String...) -> Script {
+        return mutate(integrity: hashes.joined(separator: " "))
+    }
+    
+    public func integrity(_ hashes: [String]) -> Script {
+        return mutate(integrity: hashes.joined(separator: " "))
     }
 
     public func `is`(_ value: String) -> Script {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -990,7 +990,7 @@ public struct Link: EmptyNode, HeadElement, BodyElement {
     }
 }
 
-extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, ReferenceLanguageAttribute, MediaAttribute, ReferrerPolicyAttribute, RelationshipAttribute, SizesAttribute, TypeAttribute, FetchPriorityAttribute, BlockingAttribute, FormEventAttribute {
+extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, ReferenceLanguageAttribute, MediaAttribute, ReferrerPolicyAttribute, RelationshipAttribute, SizesAttribute, TypeAttribute, FetchPriorityAttribute, BlockingAttribute, FormEventAttribute, IntegrityAttribute {
     
     public func accessKey(_ value: Character) -> Link {
         return mutate(accesskey: value)
@@ -1044,6 +1044,14 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
     
     public func inputMode(_ value: Values.Mode) -> Link {
         return mutate(inputmode: value.rawValue)
+    }
+    
+    public func integrity(_ hashes: String...) -> Link {
+        return mutate(integrity: hashes.joined(separator: " "))
+    }
+    
+    public func integrity(_ hashes: [String]) -> Link {
+        return mutate(integrity: hashes.joined(separator: " "))
     }
 
     public func `is`(_ value: String) -> Link {

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -15,7 +15,7 @@ final class AttributesTests: XCTestCase {
         @ContentBuilder<Content> var body: Content
     }
     
-    typealias AllAttributes = AccessKeyAttribute & AcceptAttribute & ActionAttribute & AlternateAttribute & AsynchronouslyAttribute & AutocapitalizeAttribute & AutocompleteAttribute & AutofocusAttribute & AutoplayAttribute & CharsetAttribute & CheckedAttribute & CiteAttribute & ClassAttribute & ColumnsAttribute & ColumnSpanAttribute & ContentAttribute & EditAttribute  & ControlsAttribute & CoordinatesAttribute & DataAttribute & DateTimeAttribute & DefaultAttribute & DeferAttribute & DirectionAttribute & DisabledAttribute & DownloadAttribute & DragAttribute & EncodingAttribute & EnterKeyHintAttribute & ForAttribute & FormAttribute & FormActionAttribute & EquivalentAttribute & HeaderAttribute & HeightAttribute & HiddenAttribute & HighAttribute & ReferenceAttribute & ReferenceLanguageAttribute & IdentifierAttribute & IsMapAttribute & InputModeAttribute & IsAttribute & ItemAttribute & ItemIdAttribute & ItemPropertyAttribute & ItemReferenceAttribute & ItemScopeAttribute & ItemTypeAttribute & KindAttribute & LabelAttribute & LanguageAttribute & ListAttribute & LoopAttribute & LowAttribute & MaximumValueAttribute & MaximumLengthAttribute & MediaAttribute & MethodAttribute & MinimumValueAttribute & MinimumLengthAttribute & MultipleAttribute & MutedAttribute & NameAttribute & NonceAttribute & NoValidateAttribute & OpenAttribute & OptimumAttribute & PatternAttribute & PartAttribute & PingAttribute & PlaceholderAttribute & PosterAttribute & PreloadAttribute & ReadyOnlyAttribute & ReferrerPolicyAttribute & RelationshipAttribute & RequiredAttribute & ReversedAttribute & RoleAttribute & RowsAttribute & RowSpanAttribute & SandboxAttribute & ScopeAttribute & ShapeAttribute & SizeAttribute & SizesAttribute & SlotAttribute & SpanAttribute & SpellCheckAttribute & SourceAttribute & StartAttribute & StepAttribute & StyleAttribute & TabulatorAttribute & TargetAttribute & TitleAttribute & TranslateAttribute & TypeAttribute & ValueAttribute & WidthAttribute & WrapAttribute & PropertyAttribute & SelectedAttribute & WindowEventAttribute & FocusEventAttribute & PointerEventAttribute & MouseEventAttribute & WheelEventAttribute & InputEventAttribute & KeyboardEventAttribute & DragEventAttribute & ClipboardEventAttribute & SelectionEventAttribute & MediaEventAttribute & FormEventAttribute & DetailEventAttribute & AriaAtomicAttribute & AriaBusyAttribute & AriaControlsAttribute & AriaCurrentAttribute & AriaDescribedAttribute & AriaDetailsAttribute & AriaDisabledAttribute & AriaErrorMessageAttribute & AriaFlowToAttribute & AriaPopupAttribute & AriaHiddenAttribute & AriaInvalidAttribute & AriaShortcutsAttribute & AriaLabelAttribute & AriaLabeledAttribute & AriaLiveAttribute & AriaOwnsAttribute & AriaRelevantAttribute & AriaRoleDescriptionAttribute & DrawAttribute & FillAttribute & FillOpacityAttribute & StrokeAttribute & StrokeWidthAttribute & StrokeOpacityAttribute & StrokeLineCapAttribute & StrokeLineJoinAttribute & RadiusAttribute & PositionPointAttribute & RadiusPointAttribute & CenterPointAttribute & ViewBoxAttribute & NamespaceAttribute & PointsAttribute & ShadowRootModeAttribute & InertAttribute & FetchPriorityAttribute & LoadingAttribute & SourceSetAttribute & DecodingAttribute & BlockingAttribute & PopoverAttribute & PopoverTargetAttribute & PopoverActionAttribute & UseMapAttribute & PlaysInlineAttribute
+    typealias AllAttributes = AccessKeyAttribute & AcceptAttribute & ActionAttribute & AlternateAttribute & AsynchronouslyAttribute & AutocapitalizeAttribute & AutocompleteAttribute & AutofocusAttribute & AutoplayAttribute & CharsetAttribute & CheckedAttribute & CiteAttribute & ClassAttribute & ColumnsAttribute & ColumnSpanAttribute & ContentAttribute & EditAttribute  & ControlsAttribute & CoordinatesAttribute & DataAttribute & DateTimeAttribute & DefaultAttribute & DeferAttribute & DirectionAttribute & DisabledAttribute & DownloadAttribute & DragAttribute & EncodingAttribute & EnterKeyHintAttribute & ForAttribute & FormAttribute & FormActionAttribute & EquivalentAttribute & HeaderAttribute & HeightAttribute & HiddenAttribute & HighAttribute & ReferenceAttribute & ReferenceLanguageAttribute & IdentifierAttribute & IsMapAttribute & InputModeAttribute & IsAttribute & ItemAttribute & ItemIdAttribute & ItemPropertyAttribute & ItemReferenceAttribute & ItemScopeAttribute & ItemTypeAttribute & KindAttribute & LabelAttribute & LanguageAttribute & ListAttribute & LoopAttribute & LowAttribute & MaximumValueAttribute & MaximumLengthAttribute & MediaAttribute & MethodAttribute & MinimumValueAttribute & MinimumLengthAttribute & MultipleAttribute & MutedAttribute & NameAttribute & NonceAttribute & NoValidateAttribute & OpenAttribute & OptimumAttribute & PatternAttribute & PartAttribute & PingAttribute & PlaceholderAttribute & PosterAttribute & PreloadAttribute & ReadyOnlyAttribute & ReferrerPolicyAttribute & RelationshipAttribute & RequiredAttribute & ReversedAttribute & RoleAttribute & RowsAttribute & RowSpanAttribute & SandboxAttribute & ScopeAttribute & ShapeAttribute & SizeAttribute & SizesAttribute & SlotAttribute & SpanAttribute & SpellCheckAttribute & SourceAttribute & StartAttribute & StepAttribute & StyleAttribute & TabulatorAttribute & TargetAttribute & TitleAttribute & TranslateAttribute & TypeAttribute & ValueAttribute & WidthAttribute & WrapAttribute & PropertyAttribute & SelectedAttribute & WindowEventAttribute & FocusEventAttribute & PointerEventAttribute & MouseEventAttribute & WheelEventAttribute & InputEventAttribute & KeyboardEventAttribute & DragEventAttribute & ClipboardEventAttribute & SelectionEventAttribute & MediaEventAttribute & FormEventAttribute & DetailEventAttribute & AriaAtomicAttribute & AriaBusyAttribute & AriaControlsAttribute & AriaCurrentAttribute & AriaDescribedAttribute & AriaDetailsAttribute & AriaDisabledAttribute & AriaErrorMessageAttribute & AriaFlowToAttribute & AriaPopupAttribute & AriaHiddenAttribute & AriaInvalidAttribute & AriaShortcutsAttribute & AriaLabelAttribute & AriaLabeledAttribute & AriaLiveAttribute & AriaOwnsAttribute & AriaRelevantAttribute & AriaRoleDescriptionAttribute & DrawAttribute & FillAttribute & FillOpacityAttribute & StrokeAttribute & StrokeWidthAttribute & StrokeOpacityAttribute & StrokeLineCapAttribute & StrokeLineJoinAttribute & RadiusAttribute & PositionPointAttribute & RadiusPointAttribute & CenterPointAttribute & ViewBoxAttribute & NamespaceAttribute & PointsAttribute & ShadowRootModeAttribute & InertAttribute & FetchPriorityAttribute & LoadingAttribute & SourceSetAttribute & DecodingAttribute & BlockingAttribute & PopoverAttribute & PopoverTargetAttribute & PopoverActionAttribute & UseMapAttribute & PlaysInlineAttribute & IntegrityAttribute
     
     struct Tag: ContentNode, GlobalElement, AllAttributes {
 
@@ -685,6 +685,14 @@ final class AttributesTests: XCTestCase {
         
         func blocking(_ value: Values.Blocking) -> Tag {
             return self.mutate(blocking: value.rawValue)
+        }
+        
+        func integrity(_ hashes: String...) -> Tag {
+            return self.mutate(integrity: hashes.joined(separator: " "))
+        }
+        
+        func integrity(_ hashes: [String]) -> Tag {
+            return self.mutate(integrity: hashes.joined(separator: " "))
         }
         
         func on(event: Events.Window, _ value: String) -> Tag {
@@ -2274,6 +2282,23 @@ final class AttributesTests: XCTestCase {
         XCTAssertEqual(try renderer.render(view: view),
                        """
                        <tag popovertargetaction="toggle"></tag>
+                       """
+        )
+    }
+    
+    func testIntegrityAttribute() throws {
+        
+        let view = TestView {
+            Tag {}.integrity("sha384...")
+            Tag {}.integrity("sha384...", "sha384...")
+            Tag {}.integrity(["sha384...", "sha384..."])
+        }
+        
+        XCTAssertEqual(try renderer.render(view: view),
+                       """
+                       <tag integrity="sha384..."></tag>\
+                       <tag integrity="sha384... sha384..."></tag>\
+                       <tag integrity="sha384... sha384..."></tag>
                        """
         )
     }


### PR DESCRIPTION
This pull request adds the missing integrity attribute, which can be used to check a resource's content against hash values prior to loading.


```swift
Script {
}
.integrity("sha384...", "sha384...")
```