### PR TITLE
Enhance the way the environment is handled in the htmlkit view renderer accessor

### DIFF
--- a/Sources/HTMLKit/Framework/Environment/Environment.swift
+++ b/Sources/HTMLKit/Framework/Environment/Environment.swift
@@ -49,6 +49,12 @@ public final class Environment {
         self.storage = [:]
     }
     
+    /// Initializes the environment from another environment
+    public init(duplicating otherEnvironment: Environment) {
+        
+        self.storage = otherEnvironment.storage
+    }
+    
     /// The current time zone of the environment
     public var timeZone: TimeZone? {
         

--- a/Sources/HTMLKitVapor/Configuration.swift
+++ b/Sources/HTMLKitVapor/Configuration.swift
@@ -19,4 +19,17 @@ public final class Configuration {
         self.environment = Environment()
         self.features = [.escaping]
     }
+    
+    /**
+     Create a new configuration by duplicating the given configuration.
+     
+     The is mostly meant as an internal convenience and should rarely be used. 
+     
+     - Important: The configuration contains many variables which are also reference types (why?? it’s a configuration, everything should be value types… but I diverge).
+     This init will _not_ deep copy the references. */
+    internal init(duplicating otherConfiguration: Configuration) {
+        self.localization = otherConfiguration.localization
+        self.environment = otherConfiguration.environment
+        self.features = otherConfiguration.features
+    }
 }

--- a/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
+++ b/Sources/HTMLKitVapor/Extensions/Vapor+HTMLKit.swift
@@ -94,12 +94,16 @@ extension Request {
     
     /// Access to the view renderer
     public var htmlkit: ViewRenderer {
-        
+        /* IMPORTANT: This is unsafe (accessing the (mutable) environment of htmlkit from a random event loop). */
+        let env = Environment(duplicating: application.htmlkit.environment)
         if let acceptLanguage = acceptLanguage {
-            application.htmlkit.environment.upsert(HTMLKit.Locale(tag: acceptLanguage), for: \HTMLKit.EnvironmentKeys.locale)
+            env.upsert(HTMLKit.Locale(tag: acceptLanguage), for: \HTMLKit.EnvironmentKeys.locale)
         }
         
-        return .init(eventLoop: eventLoop, configuration: application.htmlkit.configuration, logger: logger)
+        /* IMPORTANT: This is unsafe (accessing the (mutable) configuration of htmlkit from a random event loop). */
+        let newConfig = Configuration(duplicating: application.htmlkit.configuration)
+        newConfig.environment = env
+        return .init(eventLoop: eventLoop, configuration: newConfig, logger: logger)
     }
 }
 


### PR DESCRIPTION
Note this is _still very much unsafe_, but it should be a little bit better.
In particular, each request will have its own environment, derived from the global application’s environment, when rendering a view.

This relates to #186.