### PR TITLE
Conform the title element as a vector element

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -12,7 +12,7 @@ import OrderedCollections
 ///     }
 /// }
 /// ```
-public struct Title: ContentNode, HeadElement {
+public struct Title: ContentNode, HeadElement, VectorElement {
 
     internal var name: String { "title" }
 


### PR DESCRIPTION
This pull request adds conformance so `Title` can be used in a `Vector`.

```swift
Vector {
   Title {
      "Lorem ipsum..."
   }
}
```