### PR TITLE
Support attribute extension

### DIFF
--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -307,18 +307,18 @@ extension AutocapitalizeAttribute where Self: EmptyNode {
 /// A type that provides the `autocomplete` modifier.
 @_documentation(visibility: internal)
 public protocol AutocompleteAttribute: Attribute {
-    
+
     /// Specify an auto completion.
     ///
     /// ```swift
     /// Input()
-    ///     .autocomplete(.off)
+    ///     .autocomplete(true)
     /// ```
     ///
-    /// - Parameter value: The value to be expected.
+    /// - Parameter values: The values to be expected.
     ///
     /// - Returns: The element
-    func autocomplete(_ value: Values.Completion) -> Self
+    func autocomplete(_ value: Bool) -> Self
     
     /// Specify an auto completion.
     ///
@@ -330,7 +330,19 @@ public protocol AutocompleteAttribute: Attribute {
     /// - Parameter values: The values to be expected.
     ///
     /// - Returns: The element
-    func autocomplete(_ values: OrderedSet<Values.Completion>) -> Self
+    func autocomplete(_ values: [Values.Completion]) -> Self
+    
+    /// Specify an auto completion.
+    ///
+    /// ```swift
+    /// Input()
+    ///     .autocomplete(.organization, .organizationTitle)
+    /// ```
+    ///
+    /// - Parameter values: The values to be expected.
+    ///
+    /// - Returns: The element
+    func autocomplete(_ values: Values.Completion...) -> Self
 }
 
 extension AutocompleteAttribute where Self: ContentNode {
@@ -2951,9 +2963,9 @@ public protocol SandboxAttribute: Attribute {
     /// InlineFrame {
     /// }
     /// .source("https://...")
-    /// .sandbox(.allowDownloads)
+    /// .sandbox([.allowDownloads, .allowPopups])
     /// ```
-    func sandbox(_ value: Values.Permission) -> Self
+    func sandbox(_ values: [Values.Permission]) -> Self
     
     /// Define the permissions for the element.
     ///
@@ -2961,9 +2973,9 @@ public protocol SandboxAttribute: Attribute {
     /// InlineFrame {
     /// }
     /// .source("https://...")
-    /// .sandbox([.allowDownloads, .allowPopups])
+    /// .sandbox(.allowDownloads, .allowPopups)
     /// ```
-    func sandbox(_ values: OrderedSet<Values.Permission>) -> Self
+    func sandbox(_ values: Values.Permission...) -> Self
 }
 
 extension SandboxAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
+++ b/Sources/HTMLKit/Abstraction/Attributes/BasicAttributes.swift
@@ -515,13 +515,27 @@ public protocol ClassAttribute: Attribute{
     /// Paragraph {
     ///     "Lorem ipsum..."
     /// }
-    /// .class("text")
+    /// .class(["text", "white"])
     /// ```
     ///
-    /// - Parameter value: The class to apply to.
+    /// - Parameter names: The class to apply to.
     ///
     /// - Returns: The element
-    func `class`(_ value: String) -> Self
+    func `class`(_ names: [String]) -> Self
+    
+    /// Use a style class on an element.
+    ///
+    /// ```swift
+    /// Paragraph {
+    ///     "Lorem ipsum..."
+    /// }
+    /// .class("text", "white")
+    /// ```
+    ///
+    /// - Parameter names: The class to apply to.
+    ///
+    /// - Returns: The element
+    func `class`(_ names: String...) -> Self
 }
 
 extension ClassAttribute where Self: ContentNode {

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -117,13 +117,19 @@ public struct Html: ContentNode, BasicElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Html, T) -> Html) -> Html {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Html, T) -> Html) -> Html {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -433,13 +439,19 @@ public struct Custom: CustomNode, GlobalElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Custom, T) -> Custom) -> Custom {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Custom, T) -> Custom) -> Custom {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -205,7 +205,7 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -225,7 +225,7 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -101,10 +101,17 @@ public struct Html: ContentNode, BasicElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Html) -> Html) -> Html {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Html) -> Html) -> Html {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -116,7 +123,7 @@ public struct Html: ContentNode, BasicElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -410,10 +417,17 @@ public struct Custom: CustomNode, GlobalElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Custom) -> Custom) -> Custom {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Custom) -> Custom) -> Custom {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -425,7 +439,7 @@ public struct Custom: CustomNode, GlobalElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BasicElements.swift
@@ -134,8 +134,12 @@ extension Html: GlobalAttributes, GlobalEventAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Html {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Html {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Html {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -185,10 +185,17 @@ public struct Article: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Article) -> Article) -> Article {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Article) -> Article) -> Article {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -200,7 +207,7 @@ public struct Article: ContentNode, HtmlElement, BodyElement, FormElement, Figur
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -572,10 +579,17 @@ public struct Section: ContentNode, HtmlElement, BodyElement, FigureElement, For
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Section) -> Section) -> Section {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Section) -> Section) -> Section {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -587,7 +601,7 @@ public struct Section: ContentNode, HtmlElement, BodyElement, FigureElement, For
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -961,10 +975,17 @@ public struct Navigation: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Navigation) -> Navigation) -> Navigation {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Navigation) -> Navigation) -> Navigation {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -976,7 +997,7 @@ public struct Navigation: ContentNode, HtmlElement, BodyElement, FormElement, Fi
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1346,10 +1367,17 @@ public struct Aside: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Aside) -> Aside) -> Aside {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Aside) -> Aside) -> Aside {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1361,7 +1389,7 @@ public struct Aside: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1728,10 +1756,17 @@ public struct Heading1: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Heading1) -> Heading1) -> Heading1 {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Heading1) -> Heading1) -> Heading1 {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1743,7 +1778,7 @@ public struct Heading1: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -2119,10 +2154,17 @@ public struct Heading2: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Heading2) -> Heading2) -> Heading2 {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Heading2) -> Heading2) -> Heading2 {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -2134,7 +2176,7 @@ public struct Heading2: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -2510,10 +2552,17 @@ public struct Heading3: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Heading3) -> Heading3) -> Heading3 {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Heading3) -> Heading3) -> Heading3 {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -2525,7 +2574,7 @@ public struct Heading3: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -2901,10 +2950,17 @@ public struct Heading4: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Heading4) -> Heading4) -> Heading4 {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Heading4) -> Heading4) -> Heading4 {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -2916,7 +2972,7 @@ public struct Heading4: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -3292,10 +3348,17 @@ public struct Heading5: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Heading5) -> Heading5) -> Heading5 {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Heading5) -> Heading5) -> Heading5 {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -3307,7 +3370,7 @@ public struct Heading5: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -3683,10 +3746,17 @@ public struct Heading6: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Heading6) -> Heading6) -> Heading6 {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Heading6) -> Heading6) -> Heading6 {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -3698,7 +3768,7 @@ public struct Heading6: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -4079,10 +4149,17 @@ public struct HeadingGroup: ContentNode, HtmlElement, BodyElement, FormElement, 
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (HeadingGroup) -> HeadingGroup) -> HeadingGroup {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (HeadingGroup) -> HeadingGroup) -> HeadingGroup {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -4094,7 +4171,7 @@ public struct HeadingGroup: ContentNode, HtmlElement, BodyElement, FormElement, 
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -4462,10 +4539,17 @@ public struct Header: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Header) -> Header) -> Header {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Header) -> Header) -> Header {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -4477,7 +4561,7 @@ public struct Header: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -4843,10 +4927,17 @@ public struct Footer: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Footer) -> Footer) -> Footer {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Footer) -> Footer) -> Footer {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -4858,7 +4949,7 @@ public struct Footer: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -5231,10 +5322,17 @@ public struct Address: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Address) -> Address) -> Address {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Address) -> Address) -> Address {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -5246,7 +5344,7 @@ public struct Address: ContentNode, HtmlElement, BodyElement, FormElement, Figur
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -5613,10 +5711,17 @@ public struct Paragraph: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Paragraph) -> Paragraph) -> Paragraph {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Paragraph) -> Paragraph) -> Paragraph {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -5628,7 +5733,7 @@ public struct Paragraph: ContentNode, HtmlElement, BodyElement, FormElement, Fig
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -5995,10 +6100,17 @@ public struct HorizontalRule: EmptyNode, HtmlElement, BodyElement, FormElement, 
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (HorizontalRule) -> HorizontalRule) -> HorizontalRule {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (HorizontalRule) -> HorizontalRule) -> HorizontalRule {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -6010,7 +6122,7 @@ public struct HorizontalRule: EmptyNode, HtmlElement, BodyElement, FormElement, 
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -6383,10 +6495,17 @@ public struct PreformattedText: ContentNode, HtmlElement, BodyElement, FormEleme
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (PreformattedText) -> PreformattedText) -> PreformattedText {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (PreformattedText) -> PreformattedText) -> PreformattedText {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -6398,7 +6517,7 @@ public struct PreformattedText: ContentNode, HtmlElement, BodyElement, FormEleme
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -6765,10 +6884,17 @@ public struct Blockquote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Blockquote) -> Blockquote) -> Blockquote {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Blockquote) -> Blockquote) -> Blockquote {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -6780,7 +6906,7 @@ public struct Blockquote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -7165,10 +7291,17 @@ public struct OrderedList: ContentNode, HtmlElement, BodyElement, FormElement, F
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (OrderedList) -> OrderedList) -> OrderedList {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (OrderedList) -> OrderedList) -> OrderedList {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -7180,7 +7313,7 @@ public struct OrderedList: ContentNode, HtmlElement, BodyElement, FormElement, F
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -7564,10 +7697,17 @@ public struct UnorderedList: ContentNode, HtmlElement, BodyElement, FormElement,
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (UnorderedList) -> UnorderedList) -> UnorderedList {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (UnorderedList) -> UnorderedList) -> UnorderedList {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -7579,7 +7719,7 @@ public struct UnorderedList: ContentNode, HtmlElement, BodyElement, FormElement,
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -7957,10 +8097,17 @@ public struct Menu: ContentNode, HtmlElement, BodyElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Menu) -> Menu) -> Menu {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Menu) -> Menu) -> Menu {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -7972,7 +8119,7 @@ public struct Menu: ContentNode, HtmlElement, BodyElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -8250,10 +8397,17 @@ public struct DescriptionList: ContentNode, HtmlElement, BodyElement, FormElemen
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (DescriptionList) -> DescriptionList) -> DescriptionList {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (DescriptionList) -> DescriptionList) -> DescriptionList {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -8265,7 +8419,7 @@ public struct DescriptionList: ContentNode, HtmlElement, BodyElement, FormElemen
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -8637,10 +8791,17 @@ public struct Figure: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Figure) -> Figure) -> Figure {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Figure) -> Figure) -> Figure {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -8652,7 +8813,7 @@ public struct Figure: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -9021,10 +9182,17 @@ public struct Anchor: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Anchor) -> Anchor) -> Anchor {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Anchor) -> Anchor) -> Anchor {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -9036,7 +9204,7 @@ public struct Anchor: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -9460,10 +9628,17 @@ public struct Emphasize: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Emphasize) -> Emphasize) -> Emphasize {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Emphasize) -> Emphasize) -> Emphasize {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -9475,7 +9650,7 @@ public struct Emphasize: ContentNode, HtmlElement, BodyElement, FormElement, Fig
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -9844,10 +10019,17 @@ public struct Strong: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Strong) -> Strong) -> Strong {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Strong) -> Strong) -> Strong {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -9859,7 +10041,7 @@ public struct Strong: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -10228,10 +10410,17 @@ public struct Small: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Small) -> Small) -> Small {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Small) -> Small) -> Small {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -10243,7 +10432,7 @@ public struct Small: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -10621,10 +10810,17 @@ public struct StrikeThrough: ContentNode, HtmlElement, BodyElement, FormElement,
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (StrikeThrough) -> StrikeThrough) -> StrikeThrough {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (StrikeThrough) -> StrikeThrough) -> StrikeThrough {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -10636,7 +10832,7 @@ public struct StrikeThrough: ContentNode, HtmlElement, BodyElement, FormElement,
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -10946,10 +11142,17 @@ public struct Main: ContentNode, HtmlElement, BodyElement, FormElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Main) -> Main) -> Main {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Main) -> Main) -> Main {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -10961,7 +11164,7 @@ public struct Main: ContentNode, HtmlElement, BodyElement, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -11335,10 +11538,17 @@ public struct Search: ContentNode, HtmlElement, BodyElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Search) -> Search) -> Search {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Search) -> Search) -> Search {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -11350,7 +11560,7 @@ public struct Search: ContentNode, HtmlElement, BodyElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -11621,10 +11831,17 @@ public struct Division: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Division) -> Division) -> Division {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Division) -> Division) -> Division {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -11636,7 +11853,7 @@ public struct Division: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -12008,10 +12225,17 @@ public struct Definition: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Definition) -> Definition) -> Definition {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Definition) -> Definition) -> Definition {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -12023,7 +12247,7 @@ public struct Definition: ContentNode, HtmlElement, BodyElement, FormElement, Fi
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -12393,10 +12617,17 @@ public struct Cite: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Cite) -> Cite) -> Cite {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Cite) -> Cite) -> Cite {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -12408,7 +12639,7 @@ public struct Cite: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -12777,10 +13008,17 @@ public struct ShortQuote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (ShortQuote) -> ShortQuote) -> ShortQuote {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (ShortQuote) -> ShortQuote) -> ShortQuote {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -12792,7 +13030,7 @@ public struct ShortQuote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -13166,10 +13404,17 @@ public struct Abbreviation: ContentNode, HtmlElement, BodyElement, FormElement, 
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Abbreviation) -> Abbreviation) -> Abbreviation {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Abbreviation) -> Abbreviation) -> Abbreviation {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -13181,7 +13426,7 @@ public struct Abbreviation: ContentNode, HtmlElement, BodyElement, FormElement, 
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -13551,10 +13796,17 @@ public struct Ruby: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Ruby) -> Ruby) -> Ruby {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Ruby) -> Ruby) -> Ruby {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -13566,7 +13818,7 @@ public struct Ruby: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -13938,10 +14190,17 @@ public struct Data: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Data) -> Data) -> Data {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Data) -> Data) -> Data {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -13953,7 +14212,7 @@ public struct Data: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -14337,10 +14596,17 @@ public struct Time: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Time) -> Time) -> Time {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Time) -> Time) -> Time {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -14352,7 +14618,7 @@ public struct Time: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -14727,10 +14993,17 @@ public struct Code: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Code) -> Code) -> Code {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Code) -> Code) -> Code {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -14742,7 +15015,7 @@ public struct Code: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -15113,10 +15386,17 @@ public struct Variable: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Variable) -> Variable) -> Variable {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Variable) -> Variable) -> Variable {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -15128,7 +15408,7 @@ public struct Variable: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -15495,10 +15775,17 @@ public struct SampleOutput: ContentNode, HtmlElement, BodyElement, FormElement, 
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (SampleOutput) -> SampleOutput) -> SampleOutput {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (SampleOutput) -> SampleOutput) -> SampleOutput {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -15510,7 +15797,7 @@ public struct SampleOutput: ContentNode, HtmlElement, BodyElement, FormElement, 
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -15881,10 +16168,17 @@ public struct KeyboardInput: ContentNode, HtmlElement, BodyElement, FormElement,
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (KeyboardInput) -> KeyboardInput) -> KeyboardInput {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (KeyboardInput) -> KeyboardInput) -> KeyboardInput {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -15896,7 +16190,7 @@ public struct KeyboardInput: ContentNode, HtmlElement, BodyElement, FormElement,
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -16267,10 +16561,17 @@ public struct Subscript: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Subscript) -> Subscript) -> Subscript {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Subscript) -> Subscript) -> Subscript {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -16282,7 +16583,7 @@ public struct Subscript: ContentNode, HtmlElement, BodyElement, FormElement, Fig
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -16652,10 +16953,17 @@ public struct Superscript: ContentNode, HtmlElement, BodyElement, FormElement, F
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Superscript) -> Superscript) -> Superscript {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Superscript) -> Superscript) -> Superscript {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -16667,7 +16975,7 @@ public struct Superscript: ContentNode, HtmlElement, BodyElement, FormElement, F
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -17038,10 +17346,17 @@ public struct Italic: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Italic) -> Italic) -> Italic {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Italic) -> Italic) -> Italic {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -17053,7 +17368,7 @@ public struct Italic: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -17433,10 +17748,17 @@ public struct Bold: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Bold) -> Bold) -> Bold {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Bold) -> Bold) -> Bold {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -17448,7 +17770,7 @@ public struct Bold: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -17828,10 +18150,17 @@ public struct Underline: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Underline) -> Underline) -> Underline {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Underline) -> Underline) -> Underline {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -17843,7 +18172,7 @@ public struct Underline: ContentNode, HtmlElement, BodyElement, FormElement, Fig
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -18223,10 +18552,17 @@ public struct Mark: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Mark) -> Mark) -> Mark {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Mark) -> Mark) -> Mark {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -18238,7 +18574,7 @@ public struct Mark: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -18609,10 +18945,17 @@ public struct Bdi: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Bdi) -> Bdi) -> Bdi {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Bdi) -> Bdi) -> Bdi {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -18624,7 +18967,7 @@ public struct Bdi: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -18983,10 +19326,17 @@ public struct Bdo: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEleme
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Bdo) -> Bdo) -> Bdo {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Bdo) -> Bdo) -> Bdo {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -18998,7 +19348,7 @@ public struct Bdo: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEleme
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -19365,10 +19715,17 @@ public struct Span: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Span) -> Span) -> Span {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Span) -> Span) -> Span {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -19380,7 +19737,7 @@ public struct Span: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -19732,10 +20089,17 @@ public struct LineBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (LineBreak) -> LineBreak) -> LineBreak {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (LineBreak) -> LineBreak) -> LineBreak {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -19747,7 +20111,7 @@ public struct LineBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -20103,10 +20467,17 @@ public struct WordBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (WordBreak) -> WordBreak) -> WordBreak {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (WordBreak) -> WordBreak) -> WordBreak {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -20118,7 +20489,7 @@ public struct WordBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -20485,10 +20856,17 @@ public struct InsertedText: ContentNode, HtmlElement, BodyElement, FormElement, 
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (InsertedText) -> InsertedText) -> InsertedText {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (InsertedText) -> InsertedText) -> InsertedText {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -20500,7 +20878,7 @@ public struct InsertedText: ContentNode, HtmlElement, BodyElement, FormElement, 
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -20875,10 +21253,17 @@ public struct DeletedText: ContentNode, HtmlElement, BodyElement, FormElement, F
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (DeletedText) -> DeletedText) -> DeletedText {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (DeletedText) -> DeletedText) -> DeletedText {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -20890,7 +21275,7 @@ public struct DeletedText: ContentNode, HtmlElement, BodyElement, FormElement, F
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -21270,10 +21655,17 @@ public struct Picture: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Picture) -> Picture) -> Picture {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Picture) -> Picture) -> Picture {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -21285,7 +21677,7 @@ public struct Picture: ContentNode, HtmlElement, BodyElement, FormElement, Figur
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -21564,10 +21956,17 @@ public struct Image: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Image) -> Image) -> Image {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Image) -> Image) -> Image {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -21579,7 +21978,7 @@ public struct Image: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -22025,10 +22424,17 @@ public struct InlineFrame: ContentNode, HtmlElement, BodyElement, FormElement, F
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (InlineFrame) -> InlineFrame) -> InlineFrame {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (InlineFrame) -> InlineFrame) -> InlineFrame {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -22040,7 +22446,7 @@ public struct InlineFrame: ContentNode, HtmlElement, BodyElement, FormElement, F
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -22438,10 +22844,17 @@ public struct Embed: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Embed) -> Embed) -> Embed {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Embed) -> Embed) -> Embed {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -22453,7 +22866,7 @@ public struct Embed: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -22841,10 +23254,17 @@ public struct Object: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Object) -> Object) -> Object {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Object) -> Object) -> Object {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -22856,7 +23276,7 @@ public struct Object: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -23249,10 +23669,17 @@ public struct Video: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Video) -> Video) -> Video {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Video) -> Video) -> Video {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -23264,7 +23691,7 @@ public struct Video: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -23692,10 +24119,17 @@ public struct Audio: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Audio) -> Audio) -> Audio {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Audio) -> Audio) -> Audio {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -23707,7 +24141,7 @@ public struct Audio: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -24123,10 +24557,17 @@ public struct Map: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Map) -> Map) -> Map {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Map) -> Map) -> Map {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -24138,7 +24579,7 @@ public struct Map: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -24439,10 +24880,17 @@ public struct Form: ContentNode, HtmlElement, BodyElement, FigureElement, Object
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Form) -> Form) -> Form {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Form) -> Form) -> Form {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -24454,7 +24902,7 @@ public struct Form: ContentNode, HtmlElement, BodyElement, FigureElement, Object
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -24869,10 +25317,17 @@ public struct DataList: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (DataList) -> DataList) -> DataList {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (DataList) -> DataList) -> DataList {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -24884,7 +25339,7 @@ public struct DataList: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -25253,10 +25708,17 @@ public struct Output: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Output) -> Output) -> Output {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Output) -> Output) -> Output {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -25268,7 +25730,7 @@ public struct Output: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -25649,10 +26111,17 @@ public struct Progress: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Progress) -> Progress) -> Progress {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Progress) -> Progress) -> Progress {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -25664,7 +26133,7 @@ public struct Progress: ContentNode, HtmlElement, BodyElement, FormElement, Figu
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -26052,10 +26521,17 @@ public struct Meter: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Meter) -> Meter) -> Meter {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Meter) -> Meter) -> Meter {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -26067,7 +26543,7 @@ public struct Meter: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -26472,10 +26948,17 @@ public struct Details: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Details) -> Details) -> Details {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Details) -> Details) -> Details {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -26487,7 +26970,7 @@ public struct Details: ContentNode, HtmlElement, BodyElement, FormElement, Figur
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -26882,10 +27365,17 @@ public struct Dialog: ContentNode, BodyElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Dialog) -> Dialog) -> Dialog {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Dialog) -> Dialog) -> Dialog {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -26897,7 +27387,7 @@ public struct Dialog: ContentNode, BodyElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -27283,10 +27773,17 @@ public struct Script: ContentNode, HeadElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Script) -> Script) -> Script {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Script) -> Script) -> Script {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -27298,7 +27795,7 @@ public struct Script: ContentNode, HeadElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -27635,10 +28132,17 @@ public struct NoScript: ContentNode, HtmlElement, HeadElement, BodyElement, Form
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (NoScript) -> NoScript) -> NoScript {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (NoScript) -> NoScript) -> NoScript {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -27650,7 +28154,7 @@ public struct NoScript: ContentNode, HtmlElement, HeadElement, BodyElement, Form
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -27948,10 +28452,17 @@ public struct Template: ContentNode, BodyElement, FormElement, FigureElement, Ob
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Template) -> Template) -> Template {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Template) -> Template) -> Template {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -27963,7 +28474,7 @@ public struct Template: ContentNode, BodyElement, FormElement, FigureElement, Ob
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -28254,10 +28765,17 @@ public struct Canvas: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Canvas) -> Canvas) -> Canvas {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Canvas) -> Canvas) -> Canvas {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -28269,7 +28787,7 @@ public struct Canvas: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -28651,10 +29169,17 @@ public struct Table: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Table) -> Table) -> Table {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Table) -> Table) -> Table {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -28666,7 +29191,7 @@ public struct Table: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -29047,10 +29572,17 @@ public struct Vector: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Vector) -> Vector) -> Vector {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Vector) -> Vector) -> Vector {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -29062,7 +29594,7 @@ public struct Vector: ContentNode, HtmlElement, BodyElement, FormElement, Figure
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -29251,10 +29783,17 @@ public struct Slot: ContentNode, BodyElement, FormElement, FigureElement, Object
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Slot) -> Slot) -> Slot {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Slot) -> Slot) -> Slot {
         
         if condition {
-            return self.modify(element(self))
+            
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -29266,7 +29805,7 @@ public struct Slot: ContentNode, BodyElement, FormElement, FigureElement, Object
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -218,8 +218,12 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Article {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Article {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Article {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -601,8 +605,12 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Section {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Section {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Section {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -986,8 +994,12 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Navigation {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Navigation {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Navigation {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1367,8 +1379,12 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Aside {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Aside {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Aside {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1745,8 +1761,12 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Heading1 {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Heading1 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Heading1 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -2132,8 +2152,12 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Heading2 {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Heading2 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Heading2 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -2519,8 +2543,12 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Heading3 {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Heading3 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Heading3 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -2906,8 +2934,12 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Heading4 {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Heading4 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Heading4 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -3293,8 +3325,12 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Heading5 {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Heading5 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Heading5 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -3680,8 +3716,12 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Heading6 {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Heading6 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Heading6 {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -4072,8 +4112,12 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> HeadingGroup {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> HeadingGroup {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> HeadingGroup {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -4451,8 +4495,12 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Header {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Header {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Header {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -4828,8 +4876,12 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Footer {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Footer {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Footer {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -5212,8 +5264,12 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Address {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Address {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Address {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -5590,8 +5646,12 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Paragraph {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Paragraph {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Paragraph {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -5968,8 +6028,12 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> HorizontalRule {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> HorizontalRule {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> HorizontalRule {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -6352,8 +6416,12 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> PreformattedText {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> PreformattedText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> PreformattedText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -6730,8 +6798,12 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Blockquote {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Blockquote {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Blockquote {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -7126,8 +7198,12 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> OrderedList {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> OrderedList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> OrderedList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -7521,8 +7597,12 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> UnorderedList {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> UnorderedList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> UnorderedList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -7910,8 +7990,12 @@ extension Menu: GlobalAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Menu {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Menu {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Menu {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -8199,8 +8283,12 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> DescriptionList {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> DescriptionList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> DescriptionList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -8582,8 +8670,12 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Figure {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Figure {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Figure {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -8962,8 +9054,12 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Anchor {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Anchor {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Anchor {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -9397,8 +9493,12 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Emphasize {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Emphasize {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Emphasize {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -9777,8 +9877,12 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Strong {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Strong {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Strong {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -10157,8 +10261,12 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Small {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Small {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Small {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -10546,8 +10654,12 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> StrikeThrough {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> StrikeThrough {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> StrikeThrough {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -10867,8 +10979,12 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Main {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Main {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Main {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -11252,8 +11368,12 @@ extension Search: GlobalAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Search {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Search {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Search {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -11534,8 +11654,12 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Division {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Division {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Division {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -11917,8 +12041,12 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Definition {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Definition {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Definition {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -12298,8 +12426,12 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Cite {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Cite {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Cite {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -12678,8 +12810,12 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> ShortQuote {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> ShortQuote {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> ShortQuote {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -13063,8 +13199,12 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Abbreviation {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Abbreviation {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Abbreviation {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -13444,8 +13584,12 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Ruby {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Ruby {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Ruby {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -13827,8 +13971,12 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Data {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Data {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Data {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -14222,8 +14370,12 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Time {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Time {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Time {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -14608,8 +14760,12 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Code {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Code {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Code {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -14990,8 +15146,12 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Variable {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Variable {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Variable {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -15368,8 +15528,12 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> SampleOutput {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> SampleOutput {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> SampleOutput {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -15750,8 +15914,12 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> KeyboardInput {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> KeyboardInput {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> KeyboardInput {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -16132,8 +16300,12 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Subscript {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Subscript {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Subscript {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -16513,8 +16685,12 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Superscript {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Superscript {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Superscript {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -16895,8 +17071,12 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Italic {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Italic {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Italic {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -17286,8 +17466,12 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Bold {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Bold {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Bold {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -17677,8 +17861,12 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Underline {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Underline {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Underline {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -18068,8 +18256,12 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Mark {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Mark {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Mark {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -18450,8 +18642,12 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Bdi {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Bdi {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Bdi {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -18820,8 +19016,12 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Bdo {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Bdo {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Bdo {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -19198,8 +19398,12 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Span {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Span {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Span {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -19561,8 +19765,12 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> LineBreak {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> LineBreak {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> LineBreak {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -19928,8 +20136,12 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> WordBreak {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> WordBreak {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> WordBreak {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -20306,8 +20518,12 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> InsertedText {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> InsertedText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> InsertedText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -20692,8 +20908,12 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> DeletedText {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> DeletedText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> DeletedText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -21083,8 +21303,12 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Picture {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Picture {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Picture {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -21373,8 +21597,12 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Image {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Image {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Image {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func crossOrigin(_ value: Credential.Mode) -> Image {
@@ -21830,8 +22058,12 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> InlineFrame {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> InlineFrame {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> InlineFrame {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -22239,8 +22471,12 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Embed {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Embed {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Embed {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -22638,8 +22874,12 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Object {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Object {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Object {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -23042,8 +23282,12 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Video {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Video {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Video {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -23481,8 +23725,12 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Audio {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Audio {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Audio {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func crossOrigin(_ value: Credential.Mode) -> Audio {
@@ -23908,8 +24156,12 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Map {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Map {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Map {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -24220,8 +24472,12 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Form {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Form {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Form {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -24637,8 +24893,12 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> DataList {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> DataList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> DataList {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -25017,8 +25277,12 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Output {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Output {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Output {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -25409,8 +25673,12 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Progress {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Progress {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Progress {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -25808,8 +26076,12 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Meter {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Meter {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Meter {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -26224,8 +26496,12 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Details {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Details {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Details {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -26630,8 +26906,12 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Dialog {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Dialog {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Dialog {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -27027,8 +27307,12 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Script {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Script {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Script {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func crossOrigin(_ value: Credential.Mode) -> Script {
@@ -27375,8 +27659,12 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> NoScript {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> NoScript {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> NoScript {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -27684,8 +27972,12 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Template {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Template {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Template {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -27986,8 +28278,12 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Canvas {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Canvas {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Canvas {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -28379,8 +28675,12 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Table {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Table {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Table {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -28775,8 +29075,12 @@ extension Vector: GlobalVectorAttributes, WidthAttribute, HeightAttribute, ViewB
         return mutate(height: .init(size, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Vector {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Vector {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Vector {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Vector {
@@ -28971,8 +29275,12 @@ extension Slot: GlobalAttributes, NameAttribute {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Slot {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Slot {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Slot {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -289,7 +289,7 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -309,7 +309,7 @@ extension Article: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -676,7 +676,7 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -696,7 +696,7 @@ extension Section: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1065,7 +1065,7 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1085,7 +1085,7 @@ extension Navigation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1450,7 +1450,7 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1470,7 +1470,7 @@ extension Aside: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1832,7 +1832,7 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1852,7 +1852,7 @@ extension Heading1: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -2223,7 +2223,7 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -2243,7 +2243,7 @@ extension Heading2: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -2614,7 +2614,7 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -2634,7 +2634,7 @@ extension Heading3: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -3005,7 +3005,7 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -3025,7 +3025,7 @@ extension Heading4: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -3396,7 +3396,7 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -3416,7 +3416,7 @@ extension Heading5: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -3787,7 +3787,7 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -3807,7 +3807,7 @@ extension Heading6: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -4183,7 +4183,7 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -4203,7 +4203,7 @@ extension HeadingGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -4566,7 +4566,7 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -4586,7 +4586,7 @@ extension Header: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -4947,7 +4947,7 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -4967,7 +4967,7 @@ extension Footer: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -5335,7 +5335,7 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -5355,7 +5355,7 @@ extension Address: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -5717,7 +5717,7 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -5737,7 +5737,7 @@ extension Paragraph: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -6099,7 +6099,7 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -6119,7 +6119,7 @@ extension HorizontalRule: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -6487,7 +6487,7 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -6507,7 +6507,7 @@ extension PreformattedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaA
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -6869,7 +6869,7 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -6889,7 +6889,7 @@ extension Blockquote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -7269,7 +7269,7 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -7289,7 +7289,7 @@ extension OrderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -7668,7 +7668,7 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -7688,7 +7688,7 @@ extension UnorderedList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -8061,7 +8061,7 @@ extension Menu: GlobalAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -8081,7 +8081,7 @@ extension Menu: GlobalAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -8354,7 +8354,7 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -8374,7 +8374,7 @@ extension DescriptionList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAt
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -8741,7 +8741,7 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -8761,7 +8761,7 @@ extension Figure: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -9125,7 +9125,7 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -9145,7 +9145,7 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -9260,11 +9260,11 @@ extension Anchor: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
     }
     
     public func media(_ queries: [MediaQuery]) -> Anchor {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func media(_ queries: MediaQuery...) -> Anchor {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func ping(_ value: String) -> Anchor {
@@ -9564,7 +9564,7 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -9584,7 +9584,7 @@ extension Emphasize: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -9948,7 +9948,7 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -9968,7 +9968,7 @@ extension Strong: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -10332,7 +10332,7 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -10352,7 +10352,7 @@ extension Small: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -10725,7 +10725,7 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -10745,7 +10745,7 @@ extension StrikeThrough: GlobalAttributes, GlobalEventAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -11050,7 +11050,7 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -11070,7 +11070,7 @@ extension Main: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -11439,7 +11439,7 @@ extension Search: GlobalAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -11459,7 +11459,7 @@ extension Search: GlobalAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -11725,7 +11725,7 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -11745,7 +11745,7 @@ extension Division: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -12112,7 +12112,7 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -12132,7 +12132,7 @@ extension Definition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -12497,7 +12497,7 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -12517,7 +12517,7 @@ extension Cite: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -12881,7 +12881,7 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -12901,7 +12901,7 @@ extension ShortQuote: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -13270,7 +13270,7 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -13290,7 +13290,7 @@ extension Abbreviation: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -13655,7 +13655,7 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -13675,7 +13675,7 @@ extension Ruby: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -14042,7 +14042,7 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -14062,7 +14062,7 @@ extension Data: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, V
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -14441,7 +14441,7 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -14461,7 +14461,7 @@ extension Time: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, D
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -14831,7 +14831,7 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -14851,7 +14851,7 @@ extension Code: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -15217,7 +15217,7 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -15237,7 +15237,7 @@ extension Variable: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -15599,7 +15599,7 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -15619,7 +15619,7 @@ extension SampleOutput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -15985,7 +15985,7 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -16005,7 +16005,7 @@ extension KeyboardInput: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -16371,7 +16371,7 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -16391,7 +16391,7 @@ extension Subscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -16756,7 +16756,7 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -16776,7 +16776,7 @@ extension Superscript: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -17142,7 +17142,7 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -17162,7 +17162,7 @@ extension Italic: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -17537,7 +17537,7 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -17557,7 +17557,7 @@ extension Bold: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -17932,7 +17932,7 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -17952,7 +17952,7 @@ extension Underline: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -18327,7 +18327,7 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -18347,7 +18347,7 @@ extension Mark: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -18713,7 +18713,7 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -18733,7 +18733,7 @@ extension Bdi: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -19087,7 +19087,7 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -19107,7 +19107,7 @@ extension Bdo: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -19469,7 +19469,7 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -19489,7 +19489,7 @@ extension Span: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -19836,7 +19836,7 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -19856,7 +19856,7 @@ extension LineBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -20207,7 +20207,7 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -20227,7 +20227,7 @@ extension WordBreak: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -20589,7 +20589,7 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -20609,7 +20609,7 @@ extension InsertedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttri
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -20979,7 +20979,7 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -20999,7 +20999,7 @@ extension DeletedText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -21374,7 +21374,7 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -21394,7 +21394,7 @@ extension Picture: GlobalAttributes, GlobalEventAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -21672,7 +21672,7 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -21692,7 +21692,7 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -21821,19 +21821,19 @@ extension Image: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
     }
     
     public func sourceSet(_ candidates: [SourceCandidate]) -> Image {
-        return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func sourceSet(_ candidates: SourceCandidate...) -> Image {
-        return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func sizes(_ candidates: [SizeCandidate]) -> Image {
-        return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func sizes(_ candidates: SizeCandidate...) -> Image {
-        return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func width(_ size: Int) -> Image {
@@ -22129,7 +22129,7 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -22149,7 +22149,7 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -22251,12 +22251,12 @@ extension InlineFrame: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(sandbox: .init("sandbox", context: .trusted))
     }
     
-    public func sandbox(_ value: Values.Permission) -> InlineFrame {
-        return mutate(sandbox: .init(value.rawValue, context: .trusted))
+    public func sandbox(_ values: [Values.Permission]) -> InlineFrame {
+        return mutate(sandbox: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
     }
     
-    public func sandbox(_ values: OrderedCollections.OrderedSet<Values.Permission>) -> InlineFrame {
-        return mutate(sandbox: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+    public func sandbox(_ values: Values.Permission...) -> InlineFrame {
+        return mutate(sandbox: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
     }
     
     public func source(_ value: String) -> InlineFrame {
@@ -22542,7 +22542,7 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -22562,7 +22562,7 @@ extension Embed: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -22945,7 +22945,7 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -22965,7 +22965,7 @@ extension Object: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -23353,7 +23353,7 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -23373,7 +23373,7 @@ extension Video: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -23800,7 +23800,7 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -23820,7 +23820,7 @@ extension Audio: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -24227,7 +24227,7 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -24247,7 +24247,7 @@ extension Map: GlobalAttributes, GlobalEventAttributes, NameAttribute {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -24543,7 +24543,7 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -24563,7 +24563,7 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -24665,12 +24665,21 @@ extension Form: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(action: .init(value, context: .tainted(.html)))
     }
     
-    public func autocomplete(_ value: Values.Completion) -> Form {
-        return mutate(autocomplete: .init(value.rawValue, context: .trusted))
+    public func autocomplete(_ value: Bool) -> Form {
+
+        if value {
+            return mutate(autocomplete: .init("on", context: .trusted))
+        }
+        
+        return mutate(autocomplete: .init("off", context: .trusted))
     }
     
-    public func autocomplete(_ values: OrderedSet<Values.Completion>) -> Form {
-        return mutate(autocomplete: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+    public func autocomplete(_ values: [Values.Completion]) -> Form {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
+    }
+    
+    public func autocomplete(_ values: Values.Completion...) -> Form {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
     }
     
     public func encoding(_ value: Values.Encoding) -> Form {
@@ -24964,7 +24973,7 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -24984,7 +24993,7 @@ extension DataList: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -25348,7 +25357,7 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -25368,7 +25377,7 @@ extension Output: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -25744,7 +25753,7 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -25764,7 +25773,7 @@ extension Progress: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -26147,7 +26156,7 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -26167,7 +26176,7 @@ extension Meter: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -26567,7 +26576,7 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -26587,7 +26596,7 @@ extension Details: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -26977,7 +26986,7 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -26997,7 +27006,7 @@ extension Dialog: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -27368,11 +27377,11 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
     }
     
     public func integrity(_ hashes: String...) -> Script {
-        return mutate(integrity: .init(hashes.joined(separator: " "), context: .tainted(.html)))
+        return mutate(integrity: .init(EnumeratedList(values: hashes, separator: " "), context: .tainted(.html)))
     }
     
     public func integrity(_ hashes: [String]) -> Script {
-        return mutate(integrity: .init(hashes.joined(separator: " "), context: .tainted(.html)))
+        return mutate(integrity: .init(EnumeratedList(values: hashes, separator: " "), context: .tainted(.html)))
     }
 
     public func `is`(_ value: String) -> Script {
@@ -27394,7 +27403,7 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -27414,7 +27423,7 @@ extension Script: GlobalAttributes, GlobalEventAttributes, AsynchronouslyAttribu
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -27730,7 +27739,7 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -27750,7 +27759,7 @@ extension NoScript: GlobalAttributes, GlobalEventAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -28043,7 +28052,7 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -28063,7 +28072,7 @@ extension Template: GlobalAttributes, GlobalEventAttributes, ShadowRootModeAttri
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -28349,7 +28358,7 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -28369,7 +28378,7 @@ extension Canvas: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -28746,7 +28755,7 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -28766,7 +28775,7 @@ extension Table: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -29346,7 +29355,7 @@ extension Slot: GlobalAttributes, NameAttribute {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -29366,7 +29375,7 @@ extension Slot: GlobalAttributes, NameAttribute {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/BodyElements.swift
@@ -201,13 +201,19 @@ public struct Article: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Article, T) -> Article) -> Article {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Article, T) -> Article) -> Article {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -595,13 +601,19 @@ public struct Section: ContentNode, HtmlElement, BodyElement, FigureElement, For
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Section, T) -> Section) -> Section {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Section, T) -> Section) -> Section {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -991,13 +1003,19 @@ public struct Navigation: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Navigation, T) -> Navigation) -> Navigation {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Navigation, T) -> Navigation) -> Navigation {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1383,13 +1401,19 @@ public struct Aside: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Aside, T) -> Aside) -> Aside {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Aside, T) -> Aside) -> Aside {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1772,13 +1796,19 @@ public struct Heading1: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Heading1, T) -> Heading1) -> Heading1 {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Heading1, T) -> Heading1) -> Heading1 {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -2170,13 +2200,19 @@ public struct Heading2: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Heading2, T) -> Heading2) -> Heading2 {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Heading2, T) -> Heading2) -> Heading2 {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -2568,13 +2604,19 @@ public struct Heading3: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Heading3, T) -> Heading3) -> Heading3 {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Heading3, T) -> Heading3) -> Heading3 {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -2966,13 +3008,19 @@ public struct Heading4: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Heading4, T) -> Heading4) -> Heading4 {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Heading4, T) -> Heading4) -> Heading4 {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -3364,13 +3412,19 @@ public struct Heading5: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Heading5, T) -> Heading5) -> Heading5 {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Heading5, T) -> Heading5) -> Heading5 {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -3762,13 +3816,19 @@ public struct Heading6: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Heading6, T) -> Heading6) -> Heading6 {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Heading6, T) -> Heading6) -> Heading6 {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -4165,13 +4225,19 @@ public struct HeadingGroup: ContentNode, HtmlElement, BodyElement, FormElement, 
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (HeadingGroup, T) -> HeadingGroup) -> HeadingGroup {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (HeadingGroup, T) -> HeadingGroup) -> HeadingGroup {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -4555,13 +4621,19 @@ public struct Header: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Header, T) -> Header) -> Header {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Header, T) -> Header) -> Header {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -4943,13 +5015,19 @@ public struct Footer: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Footer, T) -> Footer) -> Footer {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Footer, T) -> Footer) -> Footer {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -5338,13 +5416,19 @@ public struct Address: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Address, T) -> Address) -> Address {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Address, T) -> Address) -> Address {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -5727,13 +5811,19 @@ public struct Paragraph: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Paragraph, T) -> Paragraph) -> Paragraph {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Paragraph, T) -> Paragraph) -> Paragraph {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -6116,13 +6206,19 @@ public struct HorizontalRule: EmptyNode, HtmlElement, BodyElement, FormElement, 
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (HorizontalRule, T) -> HorizontalRule) -> HorizontalRule {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (HorizontalRule, T) -> HorizontalRule) -> HorizontalRule {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -6511,13 +6607,19 @@ public struct PreformattedText: ContentNode, HtmlElement, BodyElement, FormEleme
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (PreformattedText, T) -> PreformattedText) -> PreformattedText {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (PreformattedText, T) -> PreformattedText) -> PreformattedText {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -6900,13 +7002,19 @@ public struct Blockquote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Blockquote, T) -> Blockquote) -> Blockquote {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Blockquote, T) -> Blockquote) -> Blockquote {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -7307,13 +7415,19 @@ public struct OrderedList: ContentNode, HtmlElement, BodyElement, FormElement, F
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (OrderedList, T) -> OrderedList) -> OrderedList {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (OrderedList, T) -> OrderedList) -> OrderedList {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -7713,13 +7827,19 @@ public struct UnorderedList: ContentNode, HtmlElement, BodyElement, FormElement,
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (UnorderedList, T) -> UnorderedList) -> UnorderedList {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (UnorderedList, T) -> UnorderedList) -> UnorderedList {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -8113,13 +8233,19 @@ public struct Menu: ContentNode, HtmlElement, BodyElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Menu, T) -> Menu) -> Menu {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Menu, T) -> Menu) -> Menu {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -8413,13 +8539,19 @@ public struct DescriptionList: ContentNode, HtmlElement, BodyElement, FormElemen
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (DescriptionList, T) -> DescriptionList) -> DescriptionList {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (DescriptionList, T) -> DescriptionList) -> DescriptionList {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -8807,13 +8939,19 @@ public struct Figure: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Figure, T) -> Figure) -> Figure {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Figure, T) -> Figure) -> Figure {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -9198,13 +9336,19 @@ public struct Anchor: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Anchor, T) -> Anchor) -> Anchor {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Anchor, T) -> Anchor) -> Anchor {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -9644,13 +9788,19 @@ public struct Emphasize: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Emphasize, T) -> Emphasize) -> Emphasize {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Emphasize, T) -> Emphasize) -> Emphasize {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -10035,13 +10185,19 @@ public struct Strong: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Strong, T) -> Strong) -> Strong {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Strong, T) -> Strong) -> Strong {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -10426,13 +10582,19 @@ public struct Small: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Small, T) -> Small) -> Small {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Small, T) -> Small) -> Small {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -10826,13 +10988,19 @@ public struct StrikeThrough: ContentNode, HtmlElement, BodyElement, FormElement,
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (StrikeThrough, T) -> StrikeThrough) -> StrikeThrough {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (StrikeThrough, T) -> StrikeThrough) -> StrikeThrough {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -11158,13 +11326,19 @@ public struct Main: ContentNode, HtmlElement, BodyElement, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Main, T) -> Main) -> Main {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Main, T) -> Main) -> Main {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -11554,13 +11728,19 @@ public struct Search: ContentNode, HtmlElement, BodyElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Search, T) -> Search) -> Search {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Search, T) -> Search) -> Search {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -11847,13 +12027,19 @@ public struct Division: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Division, T) -> Division) -> Division {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Division, T) -> Division) -> Division {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -12241,13 +12427,19 @@ public struct Definition: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Definition, T) -> Definition) -> Definition {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Definition, T) -> Definition) -> Definition {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -12633,13 +12825,19 @@ public struct Cite: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Cite, T) -> Cite) -> Cite {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Cite, T) -> Cite) -> Cite {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -13024,13 +13222,19 @@ public struct ShortQuote: ContentNode, HtmlElement, BodyElement, FormElement, Fi
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (ShortQuote, T) -> ShortQuote) -> ShortQuote {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (ShortQuote, T) -> ShortQuote) -> ShortQuote {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -13420,13 +13624,19 @@ public struct Abbreviation: ContentNode, HtmlElement, BodyElement, FormElement, 
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Abbreviation, T) -> Abbreviation) -> Abbreviation {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Abbreviation, T) -> Abbreviation) -> Abbreviation {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -13812,13 +14022,19 @@ public struct Ruby: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Ruby, T) -> Ruby) -> Ruby {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Ruby, T) -> Ruby) -> Ruby {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -14206,13 +14422,19 @@ public struct Data: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Data, T) -> Data) -> Data {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Data, T) -> Data) -> Data {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -14612,13 +14834,19 @@ public struct Time: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Time, T) -> Time) -> Time {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Time, T) -> Time) -> Time {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -15009,13 +15237,19 @@ public struct Code: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Code, T) -> Code) -> Code {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Code, T) -> Code) -> Code {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -15402,13 +15636,19 @@ public struct Variable: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Variable, T) -> Variable) -> Variable {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Variable, T) -> Variable) -> Variable {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -15791,13 +16031,19 @@ public struct SampleOutput: ContentNode, HtmlElement, BodyElement, FormElement, 
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (SampleOutput, T) -> SampleOutput) -> SampleOutput {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (SampleOutput, T) -> SampleOutput) -> SampleOutput {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -16184,13 +16430,19 @@ public struct KeyboardInput: ContentNode, HtmlElement, BodyElement, FormElement,
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (KeyboardInput, T) -> KeyboardInput) -> KeyboardInput {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (KeyboardInput, T) -> KeyboardInput) -> KeyboardInput {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -16577,13 +16829,19 @@ public struct Subscript: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Subscript, T) -> Subscript) -> Subscript {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Subscript, T) -> Subscript) -> Subscript {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -16969,13 +17227,19 @@ public struct Superscript: ContentNode, HtmlElement, BodyElement, FormElement, F
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Superscript, T) -> Superscript) -> Superscript {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Superscript, T) -> Superscript) -> Superscript {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -17362,13 +17626,19 @@ public struct Italic: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Italic, T) -> Italic) -> Italic {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Italic, T) -> Italic) -> Italic {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -17764,13 +18034,19 @@ public struct Bold: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Bold, T) -> Bold) -> Bold {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Bold, T) -> Bold) -> Bold {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -18166,13 +18442,19 @@ public struct Underline: ContentNode, HtmlElement, BodyElement, FormElement, Fig
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Underline, T) -> Underline) -> Underline {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Underline, T) -> Underline) -> Underline {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -18568,13 +18850,19 @@ public struct Mark: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Mark, T) -> Mark) -> Mark {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Mark, T) -> Mark) -> Mark {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -18961,13 +19249,19 @@ public struct Bdi: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Bdi, T) -> Bdi) -> Bdi {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Bdi, T) -> Bdi) -> Bdi {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -19342,13 +19636,19 @@ public struct Bdo: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEleme
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Bdo, T) -> Bdo) -> Bdo {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Bdo, T) -> Bdo) -> Bdo {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -19731,13 +20031,19 @@ public struct Span: ContentNode, HtmlElement, BodyElement, FormElement, FigureEl
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Span, T) -> Span) -> Span {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Span, T) -> Span) -> Span {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -20105,13 +20411,19 @@ public struct LineBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (LineBreak, T) -> LineBreak) -> LineBreak {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (LineBreak, T) -> LineBreak) -> LineBreak {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -20483,13 +20795,19 @@ public struct WordBreak: EmptyNode, HtmlElement, BodyElement, FormElement, Figur
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (WordBreak, T) -> WordBreak) -> WordBreak {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (WordBreak, T) -> WordBreak) -> WordBreak {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -20872,13 +21190,19 @@ public struct InsertedText: ContentNode, HtmlElement, BodyElement, FormElement, 
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (InsertedText, T) -> InsertedText) -> InsertedText {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (InsertedText, T) -> InsertedText) -> InsertedText {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -21269,13 +21593,19 @@ public struct DeletedText: ContentNode, HtmlElement, BodyElement, FormElement, F
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (DeletedText, T) -> DeletedText) -> DeletedText {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (DeletedText, T) -> DeletedText) -> DeletedText {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -21671,13 +22001,19 @@ public struct Picture: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Picture, T) -> Picture) -> Picture {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Picture, T) -> Picture) -> Picture {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -21972,13 +22308,19 @@ public struct Image: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Image, T) -> Image) -> Image {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Image, T) -> Image) -> Image {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -22440,13 +22782,19 @@ public struct InlineFrame: ContentNode, HtmlElement, BodyElement, FormElement, F
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (InlineFrame, T) -> InlineFrame) -> InlineFrame {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (InlineFrame, T) -> InlineFrame) -> InlineFrame {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -22860,13 +23208,19 @@ public struct Embed: EmptyNode, HtmlElement, BodyElement, FormElement, FigureEle
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Embed, T) -> Embed) -> Embed {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Embed, T) -> Embed) -> Embed {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -23270,13 +23624,19 @@ public struct Object: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Object, T) -> Object) -> Object {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Object, T) -> Object) -> Object {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -23685,13 +24045,19 @@ public struct Video: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Video, T) -> Video) -> Video {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Video, T) -> Video) -> Video {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -24135,13 +24501,19 @@ public struct Audio: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Audio, T) -> Audio) -> Audio {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Audio, T) -> Audio) -> Audio {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -24573,13 +24945,19 @@ public struct Map: ContentNode, HtmlElement, BodyElement, FormElement, FigureEle
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Map, T) -> Map) -> Map {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Map, T) -> Map) -> Map {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -24896,13 +25274,19 @@ public struct Form: ContentNode, HtmlElement, BodyElement, FigureElement, Object
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Form, T) -> Form) -> Form {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Form, T) -> Form) -> Form {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -25333,13 +25717,19 @@ public struct DataList: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (DataList, T) -> DataList) -> DataList {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (DataList, T) -> DataList) -> DataList {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -25724,13 +26114,19 @@ public struct Output: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Output, T) -> Output) -> Output {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Output, T) -> Output) -> Output {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -26127,13 +26523,19 @@ public struct Progress: ContentNode, HtmlElement, BodyElement, FormElement, Figu
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Progress, T) -> Progress) -> Progress {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Progress, T) -> Progress) -> Progress {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -26537,13 +26939,19 @@ public struct Meter: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Meter, T) -> Meter) -> Meter {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Meter, T) -> Meter) -> Meter {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -26964,13 +27372,19 @@ public struct Details: ContentNode, HtmlElement, BodyElement, FormElement, Figur
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Details, T) -> Details) -> Details {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Details, T) -> Details) -> Details {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -27381,13 +27795,19 @@ public struct Dialog: ContentNode, BodyElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Dialog, T) -> Dialog) -> Dialog {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Dialog, T) -> Dialog) -> Dialog {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -27789,13 +28209,19 @@ public struct Script: ContentNode, HeadElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Script, T) -> Script) -> Script {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Script, T) -> Script) -> Script {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -28148,13 +28574,19 @@ public struct NoScript: ContentNode, HtmlElement, HeadElement, BodyElement, Form
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (NoScript, T) -> NoScript) -> NoScript {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (NoScript, T) -> NoScript) -> NoScript {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -28468,13 +28900,19 @@ public struct Template: ContentNode, BodyElement, FormElement, FigureElement, Ob
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Template, T) -> Template) -> Template {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Template, T) -> Template) -> Template {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -28781,13 +29219,19 @@ public struct Canvas: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Canvas, T) -> Canvas) -> Canvas {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Canvas, T) -> Canvas) -> Canvas {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -29185,13 +29629,19 @@ public struct Table: ContentNode, HtmlElement, BodyElement, FormElement, FigureE
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Table, T) -> Table) -> Table {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Table, T) -> Table) -> Table {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -29588,13 +30038,19 @@ public struct Vector: ContentNode, HtmlElement, BodyElement, FormElement, Figure
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Vector, T) -> Vector) -> Vector {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Vector, T) -> Vector) -> Vector {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -29799,13 +30255,19 @@ public struct Slot: ContentNode, BodyElement, FormElement, FigureElement, Object
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Slot, T) -> Slot) -> Slot {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Slot, T) -> Slot) -> Slot {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -153,7 +153,7 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -173,7 +173,7 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -540,7 +540,7 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -560,7 +560,7 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -82,8 +82,12 @@ extension TermName: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TermName {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TermName {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TermName {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -465,8 +469,12 @@ extension TermDefinition: GlobalAttributes, GlobalEventAttributes, GlobalAriaAtt
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TermDefinition {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TermDefinition {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TermDefinition {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -49,10 +49,17 @@ public struct TermName: ContentNode, DescriptionElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TermName) -> TermName) -> TermName {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TermName) -> TermName) -> TermName {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -64,7 +71,7 @@ public struct TermName: ContentNode, DescriptionElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -436,10 +443,17 @@ public struct TermDefinition: ContentNode, DescriptionElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TermDefinition) -> TermDefinition) -> TermDefinition {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TermDefinition) -> TermDefinition) -> TermDefinition {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -451,7 +465,7 @@ public struct TermDefinition: ContentNode, DescriptionElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/DefinitionElements.swift
@@ -65,13 +65,19 @@ public struct TermName: ContentNode, DescriptionElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TermName, T) -> TermName) -> TermName {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TermName, T) -> TermName) -> TermName {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -459,13 +465,19 @@ public struct TermDefinition: ContentNode, DescriptionElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TermDefinition, T) -> TermDefinition) -> TermDefinition {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TermDefinition, T) -> TermDefinition) -> TermDefinition {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -45,10 +45,17 @@ public struct FigureCaption: ContentNode, FigureElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (FigureCaption) -> FigureCaption) -> FigureCaption {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (FigureCaption) -> FigureCaption) -> FigureCaption {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -60,7 +67,7 @@ public struct FigureCaption: ContentNode, FigureElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -61,13 +61,19 @@ public struct FigureCaption: ContentNode, FigureElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (FigureCaption, T) -> FigureCaption) -> FigureCaption {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (FigureCaption, T) -> FigureCaption) -> FigureCaption {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -78,8 +78,12 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> FigureCaption {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> FigureCaption {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> FigureCaption {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FigureElements.swift
@@ -149,7 +149,7 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -169,7 +169,7 @@ extension FigureCaption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttr
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -43,13 +43,19 @@ public struct Input: EmptyNode, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Input, T) -> Input) -> Input {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Input, T) -> Input) -> Input {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -558,13 +564,19 @@ public struct Label: ContentNode, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Label, T) -> Label) -> Label {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Label, T) -> Label) -> Label {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -969,13 +981,19 @@ public struct Select: ContentNode, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Select, T) -> Select) -> Select {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Select, T) -> Select) -> Select {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1335,13 +1353,19 @@ public struct TextArea: ContentNode, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TextArea, T) -> TextArea) -> TextArea {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TextArea, T) -> TextArea) -> TextArea {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1814,13 +1838,19 @@ public struct Button: ContentNode, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Button, T) -> Button) -> Button {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Button, T) -> Button) -> Button {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -2278,13 +2308,19 @@ public struct Fieldset: ContentNode, FormElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Fieldset, T) -> Fieldset) -> Fieldset {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Fieldset, T) -> Fieldset) -> Fieldset {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -27,10 +27,17 @@ public struct Input: EmptyNode, FormElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Input) -> Input) -> Input {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Input) -> Input) -> Input {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -42,7 +49,7 @@ public struct Input: EmptyNode, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -535,10 +542,17 @@ public struct Label: ContentNode, FormElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Label) -> Label) -> Label {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Label) -> Label) -> Label {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -550,7 +564,7 @@ public struct Label: ContentNode, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -939,10 +953,17 @@ public struct Select: ContentNode, FormElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Select) -> Select) -> Select {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Select) -> Select) -> Select {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -954,7 +975,7 @@ public struct Select: ContentNode, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1298,10 +1319,17 @@ public struct TextArea: ContentNode, FormElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TextArea) -> TextArea) -> TextArea {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TextArea) -> TextArea) -> TextArea {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1313,7 +1341,7 @@ public struct TextArea: ContentNode, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1770,10 +1798,17 @@ public struct Button: ContentNode, FormElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Button) -> Button) -> Button {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Button) -> Button) -> Button {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1785,7 +1820,7 @@ public struct Button: ContentNode, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -2227,10 +2262,17 @@ public struct Fieldset: ContentNode, FormElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Fieldset) -> Fieldset) -> Fieldset {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Fieldset) -> Fieldset) -> Fieldset {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -2242,7 +2284,7 @@ public struct Fieldset: ContentNode, FormElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -60,8 +60,12 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Input {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Input {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Input {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -555,8 +559,12 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Label {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Label {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Label {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -955,8 +963,12 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Select {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Select {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Select {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1301,8 +1313,12 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TextArea {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TextArea {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TextArea {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1760,8 +1776,12 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Button {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Button {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Button {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -2213,8 +2233,12 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Fieldset {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Fieldset {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Fieldset {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/FormElements.swift
@@ -131,7 +131,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -151,7 +151,7 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -250,19 +250,19 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
     }
     
     public func accept(_ specifiers: [String]) -> Input {
-        return mutate(accept: .init(specifiers.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .tainted(.html)))
     }
 
     public func accept(_ specifiers: String...) -> Input {
-        return mutate(accept: .init(specifiers.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .tainted(.html)))
     }
     
     public func accept(_ specifiers: [Values.Media]) -> Input {
-        return mutate(accept: .init(specifiers.map { $0.rawValue }.joined(separator: ", "), context: .trusted))
+        return mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .trusted))
     }
 
     public func accept(_ specifiers: Values.Media...) -> Input {
-        return mutate(accept: .init(specifiers.map { $0.rawValue }.joined(separator: ", "), context: .trusted))
+        return mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .trusted))
     }
     
     @_disfavoredOverload
@@ -278,12 +278,21 @@ extension Input: GlobalAttributes, GlobalEventAttributes, AcceptAttribute, Alter
         return mutate(alternate: .init(value, context: .tainted(.html)))
     }
     
-    public func autocomplete(_ value: Values.Completion) -> Input {
-        return mutate(autocomplete: .init(value.rawValue, context: .trusted))
+    public func autocomplete(_ value: Bool) -> Input {
+
+        if value {
+            return mutate(autocomplete: .init("on", context: .trusted))
+        }
+        
+        return mutate(autocomplete: .init("off", context: .trusted))
     }
     
-    public func autocomplete(_ values: OrderedSet<Values.Completion>) -> Input {
-        return mutate(autocomplete: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+    public func autocomplete(_ values: [Values.Completion]) -> Input {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
+    }
+    
+    public func autocomplete(_ values: Values.Completion...) -> Input {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
     }
     
     public func checked(_ condition: Bool = true) -> Input {
@@ -630,7 +639,7 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -650,7 +659,7 @@ extension Label: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1034,7 +1043,7 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1054,7 +1063,7 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1152,12 +1161,21 @@ extension Select: GlobalAttributes, GlobalEventAttributes, AutocompleteAttribute
         return self
     }
     
-    public func autocomplete(_ value: Values.Completion) -> Select {
-        return mutate(autocomplete: .init(value.rawValue, context: .trusted))
+    public func autocomplete(_ value: Bool) -> Select {
+
+        if value {
+            return mutate(autocomplete: .init("on", context: .trusted))
+        }
+        
+        return mutate(autocomplete: .init("off", context: .trusted))
     }
     
-    public func autocomplete(_ values: OrderedSet<Values.Completion>) -> Select {
-        return mutate(autocomplete: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+    public func autocomplete(_ values: [Values.Completion]) -> Select {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
+    }
+    
+    public func autocomplete(_ values: Values.Completion...) -> Select {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
     }
     
     public func disabled(_ condition: Bool = true) -> Select {
@@ -1384,7 +1402,7 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1404,7 +1422,7 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1502,12 +1520,21 @@ extension TextArea: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return self
     }
     
-    public func autocomplete(_ value: Values.Completion) -> TextArea {
-        return mutate(autocomplete: .init(value.rawValue, context: .trusted))
+    public func autocomplete(_ value: Bool) -> TextArea {
+
+        if value {
+            return mutate(autocomplete: .init("on", context: .trusted))
+        }
+        
+        return mutate(autocomplete: .init("off", context: .trusted))
     }
     
-    public func autocomplete(_ values: OrderedSet<Values.Completion>) -> TextArea {
-        return mutate(autocomplete: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+    public func autocomplete(_ values: [Values.Completion]) -> TextArea {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
+    }
+    
+    public func autocomplete(_ values: Values.Completion...) -> TextArea {
+        return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
     }
     
     public func columns(_ size: Int) -> TextArea {
@@ -1847,7 +1874,7 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1867,7 +1894,7 @@ extension Button: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -2304,7 +2331,7 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -2324,7 +2351,7 @@ extension Fieldset: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -38,10 +38,17 @@ public struct Title: ContentNode, HeadElement, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Title) -> Title) -> Title {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Title) -> Title) -> Title {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -53,7 +60,7 @@ public struct Title: ContentNode, HeadElement, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -342,10 +349,17 @@ public struct Base: EmptyNode, HeadElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Base) -> Base) -> Base {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Base) -> Base) -> Base {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -357,7 +371,7 @@ public struct Base: EmptyNode, HeadElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -644,10 +658,17 @@ public struct Meta: EmptyNode, HeadElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Meta) -> Meta) -> Meta {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Meta) -> Meta) -> Meta {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -659,7 +680,7 @@ public struct Meta: EmptyNode, HeadElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -989,10 +1010,17 @@ public struct Style: ContentNode, HeadElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Style) -> Style) -> Style {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Style) -> Style) -> Style {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1004,7 +1032,7 @@ public struct Style: ContentNode, HeadElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1302,10 +1330,17 @@ public struct Link: EmptyNode, HeadElement, BodyElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Link) -> Link) -> Link {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Link) -> Link) -> Link {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1317,7 +1352,7 @@ public struct Link: EmptyNode, HeadElement, BodyElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -142,7 +142,7 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -162,7 +162,7 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -446,7 +446,7 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -466,7 +466,7 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -748,7 +748,7 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -768,7 +768,7 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1093,7 +1093,7 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1113,7 +1113,7 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1220,11 +1220,11 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
     }
     
     public func media(_ queries: [MediaQuery]) -> Style {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func media(_ queries: MediaQuery...) -> Style {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func blocking(_ value: Values.Blocking) -> Style {
@@ -1396,11 +1396,11 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
     }
     
     public func integrity(_ hashes: String...) -> Link {
-        return mutate(integrity: .init(hashes.joined(separator: " "), context: .tainted(.html)))
+        return mutate(integrity: .init(EnumeratedList(values: hashes, separator: " "), context: .tainted(.html)))
     }
     
     public func integrity(_ hashes: [String]) -> Link {
-        return mutate(integrity: .init(hashes.joined(separator: " "), context: .tainted(.html)))
+        return mutate(integrity: .init(EnumeratedList(values: hashes, separator: " "), context: .tainted(.html)))
     }
 
     public func `is`(_ value: String) -> Link {
@@ -1422,7 +1422,7 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1442,7 +1442,7 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1553,11 +1553,11 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
     }
     
     public func media(_ queries: [MediaQuery]) -> Link {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func media(_ queries: MediaQuery...) -> Link {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func referrerPolicy(_ value: Values.Policy) -> Link {
@@ -1569,11 +1569,11 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
     }
     
     public func sizes(_ candidates: [String]) -> Link {
-        return mutate(sizes: .init(candidates.map { $0 }.joined(separator: " "), context: .tainted(.html)))
+        return mutate(sizes: .init(EnumeratedList(values: candidates, separator: " "), context: .tainted(.html)))
     }
     
     public func sizes(_ candidates: String...) -> Link {
-        return mutate(sizes: .init(candidates.map { $0 }.joined(separator: " "), context: .tainted(.html)))
+        return mutate(sizes: .init(EnumeratedList(values: candidates, separator: " "), context: .tainted(.html)))
     }
     
     public func type(_ value: Values.Media) -> Link {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -71,8 +71,12 @@ extension Title: GlobalAttributes, GlobalEventAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Title {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Title {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Title {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -371,8 +375,12 @@ extension Base: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Tar
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Base {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Base {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Base {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -669,8 +677,12 @@ extension Meta: GlobalAttributes, GlobalEventAttributes, ContentAttribute, NameA
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Meta {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Meta {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Meta {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1010,8 +1022,12 @@ extension Style: GlobalAttributes, GlobalEventAttributes, TypeAttribute, MediaAt
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Style {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Style {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Style {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1323,8 +1339,12 @@ extension Link: GlobalAttributes, GlobalEventAttributes, ReferenceAttribute, Ref
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Link {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Link {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Link {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func crossOrigin(_ value: Credential.Mode) -> Link {

--- a/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HeadElements.swift
@@ -54,13 +54,19 @@ public struct Title: ContentNode, HeadElement, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Title, T) -> Title) -> Title {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Title, T) -> Title) -> Title {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -365,13 +371,19 @@ public struct Base: EmptyNode, HeadElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Base, T) -> Base) -> Base {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Base, T) -> Base) -> Base {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -674,13 +686,19 @@ public struct Meta: EmptyNode, HeadElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Meta, T) -> Meta) -> Meta {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Meta, T) -> Meta) -> Meta {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1026,13 +1044,19 @@ public struct Style: ContentNode, HeadElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Style, T) -> Style) -> Style {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Style, T) -> Style) -> Style {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1346,13 +1370,19 @@ public struct Link: EmptyNode, HeadElement, BodyElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Link, T) -> Link) -> Link {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Link, T) -> Link) -> Link {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -140,7 +140,7 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -160,7 +160,7 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -451,7 +451,7 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -471,7 +471,7 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -36,10 +36,17 @@ public struct Head: ContentNode, HtmlElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Head) -> Head) -> Head {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Head) -> Head) -> Head {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -51,7 +58,7 @@ public struct Head: ContentNode, HtmlElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -347,10 +354,17 @@ public struct Body: ContentNode, HtmlElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Body) -> Body) -> Body {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Body) -> Body) -> Body {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -362,7 +376,7 @@ public struct Body: ContentNode, HtmlElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -69,8 +69,12 @@ extension Head: GlobalAttributes, GlobalEventAttributes {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Head {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Head {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Head {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -376,8 +380,12 @@ extension Body: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, W
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Body {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Body {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Body {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/HtmlElements.swift
@@ -52,13 +52,19 @@ public struct Head: ContentNode, HtmlElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Head, T) -> Head) -> Head {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Head, T) -> Head) -> Head {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -370,13 +376,19 @@ public struct Body: ContentNode, HtmlElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Body, T) -> Body) -> Body {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Body, T) -> Body) -> Body {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -51,10 +51,17 @@ public struct OptionGroup: ContentNode, InputElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (OptionGroup) -> OptionGroup) -> OptionGroup {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (OptionGroup) -> OptionGroup) -> OptionGroup {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -66,7 +73,7 @@ public struct OptionGroup: ContentNode, InputElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -458,10 +465,17 @@ public struct Option: ContentNode, InputElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Option) -> Option) -> Option {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Option) -> Option) -> Option {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -473,7 +487,7 @@ public struct Option: ContentNode, InputElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -897,10 +911,17 @@ public struct Legend: ContentNode, InputElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Legend) -> Legend) -> Legend {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Legend) -> Legend) -> Legend {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -912,7 +933,7 @@ public struct Legend: ContentNode, InputElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1284,10 +1305,17 @@ public struct Summary: ContentNode, InputElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Summary) -> Summary) -> Summary {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Summary) -> Summary) -> Summary {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1299,7 +1327,7 @@ public struct Summary: ContentNode, InputElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -155,7 +155,7 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -175,7 +175,7 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -562,7 +562,7 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -582,7 +582,7 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1001,7 +1001,7 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1021,7 +1021,7 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1388,7 +1388,7 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1408,7 +1408,7 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -84,8 +84,12 @@ extension OptionGroup: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttrib
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> OptionGroup {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> OptionGroup {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> OptionGroup {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -487,8 +491,12 @@ extension Option: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes,
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Option {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Option {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Option {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -922,8 +930,12 @@ extension Legend: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes 
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Legend {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Legend {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Legend {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1305,8 +1317,12 @@ extension Summary: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Summary {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Summary {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Summary {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/InputElements.swift
@@ -67,13 +67,19 @@ public struct OptionGroup: ContentNode, InputElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (OptionGroup, T) -> OptionGroup) -> OptionGroup {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (OptionGroup, T) -> OptionGroup) -> OptionGroup {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -481,13 +487,19 @@ public struct Option: ContentNode, InputElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Option, T) -> Option) -> Option {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Option, T) -> Option) -> Option {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -927,13 +939,19 @@ public struct Legend: ContentNode, InputElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Legend, T) -> Legend) -> Legend {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Legend, T) -> Legend) -> Legend {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1321,13 +1339,19 @@ public struct Summary: ContentNode, InputElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Summary, T) -> Summary) -> Summary {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Summary, T) -> Summary) -> Summary {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -45,10 +45,17 @@ public struct ListItem: ContentNode, ListElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (ListItem) -> ListItem) -> ListItem {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (ListItem) -> ListItem) -> ListItem {
         
         if condition {
-            return modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -60,7 +67,7 @@ public struct ListItem: ContentNode, ListElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -149,7 +149,7 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -169,7 +169,7 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -61,13 +61,19 @@ public struct ListItem: ContentNode, ListElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (ListItem, T) -> ListItem) -> ListItem {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (ListItem, T) -> ListItem) -> ListItem {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ListElements.swift
@@ -78,8 +78,12 @@ extension ListItem: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> ListItem {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> ListItem {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> ListItem {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -49,13 +49,19 @@ public struct Area: EmptyNode, MapElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Area, T) -> Area) -> Area {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Area, T) -> Area) -> Area {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -137,7 +137,7 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -157,7 +157,7 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -66,8 +66,12 @@ extension Area: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes, A
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Area {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Area {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Area {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MapElements.swift
@@ -33,10 +33,17 @@ public struct Area: EmptyNode, MapElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Area) -> Area) -> Area {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Area) -> Area) -> Area {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -48,7 +55,7 @@ public struct Area: EmptyNode, MapElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -59,8 +59,12 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Source {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Source {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Source {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -407,8 +411,12 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Track {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Track {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Track {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -130,7 +130,7 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -150,7 +150,7 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -266,19 +266,19 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
     }
     
     public func sourceSet(_ candidates: [SourceCandidate]) -> Source {
-        return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func sourceSet(_ candidates: SourceCandidate...) -> Source {
-        return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func sizes(_ candidates: [SizeCandidate]) -> Source {
-        return mutate(sizes: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sizes: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func sizes(_ candidates: SizeCandidate...) -> Source {
-        return mutate(sizes: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(sizes: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
     }
     
     public func media(_ value: String) -> Source {
@@ -286,11 +286,11 @@ extension Source: GlobalAttributes, GlobalEventAttributes, TypeAttribute, Source
     }
     
     public func media(_ queries: [MediaQuery]) -> Source {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func media(_ queries: MediaQuery...) -> Source {
-        return mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+        return mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
     }
     
     public func width(_ size: Int) -> Source {
@@ -482,7 +482,7 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -502,7 +502,7 @@ extension Track: GlobalAttributes, GlobalEventAttributes, KindAttribute, SourceA
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -42,13 +42,19 @@ public struct Source: EmptyNode, MediaElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Source, T) -> Source) -> Source {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Source, T) -> Source) -> Source {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -401,13 +407,19 @@ public struct Track: EmptyNode, MediaElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Track, T) -> Track) -> Track {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Track, T) -> Track) -> Track {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/MediaElements.swift
@@ -26,10 +26,17 @@ public struct Source: EmptyNode, MediaElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Source) -> Source) -> Source {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Source) -> Source) -> Source {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -41,7 +48,7 @@ public struct Source: EmptyNode, MediaElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -378,10 +385,17 @@ public struct Track: EmptyNode, MediaElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Track) -> Track) -> Track {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Track) -> Track) -> Track {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -393,7 +407,7 @@ public struct Track: EmptyNode, MediaElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -45,13 +45,19 @@ public struct Parameter: EmptyNode, ObjectElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Parameter, T) -> Parameter) -> Parameter {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Parameter, T) -> Parameter) -> Parameter {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -29,10 +29,17 @@ public struct Parameter: EmptyNode, ObjectElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Parameter) -> Parameter) -> Parameter {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Parameter) -> Parameter) -> Parameter {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -44,7 +51,7 @@ public struct Parameter: EmptyNode, ObjectElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -133,7 +133,7 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -153,7 +153,7 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/ObjectElements.swift
@@ -62,8 +62,12 @@ extension Parameter: GlobalAttributes, GlobalEventAttributes, NameAttribute, Val
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Parameter {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Parameter {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Parameter {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -80,8 +80,12 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> RubyText {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> RubyText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> RubyText {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -467,8 +471,12 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> RubyPronunciation {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> RubyPronunciation {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> RubyPronunciation {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -151,7 +151,7 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -171,7 +171,7 @@ extension RubyText: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -542,7 +542,7 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -562,7 +562,7 @@ extension RubyPronunciation: GlobalAttributes, GlobalEventAttributes, GlobalAria
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -47,10 +47,17 @@ public struct RubyText: ContentNode, RubyElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (RubyText) -> RubyText) -> RubyText {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (RubyText) -> RubyText) -> RubyText {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -62,7 +69,7 @@ public struct RubyText: ContentNode, RubyElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -438,10 +445,17 @@ public struct RubyPronunciation: ContentNode, RubyElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (RubyPronunciation) -> RubyPronunciation) -> RubyPronunciation {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (RubyPronunciation) -> RubyPronunciation) -> RubyPronunciation {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -453,7 +467,7 @@ public struct RubyPronunciation: ContentNode, RubyElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/RubyElements.swift
@@ -63,13 +63,19 @@ public struct RubyText: ContentNode, RubyElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (RubyText, T) -> RubyText) -> RubyText {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (RubyText, T) -> RubyText) -> RubyText {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -461,13 +467,19 @@ public struct RubyPronunciation: ContentNode, RubyElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (RubyPronunciation, T) -> RubyPronunciation) -> RubyPronunciation {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (RubyPronunciation, T) -> RubyPronunciation) -> RubyPronunciation {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -70,10 +70,17 @@ public struct Caption: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Caption) -> Caption) -> Caption {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Caption) -> Caption) -> Caption {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -85,7 +92,7 @@ public struct Caption: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -456,10 +463,17 @@ public struct ColumnGroup: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (ColumnGroup) -> ColumnGroup) -> ColumnGroup {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (ColumnGroup) -> ColumnGroup) -> ColumnGroup {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -471,7 +485,7 @@ public struct ColumnGroup: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -761,10 +775,17 @@ public struct Column: EmptyNode, TableElement {
         self.attributes = attributes
     }
     
-    public func modify(if condition: Bool, element: (Column) -> Column) -> Column {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Column) -> Column) -> Column {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -776,7 +797,7 @@ public struct Column: EmptyNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1076,10 +1097,17 @@ public struct TableBody: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TableBody) -> TableBody) -> TableBody {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TableBody) -> TableBody) -> TableBody {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1091,7 +1119,7 @@ public struct TableBody: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1479,10 +1507,17 @@ public struct TableHead: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TableHead) -> TableHead) -> TableHead {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TableHead) -> TableHead) -> TableHead {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1494,7 +1529,7 @@ public struct TableHead: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1882,10 +1917,17 @@ public struct TableFoot: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TableFoot) -> TableFoot) -> TableFoot {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TableFoot) -> TableFoot) -> TableFoot {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1897,7 +1939,7 @@ public struct TableFoot: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -2271,10 +2313,17 @@ public struct TableRow: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (TableRow) -> TableRow) -> TableRow {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (TableRow) -> TableRow) -> TableRow {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -2286,7 +2335,7 @@ public struct TableRow: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -2665,10 +2714,17 @@ public struct DataCell: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (DataCell) -> DataCell) -> DataCell {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (DataCell) -> DataCell) -> DataCell {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -2680,7 +2736,7 @@ public struct DataCell: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -3068,10 +3124,17 @@ public struct HeaderCell: ContentNode, TableElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (HeaderCell) -> HeaderCell) -> HeaderCell {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (HeaderCell) -> HeaderCell) -> HeaderCell {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -3083,7 +3146,7 @@ public struct HeaderCell: ContentNode, TableElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -174,7 +174,7 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -194,7 +194,7 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -560,7 +560,7 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -580,7 +580,7 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -865,7 +865,7 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -885,7 +885,7 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1180,7 +1180,7 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1200,7 +1200,7 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1583,7 +1583,7 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -1603,7 +1603,7 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -1986,7 +1986,7 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -2006,7 +2006,7 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -2375,7 +2375,7 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -2395,7 +2395,7 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -2769,7 +2769,7 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -2790,7 +2790,7 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -2897,11 +2897,11 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
     }
     
     public func headers(_ ids: [String]) -> DataCell {
-        return mutate(headers: .init(ids.joined(separator: " "), context: .tainted(.html)))
+        return mutate(headers: .init(EnumeratedList(values: ids, separator: " "), context: .tainted(.html)))
     }
     
     public func headers(_ ids: String...) -> DataCell {
-        return mutate(headers: .init(ids.joined(separator: " "), context: .tainted(.html)))
+        return mutate(headers: .init(EnumeratedList(values: ids, separator: " "), context: .tainted(.html)))
     }
     
     public func popover(_ value: Values.Popover.State) -> DataCell {
@@ -3172,7 +3172,7 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         }
         
         if let elements = elements {
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         }
         
         return copy
@@ -3192,7 +3192,7 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
             copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
         }
         
-        copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+        copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
         
         return copy
     }
@@ -3299,11 +3299,11 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
     }
     
     public func headers(_ ids: [String]) -> HeaderCell {
-        return mutate(headers: .init(ids.joined(separator: " "), context: .tainted(.html)))
+        return mutate(headers: .init(EnumeratedList(values: ids, separator: " "), context: .tainted(.html)))
     }
     
     public func headers(_ ids: String...) -> HeaderCell {
-        return mutate(headers: .init(ids.joined(separator: " "), context: .tainted(.html)))
+        return mutate(headers: .init(EnumeratedList(values: ids, separator: " "), context: .tainted(.html)))
     }
     
     public func scope(_ value: Values.Scope) -> HeaderCell {

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -86,13 +86,19 @@ public struct Caption: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Caption, T) -> Caption) -> Caption {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Caption, T) -> Caption) -> Caption {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -479,13 +485,19 @@ public struct ColumnGroup: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (ColumnGroup, T) -> ColumnGroup) -> ColumnGroup {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (ColumnGroup, T) -> ColumnGroup) -> ColumnGroup {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -791,13 +803,19 @@ public struct Column: EmptyNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Column, T) -> Column) -> Column {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Column, T) -> Column) -> Column {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1113,13 +1131,19 @@ public struct TableBody: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TableBody, T) -> TableBody) -> TableBody {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TableBody, T) -> TableBody) -> TableBody {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1523,13 +1547,19 @@ public struct TableHead: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TableHead, T) -> TableHead) -> TableHead {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TableHead, T) -> TableHead) -> TableHead {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1933,13 +1963,19 @@ public struct TableFoot: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TableFoot, T) -> TableFoot) -> TableFoot {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TableFoot, T) -> TableFoot) -> TableFoot {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -2329,13 +2365,19 @@ public struct TableRow: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (TableRow, T) -> TableRow) -> TableRow {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (TableRow, T) -> TableRow) -> TableRow {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -2730,13 +2772,19 @@ public struct DataCell: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (DataCell, T) -> DataCell) -> DataCell {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (DataCell, T) -> DataCell) -> DataCell {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -3140,13 +3188,19 @@ public struct HeaderCell: ContentNode, TableElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (HeaderCell, T) -> HeaderCell) -> HeaderCell {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (HeaderCell, T) -> HeaderCell) -> HeaderCell {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/TableElements.swift
@@ -103,8 +103,12 @@ extension Caption: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttributes
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Caption {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Caption {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Caption {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -485,8 +489,12 @@ extension ColumnGroup: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> ColumnGroup {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> ColumnGroup {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> ColumnGroup {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -786,8 +794,12 @@ extension Column: GlobalAttributes, GlobalEventAttributes, SpanAttribute {
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Column {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Column {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Column {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1097,8 +1109,12 @@ extension TableBody: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TableBody {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TableBody {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TableBody {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1496,8 +1512,12 @@ extension TableHead: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TableHead {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TableHead {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TableHead {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -1895,8 +1915,12 @@ extension TableFoot: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribut
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TableFoot {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TableFoot {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TableFoot {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -2280,8 +2304,12 @@ extension TableRow: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> TableRow {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> TableRow {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> TableRow {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -2670,8 +2698,12 @@ extension DataCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribute
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> DataCell {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> DataCell {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> DataCell {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")
@@ -3069,8 +3101,12 @@ extension HeaderCell: GlobalAttributes, GlobalEventAttributes, GlobalAriaAttribu
         return mutate(autofocus: .init("autofocus", context: .trusted))
     }
 
-    public func `class`(_ value: String) -> HeaderCell {
-        return mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> HeaderCell {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> HeaderCell {
+        return mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     @available(*, deprecated, message: "Use the editable(_:) modifier instead.")

--- a/Sources/HTMLKit/Abstraction/Elements/VectorElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/VectorElements.swift
@@ -73,8 +73,12 @@ extension Circle: GlobalVectorAttributes, CenterPointAttribute, RadiusAttribute 
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Circle {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Circle {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Circle {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Circle {
@@ -264,8 +268,12 @@ extension Rectangle: GlobalVectorAttributes, WidthAttribute, HeightAttribute, Ra
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Rectangle {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Rectangle {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Rectangle {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Rectangle {
@@ -476,8 +484,12 @@ extension Ellipse: GlobalVectorAttributes, CenterPointAttribute, RadiusPointAttr
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Ellipse {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Ellipse {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Ellipse {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Ellipse {
@@ -680,8 +692,12 @@ extension Line: GlobalVectorAttributes {
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Line {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Line {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Line {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Line {
@@ -849,8 +865,12 @@ extension Polygon: GlobalVectorAttributes, PointsAttribute {
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Polygon {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Polygon {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Polygon {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Polygon {
@@ -1022,8 +1042,12 @@ extension Polyline: GlobalVectorAttributes, PointsAttribute {
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Polyline {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Polyline {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Polyline {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Polyline {
@@ -1195,8 +1219,12 @@ extension Path: GlobalVectorAttributes, DrawAttribute {
         return mutate(tabindex: .init(value, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Path {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Path {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Path {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Path {
@@ -1367,8 +1395,12 @@ extension Group: GlobalVectorAttributes {
         return mutate(tabindex: .init(value, context: .trusted))
     }
 
-    public func `class`(_ value: String) -> Group {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Group {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Group {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
 
     public func style(_ value: String) -> Group {
@@ -1568,8 +1600,12 @@ extension Use: GlobalVectorAttributes, ReferenceAttribute, WidthAttribute, Heigh
         return self.mutate(height: .init(size, context: .trusted))
     }
     
-    public func `class`(_ value: String) -> Use {
-        return self.mutate(class: .init(value, context: .tainted(.html)))
+    public func `class`(_ names: [String]) -> Use {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+    }
+    
+    public func `class`(_ names: String...) -> Use {
+        return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
     }
     
     public func style(_ value: String) -> Use {

--- a/Sources/HTMLKit/Abstraction/Elements/VectorElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/VectorElements.swift
@@ -60,13 +60,19 @@ public struct Circle: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Circle, T) -> Circle) -> Circle {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Circle, T) -> Circle) -> Circle {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -262,13 +268,19 @@ public struct Rectangle: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Rectangle, T) -> Rectangle) -> Rectangle {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Rectangle, T) -> Rectangle) -> Rectangle {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -485,13 +497,19 @@ public struct Ellipse: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Ellipse, T) -> Ellipse) -> Ellipse {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Ellipse, T) -> Ellipse) -> Ellipse {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -700,13 +718,19 @@ public struct Line: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Line, T) -> Line) -> Line {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Line, T) -> Line) -> Line {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -880,13 +904,19 @@ public struct Polygon: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Polygon, T) -> Polygon) -> Polygon {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Polygon, T) -> Polygon) -> Polygon {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1064,13 +1094,19 @@ public struct Polyline: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Polyline, T) -> Polyline) -> Polyline {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Polyline, T) -> Polyline) -> Polyline {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1248,13 +1284,19 @@ public struct Path: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Path, T) -> Path) -> Path {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Path, T) -> Path) -> Path {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1431,13 +1473,19 @@ public struct Group: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Group, T) -> Group) -> Group {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Group, T) -> Group) -> Group {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 
@@ -1614,13 +1662,19 @@ public struct Use: ContentNode, VectorElement {
         return self
     }
     
-    public func modify<T>(unwrap value: T?, element: (Use, T) -> Use) -> Use {
+    public func modify<T>(unwrap value: T?, use strategy: MergeStrategy = .replacing, element: (Use, T) -> Use) -> Use {
         
         guard let value = value else {
             return self
         }
         
-        return self.replace(element(self, value as T))
+        switch strategy {
+        case .combining:
+            return self.combine(element(self, value as T))
+            
+        case .replacing:
+            return self.replace(element(self, value as T))
+        }
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Elements/VectorElements.swift
+++ b/Sources/HTMLKit/Abstraction/Elements/VectorElements.swift
@@ -44,10 +44,17 @@ public struct Circle: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Circle) -> Circle) -> Circle {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Circle) -> Circle) -> Circle {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -59,7 +66,7 @@ public struct Circle: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -239,10 +246,17 @@ public struct Rectangle: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Rectangle) -> Rectangle) -> Rectangle {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Rectangle) -> Rectangle) -> Rectangle {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -254,7 +268,7 @@ public struct Rectangle: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -455,10 +469,17 @@ public struct Ellipse: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Ellipse) -> Ellipse) -> Ellipse {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Ellipse) -> Ellipse) -> Ellipse {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -470,7 +491,7 @@ public struct Ellipse: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -663,10 +684,17 @@ public struct Line: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Line) -> Line) -> Line {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Line) -> Line) -> Line {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -678,7 +706,7 @@ public struct Line: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -836,10 +864,17 @@ public struct Polygon: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Polygon) -> Polygon) -> Polygon {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Polygon) -> Polygon) -> Polygon {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -851,7 +886,7 @@ public struct Polygon: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1013,10 +1048,17 @@ public struct Polyline: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Polyline) -> Polyline) -> Polyline {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Polyline) -> Polyline) -> Polyline {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1028,7 +1070,7 @@ public struct Polyline: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1190,10 +1232,17 @@ public struct Path: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Path) -> Path) -> Path {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Path) -> Path) -> Path {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1205,7 +1254,7 @@ public struct Path: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1366,10 +1415,17 @@ public struct Group: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Group) -> Group) -> Group {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Group) -> Group) -> Group {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1381,7 +1437,7 @@ public struct Group: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 
@@ -1542,10 +1598,17 @@ public struct Use: ContentNode, VectorElement {
         self.content = content
     }
     
-    public func modify(if condition: Bool, element: (Use) -> Use) -> Use {
+    public func modify(if condition: Bool, use strategy: MergeStrategy = .replacing, element: (Use) -> Use) -> Use {
         
         if condition {
-            return self.modify(element(self))
+
+            switch strategy {
+            case .combining:
+                return self.combine(element(self))
+                
+            case .replacing:
+                return self.replace(element(self))
+            }
         }
         
         return self
@@ -1557,7 +1620,7 @@ public struct Use: ContentNode, VectorElement {
             return self
         }
         
-        return self.modify(element(self, value as T))
+        return self.replace(element(self, value as T))
     }
 }
 

--- a/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
+++ b/Sources/HTMLKit/Abstraction/Tokens/ValueTokens.swift
@@ -1982,9 +1982,11 @@ public enum Values {
     public enum Completion: String {
         
         /// Enables completion.
+        @available(*, deprecated, message: "Use the autocomplete() modifier instead.")
         case on
         
         /// Disables completion.
+        @available(*, deprecated, message: "Use the autocomplete() modifier instead.")
         case off
         
         /// Expects a name.

--- a/Sources/HTMLKit/Framework/Primitives/Attributes/AttributeData.swift
+++ b/Sources/HTMLKit/Framework/Primitives/Attributes/AttributeData.swift
@@ -25,6 +25,9 @@ public struct AttributeData {
         
         /// An environment value.
         case environment(EnvironmentValue)
+        
+        /// An enumerated list.
+        case list(EnumeratedList)
     }
     
     /// The context of the data.
@@ -108,5 +111,16 @@ public struct AttributeData {
         
         self.context = context
         self.value = .environment(value)
+    }
+    
+    /// Create an enumerated attribute.
+    /// 
+    /// - Parameters:
+    ///   - value: The enumerated list.
+    ///   - context: Whether the list is safe
+    public init(_ value: EnumeratedList, context: EscapeContext) {
+        
+        self.context = context
+        self.value = .list(value)
     }
 }

--- a/Sources/HTMLKit/Framework/Primitives/Nodes/Nodes.swift
+++ b/Sources/HTMLKit/Framework/Primitives/Nodes/Nodes.swift
@@ -40,13 +40,17 @@ extension ContentNode {
     /// - Returns: The element
     internal func replace(_ element: Self) -> Self {
         
-        guard var attributes = self.attributes else {
-            return .init(attributes: element.attributes, context: self.context, content: self.content)
+        guard var lhs = self.attributes else {
+            return element
         }
         
-        attributes.merge(element.attributes!) { (_, new) in new }
+        guard let rhs = element.attributes else {
+            return self
+        }
+        
+        lhs.merge(rhs) { (_, new) in new }
        
-        return .init(attributes: attributes, context: self.context, content: self.content)
+        return .init(attributes: lhs, context: self.context, content: self.content)
     }
     
     /// Combines the attributes, incorporating the new values.
@@ -56,30 +60,38 @@ extension ContentNode {
     /// - Returns: The element
     internal func combine(_ element: Self) -> Self {
         
-        guard var attributes = self.attributes else {
-            return .init(attributes: element.attributes, context: self.context, content: self.content)
+        guard var lhs = self.attributes else {
+            return element
         }
         
-        for (key, value) in attributes {
+        guard let rhs = element.attributes else {
+            return self
+        }
+        
+        for (key, value) in rhs {
             
-            if let attribute = element.attributes?[key] {
+            if let attribute = lhs[key] {
                 
-                if case .list(var old) = value.value, case .list(let new) = attribute.value {
+                switch (attribute.value, value.value) {
+                case (.list(var old), .list(let new)):
                     
                     if old != new {
                         
                         old.append(new.values)
                         
-                        attributes[key] = .init(old, context: value.context)
+                        lhs[key] = .init(old, context: value.context)
                     }
                     
-                } else {
-                    attributes[key] = attribute
+                default:
+                    lhs[key] = value
                 }
+                
+            } else {
+                lhs[key] = value
             }
         }
        
-        return .init(attributes: attributes, context: self.context, content: self.content)
+        return .init(attributes: lhs, context: self.context, content: self.content)
     }
 }
 
@@ -109,13 +121,17 @@ extension EmptyNode {
     /// - Returns: The element
     internal func replace(_ element: Self) -> Self {
         
-        guard var attributes = self.attributes else {
-            return .init(attributes: element.attributes)
+        guard var lhs = self.attributes else {
+            return element
         }
         
-        attributes.merge(element.attributes!) { (_, new) in new }
+        guard let rhs = element.attributes else {
+            return self
+        }
         
-        return .init(attributes: attributes)
+        lhs.merge(rhs) { (_, new) in new }
+        
+        return .init(attributes: lhs)
     }
     
     /// Combines the attributes, incorporating the new values.
@@ -125,30 +141,38 @@ extension EmptyNode {
     /// - Returns: The element
     internal func combine(_ element: Self) -> Self {
         
-        guard var attributes = self.attributes else {
-            return .init(attributes: element.attributes)
+        guard var lhs = self.attributes else {
+            return element
         }
         
-        for (key, value) in attributes {
+        guard let rhs = element.attributes else {
+            return self
+        }
+        
+        for (key, value) in rhs {
             
-            if let attribute = element.attributes?[key] {
+            if let attribute = lhs[key] {
                 
-                if case .list(var old) = value.value, case .list(let new) = attribute.value {
+                switch (attribute.value, value.value) {
+                case (.list(var old), .list(let new)):
                     
                     if old != new {
                         
                         old.append(new.values)
-                     
-                        attributes[key] = .init(old, context: value.context)
+                        
+                        lhs[key] = .init(old, context: value.context)
                     }
                     
-                } else {
-                    attributes[key] = attribute
+                default:
+                    lhs[key] = value
                 }
+                
+            } else {
+                lhs[key] = value
             }
         }
        
-        return .init(attributes: attributes)
+        return .init(attributes: lhs)
     }
 }
 
@@ -208,13 +232,17 @@ extension CustomNode {
     /// - Returns: The element
     internal func replace(_ element: Self) -> Self {
         
-        guard var attributes = self.attributes else {
-            return .init(name: element.name, attributes: element.attributes, context: self.context, content: self.content)
+        guard var lhs = self.attributes else {
+            return element
         }
         
-        attributes.merge(element.attributes!) { (_, new) in new }
+        guard let rhs = element.attributes else {
+            return self
+        }
+        
+        lhs.merge(rhs) { (_, new) in new }
        
-        return .init(name: element.name, attributes: attributes, context: self.context, content: self.content)
+        return .init(name: element.name, attributes: lhs, context: self.context, content: self.content)
     }
     
     /// Combines the attributes, incorporating the new values.
@@ -224,29 +252,37 @@ extension CustomNode {
     /// - Returns: The element
     internal func combine(_ element: Self) -> Self {
         
-        guard var attributes = self.attributes else {
-            return .init(name: element.name, attributes: element.attributes, context: self.context, content: self.content)
+        guard var lhs = self.attributes else {
+            return element
         }
         
-        for (key, value) in attributes {
+        guard let rhs = element.attributes else {
+            return self
+        }
+        
+        for (key, value) in rhs {
             
-            if let attribute = element.attributes?[key] {
+            if let attribute = lhs[key] {
                 
-                if case .list(var old) = value.value, case .list(let new) = attribute.value {
+                switch (attribute.value, value.value) {
+                case (.list(var old), .list(let new)):
                     
                     if old != new {
                         
                         old.append(new.values)
-                     
-                        attributes[key] = .init(old, context: value.context)
+                        
+                        lhs[key] = .init(old, context: value.context)
                     }
                     
-                } else {
-                    attributes[key] = attribute
+                default:
+                    lhs[key] = value
                 }
+                
+            } else {
+                lhs[key] = value
             }
         }
        
-        return .init(name: element.name, attributes: attributes, context: self.context, content: self.content)
+        return .init(name: element.name, attributes: lhs, context: self.context, content: self.content)
     }
 }

--- a/Sources/HTMLKit/Framework/Primitives/Nodes/Nodes.swift
+++ b/Sources/HTMLKit/Framework/Primitives/Nodes/Nodes.swift
@@ -33,13 +33,51 @@ internal protocol ContentNode: Node {
 
 extension ContentNode {
     
-    internal func modify(_ element: Self) -> Self {
+    /// Replaces the attributes, with the new values taking precedence.
+    /// 
+    /// - Parameter element: The element to replace with.
+    /// 
+    /// - Returns: The element
+    internal func replace(_ element: Self) -> Self {
         
         guard var attributes = self.attributes else {
             return .init(attributes: element.attributes, context: self.context, content: self.content)
         }
         
         attributes.merge(element.attributes!) { (_, new) in new }
+       
+        return .init(attributes: attributes, context: self.context, content: self.content)
+    }
+    
+    /// Combines the attributes, incorporating the new values.
+    /// 
+    /// - Parameter element: The element to combine with.
+    /// 
+    /// - Returns: The element
+    internal func combine(_ element: Self) -> Self {
+        
+        guard var attributes = self.attributes else {
+            return .init(attributes: element.attributes, context: self.context, content: self.content)
+        }
+        
+        for (key, value) in attributes {
+            
+            if let attribute = element.attributes?[key] {
+                
+                if case .list(var old) = value.value, case .list(let new) = attribute.value {
+                    
+                    if old != new {
+                        
+                        old.append(new.values)
+                        
+                        attributes[key] = .init(old, context: value.context)
+                    }
+                    
+                } else {
+                    attributes[key] = attribute
+                }
+            }
+        }
        
         return .init(attributes: attributes, context: self.context, content: self.content)
     }
@@ -64,7 +102,12 @@ internal protocol EmptyNode: Node {
 
 extension EmptyNode {
     
-    internal func modify(_ element: Self) -> Self {
+    /// Replaces the attributes, with the new values taking precedence.
+    /// 
+    /// - Parameter element: The element to replace with.
+    /// 
+    /// - Returns: The element
+    internal func replace(_ element: Self) -> Self {
         
         guard var attributes = self.attributes else {
             return .init(attributes: element.attributes)
@@ -72,6 +115,39 @@ extension EmptyNode {
         
         attributes.merge(element.attributes!) { (_, new) in new }
         
+        return .init(attributes: attributes)
+    }
+    
+    /// Combines the attributes, incorporating the new values.
+    /// 
+    /// - Parameter element: The element to combine with.
+    /// 
+    /// - Returns: The element
+    internal func combine(_ element: Self) -> Self {
+        
+        guard var attributes = self.attributes else {
+            return .init(attributes: element.attributes)
+        }
+        
+        for (key, value) in attributes {
+            
+            if let attribute = element.attributes?[key] {
+                
+                if case .list(var old) = value.value, case .list(let new) = attribute.value {
+                    
+                    if old != new {
+                        
+                        old.append(new.values)
+                     
+                        attributes[key] = .init(old, context: value.context)
+                    }
+                    
+                } else {
+                    attributes[key] = attribute
+                }
+            }
+        }
+       
         return .init(attributes: attributes)
     }
 }
@@ -125,13 +201,51 @@ public protocol CustomNode: Node {
 
 extension CustomNode {
     
-    internal func modify(_ element: Self) -> Self {
+    /// Replaces the attributes, with the new values taking precedence.
+    /// 
+    /// - Parameter element: The element to replace with.
+    /// 
+    /// - Returns: The element
+    internal func replace(_ element: Self) -> Self {
         
         guard var attributes = self.attributes else {
             return .init(name: element.name, attributes: element.attributes, context: self.context, content: self.content)
         }
         
         attributes.merge(element.attributes!) { (_, new) in new }
+       
+        return .init(name: element.name, attributes: attributes, context: self.context, content: self.content)
+    }
+    
+    /// Combines the attributes, incorporating the new values.
+    /// 
+    /// - Parameter element: The element to combine with.
+    /// 
+    /// - Returns: The element
+    internal func combine(_ element: Self) -> Self {
+        
+        guard var attributes = self.attributes else {
+            return .init(name: element.name, attributes: element.attributes, context: self.context, content: self.content)
+        }
+        
+        for (key, value) in attributes {
+            
+            if let attribute = element.attributes?[key] {
+                
+                if case .list(var old) = value.value, case .list(let new) = attribute.value {
+                    
+                    if old != new {
+                        
+                        old.append(new.values)
+                     
+                        attributes[key] = .init(old, context: value.context)
+                    }
+                    
+                } else {
+                    attributes[key] = attribute
+                }
+            }
+        }
        
         return .init(name: element.name, attributes: attributes, context: self.context, content: self.content)
     }

--- a/Sources/HTMLKit/Framework/Rendering/EnumeratedList.swift
+++ b/Sources/HTMLKit/Framework/Rendering/EnumeratedList.swift
@@ -3,7 +3,7 @@
 public struct EnumeratedList {
     
     /// The values within the list.
-    internal let values: [String]
+    internal var values: [String]
     
     /// The separator for the list.
     internal let separator: String
@@ -22,6 +22,10 @@ public struct EnumeratedList {
     /// The string represenation of the list.
     internal var description: String {
         return values.joined(separator: separator)
+    }
+    
+    internal mutating func append(_ values: [String]) {
+        self.values.append(contentsOf: values)
     }
 }
 

--- a/Sources/HTMLKit/Framework/Rendering/EnumeratedList.swift
+++ b/Sources/HTMLKit/Framework/Rendering/EnumeratedList.swift
@@ -1,0 +1,33 @@
+/// A value type that holds a set of values along with its separator.
+@_documentation(visibility: internal)
+public struct EnumeratedList {
+    
+    /// The values within the list.
+    internal let values: [String]
+    
+    /// The separator for the list.
+    internal let separator: String
+    
+    /// Create a enumerated list.
+    /// 
+    /// - Parameters:
+    ///   - values: The values to enumerate.
+    ///   - separator: The separator to enumerate with.
+    internal init(values: [String], separator: String) {
+        
+        self.values = values
+        self.separator = separator
+    }
+    
+    /// The string represenation of the list.
+    internal var description: String {
+        return values.joined(separator: separator)
+    }
+}
+
+extension EnumeratedList: Equatable {
+    
+    public static func == (lhs: EnumeratedList, rhs: EnumeratedList) -> Bool {
+        return lhs.values == rhs.values && lhs.separator == rhs.separator
+    }
+}

--- a/Sources/HTMLKit/Framework/Rendering/EnumeratedList.swift
+++ b/Sources/HTMLKit/Framework/Rendering/EnumeratedList.swift
@@ -25,6 +25,45 @@ public struct EnumeratedList {
     }
 }
 
+extension EnumeratedList {
+    
+    internal init(values: [SizeCandidate], separator: String) {
+        
+        self.values = values.map(\.rawValue)
+        self.separator = separator
+    }
+    
+    internal init(values: [SourceCandidate], separator: String) {
+        
+        self.values = values.map(\.rawValue)
+        self.separator = separator
+    }
+    
+    internal init(values: [MediaQuery], separator: String) {
+        
+        self.values = values.map(\.rawValue)
+        self.separator = separator
+    }
+    
+    internal init(values: [Values.Media], separator: String) {
+        
+        self.values = values.map(\.rawValue)
+        self.separator = separator
+    }
+    
+    internal init(values: [Values.Completion], separator: String) {
+        
+        self.values = values.map(\.rawValue)
+        self.separator = separator
+    }
+    
+    internal init(values: [Values.Permission], separator: String) {
+     
+        self.values = values.map(\.rawValue)
+        self.separator = separator
+    }
+}
+
 extension EnumeratedList: Equatable {
     
     public static func == (lhs: EnumeratedList, rhs: EnumeratedList) -> Bool {

--- a/Sources/HTMLKit/Framework/Rendering/MergeStrategy.swift
+++ b/Sources/HTMLKit/Framework/Rendering/MergeStrategy.swift
@@ -1,0 +1,10 @@
+/// A companion type that tells the merge strategy.
+@_documentation(visibility: internal)
+public enum MergeStrategy {
+    
+    /// Indicates a combine operation.
+    case combining
+    
+    /// Indicates a replace operation.
+    case replacing
+}

--- a/Sources/HTMLKit/Framework/Rendering/Renderer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Renderer.swift
@@ -538,6 +538,16 @@ public struct Renderer {
             case .environment(let environment):
                 
                 result += try render(envattribute: environment, within: attribute.value.context)
+                
+            case .list(let enumerated):
+                
+                switch attribute.value.context {
+                case .trusted:
+                    result += enumerated.description
+                    
+                case .tainted(let subcontext):
+                    result += escape(attribute: enumerated.description, with: subcontext)
+                }
             }
             
             result += "\""

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -116,7 +116,7 @@ final class AttributesTests: XCTestCase {
             }
             
             if let elements = elements {
-                copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+                copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
             }
             
             return copy
@@ -136,7 +136,7 @@ final class AttributesTests: XCTestCase {
                 copy = copy.mutate(itemtype: .init(schema.absoluteString, context: .tainted(.html)))
             }
             
-            copy = copy.mutate(itemref: .init(elements.joined(separator: " "), context: .tainted(.html)))
+            copy = copy.mutate(itemref: .init(EnumeratedList(values: elements, separator: " "), context: .tainted(.html)))
             
             return copy
         }
@@ -192,19 +192,19 @@ final class AttributesTests: XCTestCase {
         }
         
         func accept(_ specifiers: [String]) -> Tag {
-            return self.mutate(accept: .init(specifiers.joined(separator: ", "), context: .tainted(.html)))
+            return self.mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .tainted(.html)))
         }
         
         func accept(_ specifiers: String...) -> Tag {
-            return self.mutate(accept: .init(specifiers.joined(separator: ", "), context: .tainted(.html)))
+            return self.mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .tainted(.html)))
         }
         
         func accept(_ specifiers: [Values.Media]) -> Tag {
-            return self.mutate(accept: .init(specifiers.map { $0.rawValue }.joined(separator: ", "), context: .trusted))
+            return self.mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .trusted))
         }
         
         func accept(_ specifiers: Values.Media...) -> Tag {
-            return self.mutate(accept: .init(specifiers.map { $0.rawValue }.joined(separator: ", "), context: .trusted))
+            return self.mutate(accept: .init(EnumeratedList(values: specifiers, separator: ", "), context: .trusted))
         }
         
         func action(_ value: String) -> Tag {
@@ -228,12 +228,21 @@ final class AttributesTests: XCTestCase {
             return self.mutate(async: .init("async", context: .trusted))
         }
         
-        func autocomplete(_ value: Values.Completion) -> Tag {
-            return mutate(autocomplete: .init(value.rawValue, context: .trusted))
+        public func autocomplete(_ value: Bool) -> Tag {
+
+            if value {
+                return mutate(autocomplete: .init("on", context: .trusted))
+            }
+            
+            return mutate(autocomplete: .init("off", context: .trusted))
         }
         
-        func autocomplete(_ values: OrderedSet<Values.Completion>) -> Tag {
-            return mutate(autocomplete: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+        func autocomplete(_ values: [Values.Completion]) -> Tag {
+            return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
+        }
+        
+        func autocomplete(_ values: Values.Completion...) -> Tag {
+            return mutate(autocomplete: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
         }
         
         func autoplay(_ condition: Bool = true) -> Tag {
@@ -340,11 +349,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func headers(_ ids: [String]) -> Tag {
-            return self.mutate(headers: .init(ids.joined(separator: " "), context: .tainted(.html)))
+            return self.mutate(headers: .init(EnumeratedList(values: ids, separator: " "), context: .tainted(.html)))
         }
         
         func headers(_ ids: String...) -> Tag {
-            return self.mutate(headers: .init(ids.joined(separator: " "), context: .tainted(.html)))
+            return self.mutate(headers: .init(EnumeratedList(values: ids, separator: " "), context: .tainted(.html)))
         }
         
         func height(_ size: Int) -> Tag {
@@ -414,11 +423,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func media(_ queries: [MediaQuery]) -> Tag {
-            return self.mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+            return self.mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
         }
         
         func media(_ queries: MediaQuery...) -> Tag {
-            return self.mutate(media: .init(queries.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+            return self.mutate(media: .init(EnumeratedList(values: queries, separator: ", "), context: .tainted(.html)))
         }
         
         func method(_ value: HTMLKit.Values.Method) -> Tag {
@@ -546,12 +555,12 @@ final class AttributesTests: XCTestCase {
             return self.mutate(sandbox: .init("sandbox", context: .trusted))
         }
         
-        func sandbox(_ value: Values.Permission) -> Tag {
-            return self.mutate(sandbox: .init(value.rawValue, context: .trusted))
+        func sandbox(_ values: [Values.Permission]) -> Tag {
+            return self.mutate(sandbox: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
         }
         
-        func sandbox(_ values: OrderedSet<Values.Permission>) -> Tag {
-            return self.mutate(sandbox: .init(values.map { $0.rawValue }.joined(separator: " "), context: .trusted))
+        func sandbox(_ values: Values.Permission...) -> Tag {
+            return self.mutate(sandbox: .init(EnumeratedList(values: values, separator: " "), context: .trusted))
         }
         
         func scope(_ value: Values.Scope) -> Tag {
@@ -571,11 +580,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func sizes(_ candidates: [SizeCandidate]) -> Tag {
-            return self.mutate(sizes: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+            return self.mutate(sizes: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
         }
         
         func sizes(_ candidates: SizeCandidate...) -> Tag {
-            return self.mutate(sizes: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+            return self.mutate(sizes: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
         }
         
         func slot(_ value: String) -> Tag {
@@ -603,11 +612,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func sourceSet(_ candidates: [SourceCandidate]) -> Tag {
-            return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+            return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
         }
         
         func sourceSet(_ candidates: SourceCandidate...) -> Tag {
-            return mutate(sourceset: .init(candidates.map { $0.rawValue }.joined(separator: ", "), context: .tainted(.html)))
+            return mutate(sourceset: .init(EnumeratedList(values: candidates, separator: ", "), context: .tainted(.html)))
         }
         
         func start(_ size: Int) -> Tag {
@@ -860,11 +869,11 @@ final class AttributesTests: XCTestCase {
         }
         
         func integrity(_ hashes: String...) -> Tag {
-            return self.mutate(integrity: .init(hashes.joined(separator: " "), context: .tainted(.html)))
+            return self.mutate(integrity: .init(EnumeratedList(values: hashes, separator: " "), context: .tainted(.html)))
         }
         
         func integrity(_ hashes: [String]) -> Tag {
-            return self.mutate(integrity: .init(hashes.joined(separator: " "), context: .tainted(.html)))
+            return self.mutate(integrity: .init(EnumeratedList(values: hashes, separator: " "), context: .tainted(.html)))
         }
         
         func crossOrigin(_ value: Credential.Mode) -> Tag {
@@ -1335,10 +1344,10 @@ final class AttributesTests: XCTestCase {
     func testCompleteAttribute() throws {
         
         let view = TestView {
-            Tag {}.autocomplete(.on)
-            Tag {}.autocomplete(.off)
+            Tag {}.autocomplete(true)
+            Tag {}.autocomplete(false)
             Tag {}.autocomplete([.organization, .organizationTitle])
-            Tag {}.autocomplete([.birthday, .birthday])
+            Tag {}.autocomplete(.organization, .organizationTitle)
         }
         
         XCTAssertEqual(try renderer.render(view: view),
@@ -1346,7 +1355,7 @@ final class AttributesTests: XCTestCase {
                        <tag autocomplete="on"></tag>\
                        <tag autocomplete="off"></tag>\
                        <tag autocomplete="organization organization-title"></tag>\
-                       <tag autocomplete="bday"></tag>
+                       <tag autocomplete="organization organization-title"></tag>
                        """
         )
     }

--- a/Tests/HTMLKitTests/AttributesTests.swift
+++ b/Tests/HTMLKitTests/AttributesTests.swift
@@ -56,8 +56,12 @@ final class AttributesTests: XCTestCase {
             return self.mutate(autofocus: .init("autofocus", context: .trusted))
         }
         
-        func `class`(_ value: String) -> Tag {
-            return self.mutate(class: .init(value, context: .tainted(.html)))
+        func `class`(_ names: [String]) -> Tag {
+            return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
+        }
+        
+        func `class`(_ names: String...) -> Tag {
+            return self.mutate(class: .init(EnumeratedList(values: names, separator: " "), context: .tainted(.html)))
         }
         
         func direction(_ value: Values.Direction) -> Tag {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -259,6 +259,49 @@ final class RenderingTests: XCTestCase {
         )
     }
     
+    func testUnwrappedAttributeAttachment() throws {
+        
+        let passcode: String? = "ipsum"
+        
+        let view = TestView {
+            Input()
+                .class("lorem")
+                .modify(unwrap: passcode, use: .combining) {
+                    $0.placeholder($1)
+                }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: view),
+                       """
+                       <input class="lorem" placeholder="ipsum">
+                       """
+        )
+    }
+    
+    func testModifiedAndContextChange() throws {
+        
+        let view = TestView {
+            Input()
+                .class("<h1>lorem</h1>")
+                .modify(if: false, use: .combining) {
+                    $0.custom(key: "class", value: "<h1>ipsum</h1>", context: .trusted)
+                }
+            
+            Input()
+                .class("<h1>lorem</h1>")
+                .modify(if: true, use: .combining) {
+                    $0.custom(key: "class", value: "<h1>ipsum</h1>", context: .trusted)
+                }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: view),
+                       """
+                       <input class="&lt;h1>lorem&lt;/h1>">\
+                       <input class="<h1>ipsum</h1>">
+                       """
+        )
+    }
+    
     func testRenderingCustomProperty() throws {
         
         let view = TestView {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -239,6 +239,26 @@ final class RenderingTests: XCTestCase {
         )
     }
     
+    func testUnwrappedAttributeConcatenation() throws {
+        
+        let passcode: String? = "ipsum"
+        
+        let view = TestView {
+            Division {
+            }
+            .class("lorem")
+            .modify(unwrap: passcode, use: .combining) {
+                $0.class($1)
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: view),
+                       """
+                       <div class="lorem ipsum"></div>
+                       """
+        )
+    }
+    
     func testRenderingCustomProperty() throws {
         
         let view = TestView {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -181,6 +181,26 @@ final class RenderingTests: XCTestCase {
         )
     }
     
+    func testAttributeConcatenation() throws {
+        
+        let isModified: Bool = true
+        
+        let view = TestView {
+            Division {
+            }
+            .class("lorem")
+            .modify(if: isModified, use: .combining) {
+                $0.class("ipsum")
+            }
+        }
+        
+        XCTAssertEqual(try renderer!.render(view: view),
+                       """
+                       <div class="lorem ipsum"></div>
+                       """
+        )
+    }
+    
     func testUnmodified() throws {
         
         let isModified: Bool = false


### PR DESCRIPTION
This pull request addresses #182 and adds support for conditional attribute extension, by giving the user the choice of a `.replacing` or `.combining` operation, while the modifier defaults to `.replacing`.

```swift
Division {
}
.class("lorem")
.modify(true, use: .combining) {
   $0.class("ipsum")
}

// Renders <div class="lorem ipsum">...
```

Data types, which cannot meaningfully combined like `Bool` will automatically replaced. Open for debate, whether a `String` should count as a combinable type. For now, it is more about list attributes such as `class`, `headers`... I would say.

This pull request acknowledges that the value of the attributes like `class`, `headers` are actually a list, defined by its individual values plus a separator. With that in place, all information needed for a predictable combination is already available.