### PR TITLE
Deprecate old doctypes

### DIFF
--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -1038,18 +1038,25 @@ public enum Values {
         /// Indicates a html document.
         case html5 = "html"
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case html4Strict = #"HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd""#
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case html4Transitional = #"HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd""#
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case html4Frameset = #"HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd""#
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case xhtmlStrict = #"html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd""#
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case xhtmlTransitional = #"html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd""#
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case xhtmlFrameset = #"html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd""#
         
+        @available(*, deprecated, message: "The definition is no longer part of the html standard. Use 'html5' instead.")
         case xhtml = #"html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd""#
     }
 


### PR DESCRIPTION
Some of these doctypes are no longer part of the standard and should not be encouraged. It is time to cut ties...