### PR TITLE
Introduce the as attribute

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -182,7 +182,7 @@ extension AlternateAttribute where Self: EmptyNode {
 @_documentation(visibility: internal)
 public protocol AsAttribute: Attribute {
     
-    /// Hint about the type of content to preload.
+    /// Hint about the type of resource to preload.
     ///
     /// ```swift
     /// Link()
@@ -191,10 +191,10 @@ public protocol AsAttribute: Attribute {
     ///     .as(.script)
     /// ```
     ///
-    /// - Parameter value: The content type to use.
+    /// - Parameter value: The resource type to use.
     ///
     /// - Returns: The element
-    func `as`(_ value: Values.AsValue) -> Self
+    func `as`(_ value: Values.Resource) -> Self
 }
 
 extension AsAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -996,7 +996,7 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
         return mutate(accesskey: value)
     }
     
-    public func `as`(_ value: Values.AsValue) -> Link {
+    public func `as`(_ value: Values.Resource) -> Link {
         return mutate(as: value.rawValue)
     }
 

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -1509,13 +1509,13 @@ public enum Values {
         case none
     }
     
-    /// A type as preload hint.
+    /// A type as resource hint.
     ///
     /// ```swift
     /// Link()
     ///     .as(.fetch)
     /// ```
-    public enum AsValue: String {
+    public enum Resource: String {
         
         /// Hints a fetch response.
         case fetch

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -38,7 +38,7 @@ final class AttributesTests: XCTestCase {
             return self.mutate(accesskey: value)
         }
         
-        func `as`(_ value: HTMLKit.Values.AsValue) -> Tag {
+        func `as`(_ value: HTMLKit.Values.Resource) -> Tag {
             return self.mutate(as: value.rawValue)
         }
         


### PR DESCRIPTION
This pull request adds the missing as attribute, which can be used to tell the browser the type of resource being loaded.

```swift
Link()
   .relationship(.preload)
   .as(.fetch)
```