### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.swift]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
I use (the superior) tab indentation in Xcode, but this project uses spaces for indentation.
Having a `.editorconfig` file at the root of the project makes Xcode automatically apply the correct config for this project.

(PS: I’m trolling regarding the tabs vs. spaces subject as it is a common flame war, but I’m not serious about it! Except that tabs [**are indeed objectively better, for accessibility**](<https://adamtuttle.codes/blog/2021/tabs-vs-spaces-its-an-accessibility-issue/>).)