### PR TITLE
Fix markdown tokenization

### DIFF
--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Extensions/Markdown+Character.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Extensions/Markdown+Character.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Character {
     
-    /// A boolean value indicating whether this character represents an asterisk (U+002A).
+    /// Whether this character represents an asterisk.
     internal var isAsterisk: Bool {
         
         if self == "\u{002A}" {
@@ -12,7 +12,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a comma (U+005F).
+    /// Whether this character represents a comma.
     internal var isUnderscore: Bool {
         
         if self == "\u{005F}" {
@@ -22,7 +22,7 @@ extension Character {
         return false
     }
 
-    /// A boolean value indicating whether this character represents a tilde (U+007E).
+    /// Whether this character represents a tilde.
     internal var isTilde: Bool {
         
         if self == "\u{007E}" {
@@ -32,7 +32,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a back tick (U+0060).
+    /// Whether this character represents a back tick.
     public var isBackTick: Bool {
         
         if self == "\u{0060}" {
@@ -42,7 +42,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a left square bracket (U+005B).
+    /// Whether this character represents a left square bracket.
     public var isLeftSquareBracket: Bool {
         
         if self == "\u{005B}" {
@@ -52,7 +52,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a right square bracket (U+005D).
+    /// Whether this character represents a right square bracket.
     public var isRightSquareBracket: Bool {
         
         if self == "\u{005D}" {
@@ -62,7 +62,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a left parenthesis (U+0028).
+    /// Whether this character represents a left parenthesis.
     public var isLeftParenthesis: Bool {
         
         if self == "\u{0028}" {
@@ -72,7 +72,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a right parenthesis (U+0029).
+    /// Whether this character represents a right parenthesis.
     public var isRightParenthesis: Bool {
         
         if self == "\u{0029}" {
@@ -82,7 +82,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a solidus (U+002F).
+    /// Whether this character represents a solidus.
     public var isSolidus: Bool {
         
         if self == "\u{002F}" {
@@ -92,7 +92,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a colon (U+003A).
+    /// Whether this character represents a colon.
     public var isColon: Bool {
         
         if self == "\u{003A}" {
@@ -102,7 +102,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a period (U+002E).
+    /// Whether this character represents a period.
     public var isPeriod: Bool {
         
         if self == "\u{002E}" {
@@ -112,7 +112,7 @@ extension Character {
         return false
     }
     
-    /// A boolean value indicating whether this character represents a period (U+002E).
+    /// Whether this character represents a period.
     public var isComma: Bool {
         
         if self == "\u{002C}" {

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownLexer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownLexer.swift
@@ -1,6 +1,6 @@
 internal final class MarkdownLexer {
     
-    /// A enumeration of different states of the tokenizer
+    /// An enumeration of different states of the tokenizer.
     ///
     /// Initial is the initial state.
     internal enum InsertionMode {
@@ -14,7 +14,7 @@ internal final class MarkdownLexer {
         case link
     }
     
-    /// A enumeration of different level of logging
+    /// An enumeration of different level of logging.
     ///
     /// None is the initial state.
     internal enum LogLevel {
@@ -24,16 +24,16 @@ internal final class MarkdownLexer {
         case debug
     }
     
-    /// The  current state of the tokenizer
+    /// The current state of the tokenizer.
     private var mode: InsertionMode
     
-    /// The temporary token collection
+    /// The temporary token collection.
     private var tokens: [MarkdownToken]
     
-    /// The level of logging
+    /// The level of logging.
     private var level: LogLevel
     
-    /// Creates a the tokenizer
+    /// Create a tokenizer.
     internal init(mode: InsertionMode = .initial, log level: LogLevel = .none) {
         
         self.mode = .initial
@@ -41,19 +41,19 @@ internal final class MarkdownLexer {
         self.tokens = []
     }
     
-    /// Verboses the steps of the tokenizer depending on the log level
+    /// Verboses the steps of the tokenizer depending on the log level.
     private func verbose(_ message: Any...) {
         
         switch self.level {
         case .information:
-            print("Message:", message)
+            print(message)
             
         default:
             break
         }
     }
     
-    /// Emits a token into the token collection
+    /// Emits a token into the token collection.
     private func emit(token: MarkdownToken) {
         
         self.verbose(#function)
@@ -61,20 +61,20 @@ internal final class MarkdownLexer {
         self.tokens.append(token)
     }
     
-    /// Consumes the content by the state the tokenizer is currently in
+    /// Consumes the content by the state the tokenizer is currently in.
     internal func consume(string: String) -> [MarkdownToken] {
         
         for character in string {
             
             switch mode {
             case .asteriskEmphasis:
-                self.mode = consumeAsteriskEmphisis(character)
+                self.mode = consumeAsteriskEmphasis(character)
                 
             case .tildeEmphasis:
-                self.mode = consumeTildeEmphisis(character)
+                self.mode = consumeTildeEmphasis(character)
                 
             case .underscoreEmphasis:
-                self.mode = consumeUnderscoreEmphisis(character)
+                self.mode = consumeUnderscoreEmphasis(character)
                 
             case .textLiteral:
                 self.mode = consumeTextLiteral(character)
@@ -93,7 +93,7 @@ internal final class MarkdownLexer {
         return self.tokens
     }
     
-    /// Consumes the character
+    /// Consumes the character.
     private func consumeCharacter(_ character: Character) -> InsertionMode {
         
         self.verbose(#function, character)
@@ -160,7 +160,7 @@ internal final class MarkdownLexer {
         return .initial
     }
     
-    /// Consumes a character for a bold or italic emphisis
+    /// Consumes a character for a bold or italic emphasis
     ///
     /// ```
     /// *italic*
@@ -168,7 +168,7 @@ internal final class MarkdownLexer {
     /// ***italic***
     /// ```
     ///
-    private func consumeAsteriskEmphisis(_ character: Character) -> InsertionMode {
+    private func consumeAsteriskEmphasis(_ character: Character) -> InsertionMode {
         
         self.verbose(#function, character)
         
@@ -185,7 +185,7 @@ internal final class MarkdownLexer {
         if character.isUnderscore {
             
             let token = MarkdownToken(kind: .emphasis)
-            token.value.append(character)
+            token.value += String(character)
             
             self.emit(token: token)
             
@@ -219,14 +219,14 @@ internal final class MarkdownLexer {
         return .asteriskEmphasis
     }
     
-    /// Consumes a character for a strikethrough emphisis
+    /// Consumes a character for a strikethrough emphasis.
     ///
     /// ```
     /// ~string~
     /// ~~string~~
     /// ```
     ///
-    private func consumeTildeEmphisis(_ character: Character) -> InsertionMode {
+    private func consumeTildeEmphasis(_ character: Character) -> InsertionMode {
         
         self.verbose(#function, character)
         
@@ -277,7 +277,7 @@ internal final class MarkdownLexer {
         return .tildeEmphasis
     }
     
-    /// Consumes a character for a bold or italic emphisis
+    /// Consumes a character for a bold or italic emphasis.
     ///
     /// ```
     /// _string_
@@ -285,7 +285,7 @@ internal final class MarkdownLexer {
     /// ___string___
     /// ```
     ///
-    private func consumeUnderscoreEmphisis(_ character: Character) -> InsertionMode {
+    private func consumeUnderscoreEmphasis(_ character: Character) -> InsertionMode {
         
         self.verbose(#function, character)
         
@@ -336,7 +336,7 @@ internal final class MarkdownLexer {
         return .underscoreEmphasis
     }
     
-    /// Consumes a character for a text literal
+    /// Consumes a character for a text literal.
     ///
     /// ```
     /// Text
@@ -407,7 +407,7 @@ internal final class MarkdownLexer {
         return .textLiteral
     }
     
-    /// Consumes a character for a code emphisis
+    /// Consumes a character for a code emphasis.
     ///
     /// ```
     /// `code`
@@ -451,7 +451,7 @@ internal final class MarkdownLexer {
         return .code
     }
     
-    /// Consumes a character for a link emphisis
+    /// Consumes a character for a link emphasis.
     ///
     /// ```
     /// [Vapor](https://www.vapor.codes)

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownLexer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownLexer.swift
@@ -400,11 +400,6 @@ internal final class MarkdownLexer {
             return .link
         }
         
-        if character.isRightParenthesis {
-            
-            return .initial
-        }
-        
         if let last = self.tokens.last {
             last.value += String(character)
         }
@@ -445,20 +440,49 @@ internal final class MarkdownLexer {
         
         self.verbose(#function, character)
         
-        if character.isLetter {
+        if character.isRightSquareBracket {
+            return .link
+        }
+        
+        if character.isLeftParenthesis {
+            
+            let token = MarkdownToken(kind: .textLiteral)
+            
+            self.emit(token: token)
+            
+            return .link
+        }
+        
+        if character.isRightParenthesis {
+            
+            let token = MarkdownToken(kind: .link)
+            
+            self.emit(token: token)
+            
+            return .initial
+        }
+        
+        if let last = self.tokens.last {
+
+            if last.kind == .link {
+                
+                let token = MarkdownToken(kind: .textLiteral)
+                token.value += String(character)
+                
+                self.emit(token: token)
+                
+            } else {
+                last.value += String(character)
+            }
+            
+        } else {
             
             let token = MarkdownToken(kind: .textLiteral)
             token.value += String(character)
             
             self.emit(token: token)
-            
-            return .textLiteral
         }
         
-        if character.isLeftParenthesis {
-            return .link
-        }
-        
-        return .initial
+        return .link
     }
 }

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownLexer.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownLexer.swift
@@ -417,17 +417,38 @@ internal final class MarkdownLexer {
         
         self.verbose(#function, character)
         
-        if character.isLetter || character.isWhitespace {
+        if character.isBackTick {
+            
+            let token = MarkdownToken(kind: .code)
+            token.value += String(character)
+            
+            self.emit(token: token)
+            
+            return .initial
+        }
+        
+        if let last = self.tokens.last {
+
+            if last.kind == .code {
+                
+                let token = MarkdownToken(kind: .textLiteral)
+                token.value += String(character)
+                
+                self.emit(token: token)
+                
+            } else {
+                last.value += String(character)
+            }
+            
+        } else {
             
             let token = MarkdownToken(kind: .textLiteral)
             token.value += String(character)
             
             self.emit(token: token)
-            
-            return .textLiteral
         }
         
-        return .initial
+        return .code
     }
     
     /// Consumes a character for a link emphisis

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownToken.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Lexer/MarkdownToken.swift
@@ -1,29 +1,29 @@
-/// A type that represents a markdown token
+/// A type that represents a markdown token.
 internal final class MarkdownToken {
     
-    /// A enumeration of different tokens
+    /// An enumeration of different kind of tokens.
     internal enum TokenKind {
         
-        /// Indicates a emphasis token
+        /// Indicates an emphasis token.
         case emphasis
 
-        /// Indicates a text literal
+        /// Indicates a text literal.
         case textLiteral
         
-        /// Indicates a code token
+        /// Indicates a code token.
         case code
         
-        /// Indicates a link token
+        /// Indicates a link token.
         case link
     }
     
-    /// The raw value of the token
+    /// The raw value of the token.
     internal var value: String
     
-    /// The kind of the token
+    /// The kind of the token.
     internal var kind: TokenKind
     
-    /// Initiates a markdown token
+    /// Create a markdown token.
     internal init(kind: TokenKind) {
         
         self.kind = kind

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/MarkdownString.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/MarkdownString.swift
@@ -52,7 +52,7 @@ extension String.StringInterpolation {
     /// \(link: "https://www.example.com")
     /// ```
     public mutating func appendInterpolation(link url: String) {
-        appendLiteral("[\(url)](\(url)")
+        appendLiteral("[\(url)](\(url))")
     }
     
     /// Enables interpolation of a email link in Markdown format
@@ -61,7 +61,7 @@ extension String.StringInterpolation {
     /// \(email: "example@example.com")
     /// ```
     public mutating func appendInterpolation(email address: String) {
-        appendLiteral("[\(address)](mailto:\(address)")
+        appendLiteral("[\(address)](mailto:\(address))")
     }
     
     /// Enables interpolation of a phone number link in Markdown format
@@ -70,7 +70,7 @@ extension String.StringInterpolation {
     /// \(phone: "123-456-7890")
     /// ```
     public mutating func appendInterpolation(phone number: String) {
-        appendLiteral("[\(number)](tel:\(number)")
+        appendLiteral("[\(number)](tel:\(number))")
     }
     
     /// Enables interpolation of italicized text in Markdown format

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Parser/MarkdownNode.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Parser/MarkdownNode.swift
@@ -1,30 +1,30 @@
-/// A type that represents a markdown token
+/// A type that represents a markdown node.
 internal final class MarkdownNode {
     
-    /// A enumeration of different kinds of nodes
+    /// An enumeration of different kinds of nodes.
     internal enum NodeKind {
         
-        /// Indicates a block node
+        /// Indicates a block node.
         ///
-        /// A block node can contain children
+        /// A block node can contain children.
         case block(String)
         
-        /// Indicates a inline node
+        /// Indicates an inline node.
         ///
-        /// A inline node can not contain any children
+        /// An inline node cannot contain any children.
         case inline(String)
     }
     
-    /// The nodes descendants
+    /// The nodes descendants.
     internal var children: [MarkdownNode]
     
-    /// The kind of the node
+    /// The kind of the node.
     internal var kind: NodeKind
     
-    /// The raw content of the node
+    /// The raw content of the node.
     internal var value: String
     
-    /// Initiates a markdown node
+    /// Create a markdown node.
     internal init(kind: NodeKind, value: String) {
         
         self.kind = kind

--- a/Sources/HTMLKit/Framework/Rendering/Markdown/Parser/MarkdownParser.swift
+++ b/Sources/HTMLKit/Framework/Rendering/Markdown/Parser/MarkdownParser.swift
@@ -1,6 +1,6 @@
 internal final class MarkdownParser {
     
-    /// A enumeration of different level of logging
+    /// An enumeration of different level of logging.
     ///
     /// None is the initial state.
     internal enum LogLevel {
@@ -10,16 +10,16 @@ internal final class MarkdownParser {
         case debug
     }
     
-    /// The tree with nodes
+    /// The tree of nodes.
     private var tree: [MarkdownNode]
     
-    /// The collection of nodes
+    /// A temporary collection of nodes.
     private var nodes: [MarkdownNode]
     
-    /// The level of logging
+    /// The level of logging.
     private var level: LogLevel
     
-    /// Creates a the parser
+    /// Create a markdown parser.
     internal init(log level: LogLevel = .none) {
          
         self.tree = []
@@ -27,7 +27,7 @@ internal final class MarkdownParser {
         self.level = level
     }
     
-    /// Logs the steps of the tokenizer depending on the log level
+    /// Logs the steps of the tokenizer depending on the log level.
     private func verbose(_ message: Any...) {
         
         switch self.level {
@@ -39,7 +39,7 @@ internal final class MarkdownParser {
         }
     }
     
-    /// Inserts the node into the syntax tree
+    /// Inserts the node into the syntax tree.
     private func insert(node: MarkdownNode) {
         
         self.verbose(#function, node.value)
@@ -47,7 +47,7 @@ internal final class MarkdownParser {
         self.tree.append(node)
     }
     
-    /// Emits the node into the node collection
+    /// Emits the node into the node collection.
     private func emit(node: MarkdownNode) {
         
         self.verbose(#function, node.value)
@@ -73,7 +73,7 @@ internal final class MarkdownParser {
         }
     }
     
-    /// Processes the tokens and emits it to the syntax tree or node collection
+    /// Processes the tokens and emits it to the syntax tree or node collection.
     internal func process(tokens: [MarkdownToken]) -> [MarkdownNode] {
         
         for (index, token) in tokens.enumerated() {

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -386,14 +386,14 @@ final class RenderingTests: XCTestCase {
     func testRenderingMonospaceMarkdown() throws {
         
         let view = TestView {
-            MarkdownString("`code`")
-            MarkdownString("\(code: "code")")
+            MarkdownString("`<div>test</div>`")
+            MarkdownString("\(code: "**test**")")
         }
         
         XCTAssertEqual(try renderer!.render(view: view),
                        """
-                       <code>code</code>\
-                       <code>code</code>
+                       <code>&lt;div&gt;test&lt;/div&gt;</code>\
+                       <code>**test**</code>
                        """
         )
     }

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -427,13 +427,17 @@ final class RenderingTests: XCTestCase {
             MarkdownString("[Link](https://www.vapor.codes)")
             MarkdownString("\(link: "https://www.vapor.codes")")
             MarkdownString("\(email: "alone@home.com")")
+            MarkdownString("[Vapor](https://www.vapor.codes) and [Swift](https://www.swift.org)")
+            MarkdownString("\(link: "https://www.vapor.codes") and \(link: "https://www.swift.org")")
         }
         
         XCTAssertEqual(try renderer!.render(view: view),
                        """
                        <a href="https://www.vapor.codes" target="_blank">Link</a>\
                        <a href="https://www.vapor.codes" target="_blank">https://www.vapor.codes</a>\
-                       <a href="mailto:alone@home.com" target="_blank">alone@home.com</a>
+                       <a href="mailto:alone@home.com" target="_blank">alone@home.com</a>\
+                       <a href="https://www.vapor.codes" target="_blank">Vapor</a> and <a href="https://www.swift.org" target="_blank">Swift</a>\
+                       <a href="https://www.vapor.codes" target="_blank">https://www.vapor.codes</a> and <a href="https://www.swift.org" target="_blank">https://www.swift.org</a>
                        """
         )
     }

--- a/Tests/HTMLKitTests/RenderingTests.swift
+++ b/Tests/HTMLKitTests/RenderingTests.swift
@@ -383,7 +383,7 @@ final class RenderingTests: XCTestCase {
     /// Tests the Markdown rendering for inline code emphasis
     ///
     /// The renderer is expected to convert the Markdown syntax into the HTML equivalent
-    func testRenderingMonospaceMarkdown() throws {
+    func testRenderingCodeMarkdown() throws {
         
         let view = TestView {
             MarkdownString("`<div>test</div>`")


### PR DESCRIPTION
The markdown syntax for `link` and `code` does not accept nesting. Therefore, they need to be handled differently. This pull request updates how both are processed.