### PR TITLE
Use the correct enum in the type modifier of the script element

### DIFF
--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -21360,7 +21360,7 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         return mutate(source: value)
     }
     
-    public func type(_ value: Values.Media) -> Script {
+    public func type(_ value: Values.Script) -> Script {
         return mutate(type: value.rawValue)
     }
     

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -2231,4 +2231,26 @@ public enum Values {
         /// Permits the content to navigate its top-level browsing context, but only if initiated by user.
         case allowTopNavigationByUserActivation = "allow-top-navigation-by-user-activation"
     }
+    
+    /// An enumeration of script types.
+    /// 
+    /// ```swift
+    /// Script {
+    /// }
+    /// .type(.module)
+    /// ```
+    public enum Script: String {
+        
+        /// Indicates the script is used as importmap.
+        case importMap = "importmap"
+        
+        /// Indicates the script is used as module.
+        case module
+        
+        /// Indicates the script defines speculation rules.
+        case speculationRules = "speculationrules"
+        
+        /// Indicates the script contains json data.
+        case data = "application/json"
+    }
 }


### PR DESCRIPTION
As correctly stated in #191, the `type` modifier of `Script` does not provide all potential cases. This pull request fixes that by changing the accepted enum.

The reason for this is that, although the attribute type allows any valid MIME type in HTML, only `text/javascript` and `application/json` make really sense to me. However, the standard suggests omitting the default `text/javascript`.
